### PR TITLE
[FE] `SideBar` 컴포넌트 생성

### DIFF
--- a/frontend/src/components/SideBar/SideBar.style.tsx
+++ b/frontend/src/components/SideBar/SideBar.style.tsx
@@ -1,0 +1,72 @@
+import { Link } from 'react-router-dom';
+import styled from 'styled-components';
+
+interface SideBarSelect {
+  $isSelected: boolean;
+}
+
+interface SideBarSize {
+  $width: number;
+  $height: number;
+}
+
+type SideBarStyleProps = SideBarSelect & SideBarSize;
+
+export const SideBarContainer = styled.div<SideBarSize>`
+  display: flex;
+  flex-direction: column;
+
+  position: relative;
+  width: ${(props) => `${props.$width}px`};
+  height: ${(props) => `${props.$height}px`};
+
+  border-top: 1px solid ${({ theme }) => theme.colors.gray};
+
+  & > :nth-child(n) {
+    border: solid ${({ theme }) => theme.colors.gray};
+    border-width: 0 1px 1px 1px;
+  }
+`;
+
+export const LabelContent = styled.span<SideBarStyleProps>`
+  display: flex;
+  align-items: center;
+  justify-content: space-around;
+
+  width: ${(props) => `${props.$width}px`};
+  height: ${(props) => `${props.$height}px`};
+
+  font-weight: ${(props) => (props.$isSelected ? 'bold' : 'normal')};
+  color: ${({ theme }) => theme.colors.gray};
+
+  transition: all 0.4s ease;
+  cursor: pointer;
+`;
+
+export const SideBarLink = styled(Link)`
+  text-decoration: none;
+`;
+
+export const SideBarContent = styled.div<SideBarSelect>`
+  transition: all 0.4s ease;
+  background-color: ${(props) => `${props.$isSelected ? '#eee' : 'transparent'}`};
+`;
+
+export const Arrow = styled.span`
+  position: relative;
+
+  &::after {
+    position: absolute;
+    left: 0;
+    top: -8px;
+
+    width: 10px;
+    height: 10px;
+
+    border-top: 3px solid ${({ theme }) => theme.colors.gray};
+    border-right: 3px solid ${({ theme }) => theme.colors.gray};
+
+    content: '';
+    transform: rotate(45deg);
+  }
+`;

--- a/frontend/src/components/SideBar/index.tsx
+++ b/frontend/src/components/SideBar/index.tsx
@@ -1,0 +1,48 @@
+import { useLocation } from 'react-router-dom';
+import {
+  Arrow,
+  LabelContent,
+  SideBarContainer,
+  SideBarContent,
+  SideBarLink,
+} from './SideBar.style';
+
+interface SideBarOptions {
+  key: string;
+  value: string;
+}
+
+interface SideBarProps {
+  width: number;
+  height: number;
+
+  options: SideBarOptions[];
+}
+
+const SideBar = ({ width, height, options }: SideBarProps) => {
+  const current = useLocation().pathname;
+
+  return (
+    <SideBarContainer $width={width} $height={height}>
+      {options.map(({ key, value }) => {
+        console.log(value === current);
+        return (
+          <SideBarContent key={key} $isSelected={value === current}>
+            <SideBarLink to={value}>
+              <LabelContent
+                $isSelected={value === current}
+                $width={width}
+                $height={height / options.length}
+              >
+                {key}
+                <Arrow />
+              </LabelContent>
+            </SideBarLink>
+          </SideBarContent>
+        );
+      })}
+    </SideBarContainer>
+  );
+};
+
+export default SideBar;

--- a/frontend/src/components/SideBar/index.tsx
+++ b/frontend/src/components/SideBar/index.tsx
@@ -25,7 +25,6 @@ const SideBar = ({ width, height, options }: SideBarProps) => {
   return (
     <SideBarContainer $width={width} $height={height}>
       {options.map(({ key, value }) => {
-        console.log(value === current);
         return (
           <SideBarContent key={key} $isSelected={value === current}>
             <SideBarLink to={value}>


### PR DESCRIPTION
## 주요 구현사항
close #11 

- 윤생의 `TapBar`를 상당부분 참고하였습니다.😅
- `useLocation`을 사용하여 현재 페이지의 `pathname`과 외부에서 주입받는 `value`를 비교합니다. 이를 통해 현재 페이지에 해당하는 네비게이션 바의 색상이 변경됩니다.
- 꺽쇠 부분은 `react-icons` 라이브러리를 사용하려다 현재는 css로 구현해둔 상태입니다. `react-icons`에 도입에 대한 이야기도 나누었으면 좋겠습니다.

### 사용법
`props`의 `options`로 

```typescript
export const routingList = [
  { key: '내 카페 등록', value: '/register-cafe' },
  { key: '내 카페 관리', value: '/manage-cafe' },
  { key: '고객 목록', value: '/' },
];

```

이런 형태의 배열을 넘겨주면 됩니다!

## 리뷰어에게...
<img width="307" alt="스크린샷 2023-07-11 오후 10 24 14" src="https://github.com/woowacourse-teams/2023-stamp-crush/assets/90092440/ab797d30-4950-4fd2-82f0-5167e2672e7c">
<img width="309" alt="스크린샷 2023-07-11 오후 10 23 57" src="https://github.com/woowacourse-teams/2023-stamp-crush/assets/90092440/b758e5a4-dc30-4fbc-ad73-b597a285bfb2">

라우팅에 따라 사이드바의 background 색상이 변경되는 것을 확인할 수 있습니다.