### PR TITLE
[FE] createBrowserRouter 내에서 children의 라우팅이 되지 않는 문제

### DIFF
--- a/frontend/src/Router.tsx
+++ b/frontend/src/Router.tsx
@@ -12,7 +12,16 @@ import RegisterCafe from './pages/Admin/RegisterCafe';
 import MyPage from './pages/MyPage';
 import History from './pages/History';
 
-const Root = () => {
+const AdminRoot = () => {
+  return (
+    <>
+      <Header />
+      <Outlet />
+    </>
+  );
+};
+
+const CustomerRoot = () => {
   return (
     <>
       <Header />
@@ -23,33 +32,34 @@ const Root = () => {
 
 const Router = () => {
   const router = createBrowserRouter([
-    //사장모드
-    { path: '/login', element: <Login /> },
-    { path: '/sign-up', element: <SignUp /> },
-    { path: '/enter', element: <EnterPhoneNumber /> },
+    // 사장
     {
-      path: '/',
-      element: <Root />,
+      path: '/admin',
+      element: <AdminRoot />,
       errorElement: <NotFound />,
       children: [
         { index: true, element: <CustomerList /> },
+        { path: 'login', element: <Login /> },
+        { path: 'sign-up', element: <SignUp /> },
         { path: 'register-cafe', element: <RegisterCafe /> },
         { path: 'make-coupon-policy', element: <MakeCouponPolicy /> },
         { path: 'manage-cafe', element: <ManageCafe /> },
+        { path: 'enter', element: <EnterPhoneNumber /> },
       ],
     },
-    //고객모드
+    // 고객
     {
-      path: '/coupon-list',
-      element: <CouponList />,
-    },
-    {
-      path: '/my-page',
-      element: <MyPage />,
-    },
-    {
-      path: '/history',
-      element: <History />,
+      path: '/',
+      element: <CustomerRoot />,
+      errorElement: <NotFound />,
+      children: [
+        { index: true, element: <CustomerList /> },
+        { path: 'login', element: <Login /> },
+        { path: 'sign-up', element: <SignUp /> },
+        { path: 'coupon-list', element: <CouponList /> },
+        { path: '/my-page', element: <MyPage /> },
+        { path: '/history', element: <History /> },
+      ],
     },
   ]);
 

--- a/frontend/webpack.common.js
+++ b/frontend/webpack.common.js
@@ -8,6 +8,7 @@ module.exports = {
     filename: 'bundle.js',
     path: path.resolve(__dirname, 'dist'),
     clean: true,
+    publicPath: '/',
   },
   resolve: {
     extensions: ['.ts', '.tsx', '.js', '.jsx'],


### PR DESCRIPTION
## 주요 변경사항
close #34 
webpack.common.js 파일에
```javascript
module.exports = {
...
   output:{
   ...
      publicPath: '/',
   ...
   }
...
}
```

추가했더니 해결되었습니다!

## 리뷰어에게...
https://stackoverflow.com/questions/75391508/react-router-dom6-3-0-does-not-render-child-components
