### PR TITLE
[FE] feat: 전화번호 입력 페이지 레이아웃 구현

### DIFF
--- a/frontend/src/Router.tsx
+++ b/frontend/src/Router.tsx
@@ -44,14 +44,15 @@ const Router = () => {
       errorElement: <NotFound />,
       children: [
         { index: true, element: <CustomerList /> },
-        { path: 'login', element: <Login /> },
-        { path: 'sign-up', element: <SignUp /> },
+
         { path: 'register-cafe', element: <RegisterCafe /> },
         { path: 'make-coupon-policy', element: <MakeCouponPolicy /> },
         { path: 'manage-cafe', element: <ManageCafe /> },
-        { path: 'enter', element: <EnterPhoneNumber /> },
       ],
     },
+    { path: '/admin/login', element: <Login /> },
+    { path: '/admin/sign-up', element: <SignUp /> },
+    { path: '/admin/enter', element: <EnterPhoneNumber /> },
     // 고객
     {
       path: '/',

--- a/frontend/src/components/Dialpad/Dialpad.style.tsx
+++ b/frontend/src/components/Dialpad/Dialpad.style.tsx
@@ -2,16 +2,19 @@ import { styled } from 'styled-components';
 
 export const Container = styled.section`
   display: flex;
-  width: 540px;
   flex-direction: column;
-  border: 1px solid black;
+  border-left: 1px solid black;
+  border-right: 1px solid black;
+  border-collapse: separate;
+  min-width: 580px;
 `;
 
 export const KeyContainer = styled.div`
   display: grid;
+  height: 100%;
 
-  grid-template-columns: repeat(3, 180px);
-  grid-template-rows: repeat(4, 120px);
+  grid-template-columns: repeat(3, 1fr);
+  grid-template-rows: repeat(4, 1fr);
 `;
 
 export const Pad = styled.button`
@@ -35,8 +38,10 @@ export const Pad = styled.button`
 
 export const BaseInput = styled.input`
   outline: none;
-  height: 150px;
   padding: 20px 0px;
+  height: 210px;
+  border: 1px solid black;
+  border-top: none;
 
   font-size: 50px;
   text-align: center;

--- a/frontend/src/components/Template/Template.style.tsx
+++ b/frontend/src/components/Template/Template.style.tsx
@@ -6,6 +6,5 @@ export const BaseTemplate = styled.main`
   margin: 0 auto;
   width: 100vw;
   height: 100vh;
-  padding: 20px;
   background: white;
 `;

--- a/frontend/src/pages/EnterPhoneNumber/index.tsx
+++ b/frontend/src/pages/EnterPhoneNumber/index.tsx
@@ -1,11 +1,19 @@
+import Template from '../../components/Template';
 import Dialpad from '../../components/Dialpad';
+import { Container, PrivacyBox, Title } from './style';
 
 const EnterPhoneNumber = () => {
   return (
-    <div>
-      EnterPhoneNumber
-      <Dialpad />
-    </div>
+    <Template>
+      <Title>전화번호 입력</Title>
+      <Container>
+        <PrivacyBox>
+          <h1>개인정보 제공동의</h1>
+          <p>전화번호를 입력하시면 개인정보 제공에 동의하시는 것으로 간주됩니다.</p>
+        </PrivacyBox>
+        <Dialpad />
+      </Container>
+    </Template>
   );
 };
 

--- a/frontend/src/pages/EnterPhoneNumber/style.tsx
+++ b/frontend/src/pages/EnterPhoneNumber/style.tsx
@@ -1,0 +1,34 @@
+import { styled } from 'styled-components';
+
+export const Title = styled.header`
+  width: 100vw;
+  height: 110px;
+  border-bottom: 3px solid ${({ theme }) => theme.colors.gray400};
+  padding: auto 0;
+  line-height: 110px;
+
+  text-align: center;
+  font-size: 30px;
+  font-weight: 600;
+`;
+
+export const Container = styled.div`
+  display: flex;
+  height: 100%;
+`;
+
+export const PrivacyBox = styled.section`
+  padding: 50px 10%;
+  width: 53%;
+
+  & > p {
+    font-size: 16px;
+    line-height: 24px;
+  }
+
+  & > h1 {
+    font-size: 24px;
+    font-weight: 700;
+    margin-bottom: 15px;
+  }
+`;


### PR DESCRIPTION
## 주요 변경사항
- 카페 사장님만이 전화번호를 입력할 수 있다는 플로우 하에 고객이 개인정보 제공 동의 체크박스를 체크할 수 없기 때문에 
개인정보 제공동의 컴포넌트 구현을 보류하였습니다.
<img width="733" alt="스크린샷 2023-07-14 오후 3 03 04" src="https://github.com/woowacourse-teams/2023-stamp-crush/assets/62367797/687a3b32-5fa5-4b54-98a7-9602aeda5b04">



## 리뷰어에게...

## 관련 이슈

close #13 

## 체크리스트

- [ ] `reviewers` 설정
- [ ] `label` 설정
- [ ] `milestone` 설정
