### PR TITLE
[FE] refactor: 상태 로직을 컴포넌트 내부가 아닌 props로 이전

### DIFF
--- a/frontend/src/components/SelectBox/index.tsx
+++ b/frontend/src/components/SelectBox/index.tsx
@@ -1,4 +1,4 @@
-import { MouseEventHandler, useState } from 'react';
+import { MouseEventHandler, useState, Dispatch, SetStateAction } from 'react';
 import { BaseSelectBox, LabelContent, SelectContent } from './SelectBox.style';
 
 export type SelectBoxOption = {
@@ -8,10 +8,11 @@ export type SelectBoxOption = {
 
 interface SelectBoxProps {
   options: SelectBoxOption[];
+  checkedOption: string;
+  setCheckedOption: Dispatch<SetStateAction<string>>;
 }
 
-const SelectBox = ({ options }: SelectBoxProps) => {
-  const [checkedOption, setCheckedOption] = useState(options[0].value);
+const SelectBox = ({ options, checkedOption, setCheckedOption }: SelectBoxProps) => {
   const [isExpanded, setIsExpanded] = useState(false);
 
   const toggleExpandSelectBox: MouseEventHandler<HTMLInputElement> = (event) => {


### PR DESCRIPTION
## 주요 변경사항
- 컴포넌트 내부에 있는 상태 로직을 props로 빼 내었습니다.
## 리뷰어에게...
주말 잘 보내세요~~
## 관련 이슈

closes #73 

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [x] `milestone` 설정
