### PR TITLE
[BE] feat: 리워드 사용 및 조회 기능을 구현한다

### DIFF
--- a/backend/src/main/java/com/stampcrush/backend/api/reward/RewardApiController.java
+++ b/backend/src/main/java/com/stampcrush/backend/api/reward/RewardApiController.java
@@ -24,7 +24,6 @@ public class RewardApiController {
     @GetMapping("/customers/{customerId}/rewards")
     public ResponseEntity<RewardsFindResponse> findRewards(@PathVariable("customerId") Long customerId,
                                                            @ModelAttribute RewardFindRequest rewardFindRequest) {
-        System.out.println("here");
         RewardFind rewardFind = new RewardFind(customerId, rewardFindRequest.getCafeId(), rewardFindRequest.isUsed());
         List<RewardFindResult> rewardFindResults = rewardService.findRewards(rewardFind);
         List<RewardFindResponse> rewardFindResponses = rewardFindResults.stream()

--- a/backend/src/main/java/com/stampcrush/backend/api/reward/RewardApiController.java
+++ b/backend/src/main/java/com/stampcrush/backend/api/reward/RewardApiController.java
@@ -1,20 +1,37 @@
 package com.stampcrush.backend.api.reward;
 
+import com.stampcrush.backend.api.reward.dto.request.RewardFindRequest;
 import com.stampcrush.backend.api.reward.dto.request.RewardUsedUpdateRequest;
+import com.stampcrush.backend.api.reward.dto.response.RewardFindResponse;
+import com.stampcrush.backend.api.reward.dto.response.RewardsFindResponse;
 import com.stampcrush.backend.application.reward.RewardService;
+import com.stampcrush.backend.application.reward.dto.RewardFind;
+import com.stampcrush.backend.application.reward.dto.RewardFindResult;
 import com.stampcrush.backend.application.reward.dto.RewardUsedUpdate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RequiredArgsConstructor
 @RestController
 public class RewardApiController {
 
     private final RewardService rewardService;
+
+    @GetMapping("/customers/{customerId}/rewards")
+    public ResponseEntity<RewardsFindResponse> findRewards(@PathVariable("customerId") Long customerId,
+                                                           @ModelAttribute RewardFindRequest rewardFindRequest) {
+        System.out.println("here");
+        RewardFind rewardFind = new RewardFind(customerId, rewardFindRequest.getCafeId(), rewardFindRequest.isUsed());
+        List<RewardFindResult> rewardFindResults = rewardService.findRewards(rewardFind);
+        List<RewardFindResponse> rewardFindResponses = rewardFindResults.stream()
+                .map(RewardFindResponse::new)
+                .toList();
+        RewardsFindResponse response = new RewardsFindResponse(rewardFindResponses);
+        return ResponseEntity.ok(response);
+    }
 
     @PatchMapping("/customers/{customerId}/rewards/{rewardId}")
     public ResponseEntity<Void> updateRewardUsed(@PathVariable("customerId") Long customerId,

--- a/backend/src/main/java/com/stampcrush/backend/api/reward/RewardApiController.java
+++ b/backend/src/main/java/com/stampcrush/backend/api/reward/RewardApiController.java
@@ -8,6 +8,7 @@ import com.stampcrush.backend.application.reward.RewardService;
 import com.stampcrush.backend.application.reward.dto.RewardFind;
 import com.stampcrush.backend.application.reward.dto.RewardFindResult;
 import com.stampcrush.backend.application.reward.dto.RewardUsedUpdate;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -36,9 +37,9 @@ public class RewardApiController {
     @PatchMapping("/customers/{customerId}/rewards/{rewardId}")
     public ResponseEntity<Void> updateRewardUsed(@PathVariable("customerId") Long customerId,
                                                  @PathVariable("rewardId") Long rewardId,
-                                                 @RequestBody RewardUsedUpdateRequest rewardUsedUpdateRequest) {
+                                                 @RequestBody @Valid RewardUsedUpdateRequest rewardUsedUpdateRequest) {
         RewardUsedUpdate rewardUsedUpdate = new RewardUsedUpdate(rewardId, customerId, rewardUsedUpdateRequest.getCafeId(), rewardUsedUpdateRequest.isUsed());
-        rewardService.updateUsed(rewardUsedUpdate);
+        rewardService.useReward(rewardUsedUpdate);
         return ResponseEntity.ok().build();
     }
 }

--- a/backend/src/main/java/com/stampcrush/backend/api/reward/RewardApiController.java
+++ b/backend/src/main/java/com/stampcrush/backend/api/reward/RewardApiController.java
@@ -1,0 +1,27 @@
+package com.stampcrush.backend.api.reward;
+
+import com.stampcrush.backend.api.reward.dto.request.RewardUsedUpdateRequest;
+import com.stampcrush.backend.application.reward.RewardService;
+import com.stampcrush.backend.application.reward.dto.RewardUsedUpdate;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+public class RewardApiController {
+
+    private final RewardService rewardService;
+
+    @PatchMapping("/customers/{customerId}/rewards/{rewardId}")
+    public ResponseEntity<Void> updateRewardUsed(@PathVariable("customerId") Long customerId,
+                                                 @PathVariable("rewardId") Long rewardId,
+                                                 @RequestBody RewardUsedUpdateRequest rewardUsedUpdateRequest) {
+        RewardUsedUpdate rewardUsedUpdate = new RewardUsedUpdate(rewardId, customerId, rewardUsedUpdateRequest.getCafeId(), rewardUsedUpdateRequest.isUsed());
+        rewardService.updateUsed(rewardUsedUpdate);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/backend/src/main/java/com/stampcrush/backend/api/reward/dto/request/RewardFindRequest.java
+++ b/backend/src/main/java/com/stampcrush/backend/api/reward/dto/request/RewardFindRequest.java
@@ -1,0 +1,12 @@
+package com.stampcrush.backend.api.reward.dto.request;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class RewardFindRequest {
+
+    private final Long cafeId;
+    private final boolean used;
+}

--- a/backend/src/main/java/com/stampcrush/backend/api/reward/dto/request/RewardUsedUpdateRequest.java
+++ b/backend/src/main/java/com/stampcrush/backend/api/reward/dto/request/RewardUsedUpdateRequest.java
@@ -1,5 +1,6 @@
 package com.stampcrush.backend.api.reward.dto.request;
 
+import jakarta.validation.constraints.AssertTrue;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -8,5 +9,7 @@ import lombok.RequiredArgsConstructor;
 public class RewardUsedUpdateRequest {
 
     private final Long cafeId;
+
+    @AssertTrue
     private final boolean used;
 }

--- a/backend/src/main/java/com/stampcrush/backend/api/reward/dto/request/RewardUsedUpdateRequest.java
+++ b/backend/src/main/java/com/stampcrush/backend/api/reward/dto/request/RewardUsedUpdateRequest.java
@@ -1,0 +1,15 @@
+package com.stampcrush.backend.api.reward.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class RewardUsedUpdateRequest {
+
+    private Long cafeId;
+    private boolean used;
+
+    public RewardUsedUpdateRequest(Long cafeId, Boolean used) {
+        this.cafeId = cafeId;
+        this.used = used;
+    }
+}

--- a/backend/src/main/java/com/stampcrush/backend/api/reward/dto/request/RewardUsedUpdateRequest.java
+++ b/backend/src/main/java/com/stampcrush/backend/api/reward/dto/request/RewardUsedUpdateRequest.java
@@ -1,15 +1,12 @@
 package com.stampcrush.backend.api.reward.dto.request;
 
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 @Getter
+@RequiredArgsConstructor
 public class RewardUsedUpdateRequest {
 
-    private Long cafeId;
-    private boolean used;
-
-    public RewardUsedUpdateRequest(Long cafeId, Boolean used) {
-        this.cafeId = cafeId;
-        this.used = used;
-    }
+    private final Long cafeId;
+    private final boolean used;
 }

--- a/backend/src/main/java/com/stampcrush/backend/api/reward/dto/response/RewardFindResponse.java
+++ b/backend/src/main/java/com/stampcrush/backend/api/reward/dto/response/RewardFindResponse.java
@@ -1,0 +1,18 @@
+package com.stampcrush.backend.api.reward.dto.response;
+
+import com.stampcrush.backend.application.reward.dto.RewardFindResult;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class RewardFindResponse {
+
+    private final Long id;
+    private final String name;
+
+    public RewardFindResponse(RewardFindResult rewardFindResult) {
+        this.id = rewardFindResult.getId();
+        this.name = rewardFindResult.getName();
+    }
+}

--- a/backend/src/main/java/com/stampcrush/backend/api/reward/dto/response/RewardsFindResponse.java
+++ b/backend/src/main/java/com/stampcrush/backend/api/reward/dto/response/RewardsFindResponse.java
@@ -1,0 +1,13 @@
+package com.stampcrush.backend.api.reward.dto.response;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@RequiredArgsConstructor
+public class RewardsFindResponse {
+
+    private final List<RewardFindResponse> rewards;
+}

--- a/backend/src/main/java/com/stampcrush/backend/application/reward/RewardService.java
+++ b/backend/src/main/java/com/stampcrush/backend/application/reward/RewardService.java
@@ -1,0 +1,32 @@
+package com.stampcrush.backend.application.reward;
+
+import com.stampcrush.backend.application.reward.dto.RewardUsedUpdate;
+import com.stampcrush.backend.entity.cafe.Cafe;
+import com.stampcrush.backend.entity.reward.Reward;
+import com.stampcrush.backend.entity.user.Customer;
+import com.stampcrush.backend.repository.cafe.CafeRepository;
+import com.stampcrush.backend.repository.reward.RewardRepository;
+import com.stampcrush.backend.repository.user.CustomerRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class RewardService {
+
+    private final RewardRepository rewardRepository;
+    private final CustomerRepository customerRepository;
+    private final CafeRepository cafeRepository;
+
+    public void updateUsed(RewardUsedUpdate rewardUsedUpdate) {
+        Reward reward = rewardRepository.findById(rewardUsedUpdate.getRewardId())
+                .orElseThrow(IllegalArgumentException::new);
+        Customer customer = customerRepository.findById(rewardUsedUpdate.getCustomerId())
+                .orElseThrow(IllegalArgumentException::new);
+        Cafe cafe = cafeRepository.findById(rewardUsedUpdate.getCafeId())
+                .orElseThrow(IllegalArgumentException::new);
+        reward.useReward(customer, cafe);
+    }
+}

--- a/backend/src/main/java/com/stampcrush/backend/application/reward/RewardService.java
+++ b/backend/src/main/java/com/stampcrush/backend/application/reward/RewardService.java
@@ -32,7 +32,7 @@ public class RewardService {
                 .toList();
     }
 
-    public void updateUsed(RewardUsedUpdate rewardUsedUpdate) {
+    public void useReward(RewardUsedUpdate rewardUsedUpdate) {
         Reward reward = rewardRepository.findById(rewardUsedUpdate.getRewardId())
                 .orElseThrow(IllegalArgumentException::new);
         Customer customer = customerRepository.findById(rewardUsedUpdate.getCustomerId())

--- a/backend/src/main/java/com/stampcrush/backend/application/reward/RewardService.java
+++ b/backend/src/main/java/com/stampcrush/backend/application/reward/RewardService.java
@@ -1,5 +1,7 @@
 package com.stampcrush.backend.application.reward;
 
+import com.stampcrush.backend.application.reward.dto.RewardFind;
+import com.stampcrush.backend.application.reward.dto.RewardFindResult;
 import com.stampcrush.backend.application.reward.dto.RewardUsedUpdate;
 import com.stampcrush.backend.entity.cafe.Cafe;
 import com.stampcrush.backend.entity.reward.Reward;
@@ -11,6 +13,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @RequiredArgsConstructor
 @Transactional
 @Service
@@ -19,6 +23,14 @@ public class RewardService {
     private final RewardRepository rewardRepository;
     private final CustomerRepository customerRepository;
     private final CafeRepository cafeRepository;
+
+    @Transactional(readOnly = true)
+    public List<RewardFindResult> findRewards(RewardFind rewardFind) {
+        List<Reward> rewards = rewardRepository.findAllByCustomerIdAndCafeIdAndUsed(rewardFind.getCustomerId(), rewardFind.getCafeId(), rewardFind.isUsed());
+        return rewards.stream()
+                .map(reward -> new RewardFindResult(reward.getId(), reward.getName()))
+                .toList();
+    }
 
     public void updateUsed(RewardUsedUpdate rewardUsedUpdate) {
         Reward reward = rewardRepository.findById(rewardUsedUpdate.getRewardId())

--- a/backend/src/main/java/com/stampcrush/backend/application/reward/dto/RewardFind.java
+++ b/backend/src/main/java/com/stampcrush/backend/application/reward/dto/RewardFind.java
@@ -1,0 +1,13 @@
+package com.stampcrush.backend.application.reward.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class RewardFind {
+
+    private final Long customerId;
+    private final Long cafeId;
+    private final boolean used;
+}

--- a/backend/src/main/java/com/stampcrush/backend/application/reward/dto/RewardFindResult.java
+++ b/backend/src/main/java/com/stampcrush/backend/application/reward/dto/RewardFindResult.java
@@ -1,0 +1,12 @@
+package com.stampcrush.backend.application.reward.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class RewardFindResult {
+
+    private final Long id;
+    private final String name;
+}

--- a/backend/src/main/java/com/stampcrush/backend/application/reward/dto/RewardUsedUpdate.java
+++ b/backend/src/main/java/com/stampcrush/backend/application/reward/dto/RewardUsedUpdate.java
@@ -1,0 +1,19 @@
+package com.stampcrush.backend.application.reward.dto;
+
+import lombok.Getter;
+
+@Getter
+public class RewardUsedUpdate {
+
+    private Long rewardId;
+    private Long customerId;
+    private Long cafeId;
+    private Boolean used;
+
+    public RewardUsedUpdate(Long rewardId, Long customerId, Long cafeId, Boolean used) {
+        this.rewardId = rewardId;
+        this.customerId = customerId;
+        this.cafeId = cafeId;
+        this.used = used;
+    }
+}

--- a/backend/src/main/java/com/stampcrush/backend/application/reward/dto/RewardUsedUpdate.java
+++ b/backend/src/main/java/com/stampcrush/backend/application/reward/dto/RewardUsedUpdate.java
@@ -1,19 +1,14 @@
 package com.stampcrush.backend.application.reward.dto;
 
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
+@RequiredArgsConstructor
 @Getter
 public class RewardUsedUpdate {
 
-    private Long rewardId;
-    private Long customerId;
-    private Long cafeId;
-    private Boolean used;
-
-    public RewardUsedUpdate(Long rewardId, Long customerId, Long cafeId, Boolean used) {
-        this.rewardId = rewardId;
-        this.customerId = customerId;
-        this.cafeId = cafeId;
-        this.used = used;
-    }
+    private final Long rewardId;
+    private final Long customerId;
+    private final Long cafeId;
+    private final Boolean used;
 }

--- a/backend/src/main/java/com/stampcrush/backend/entity/cafe/Cafe.java
+++ b/backend/src/main/java/com/stampcrush/backend/entity/cafe/Cafe.java
@@ -1,7 +1,7 @@
 package com.stampcrush.backend.entity.cafe;
 
-import com.stampcrush.backend.entity.user.Owner;
 import com.stampcrush.backend.entity.baseentity.BaseDate;
+import com.stampcrush.backend.entity.user.Owner;
 import jakarta.persistence.*;
 import lombok.Getter;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -45,4 +45,19 @@ public class Cafe extends BaseDate {
 
     @OneToMany(mappedBy = "cafe")
     private List<CafePolicy> policies = new ArrayList<>();
+
+    protected Cafe() {
+    }
+
+    public Cafe(String name, LocalTime openTime, LocalTime closeTime, String telephoneNumber, String cafeImageUrl, String roadAddress, String detailAddress, String businessRegistrationNumber, Owner owner) {
+        this.name = name;
+        this.openTime = openTime;
+        this.closeTime = closeTime;
+        this.telephoneNumber = telephoneNumber;
+        this.cafeImageUrl = cafeImageUrl;
+        this.roadAddress = roadAddress;
+        this.detailAddress = detailAddress;
+        this.businessRegistrationNumber = businessRegistrationNumber;
+        this.owner = owner;
+    }
 }

--- a/backend/src/main/java/com/stampcrush/backend/entity/cafe/Cafe.java
+++ b/backend/src/main/java/com/stampcrush/backend/entity/cafe/Cafe.java
@@ -46,9 +46,6 @@ public class Cafe extends BaseDate {
     @OneToMany(mappedBy = "cafe")
     private List<CafePolicy> policies = new ArrayList<>();
 
-    protected Cafe() {
-    }
-
     public Cafe(String name, LocalTime openTime, LocalTime closeTime, String telephoneNumber, String cafeImageUrl, String roadAddress, String detailAddress, String businessRegistrationNumber, Owner owner) {
         this.name = name;
         this.openTime = openTime;
@@ -59,5 +56,8 @@ public class Cafe extends BaseDate {
         this.detailAddress = detailAddress;
         this.businessRegistrationNumber = businessRegistrationNumber;
         this.owner = owner;
+    }
+
+    protected Cafe() {
     }
 }

--- a/backend/src/main/java/com/stampcrush/backend/entity/reward/Reward.java
+++ b/backend/src/main/java/com/stampcrush/backend/entity/reward/Reward.java
@@ -19,7 +19,7 @@ public class Reward extends BaseDate {
 
     private String name;
 
-    private Boolean used;
+    private Boolean used = false;
 
     @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "customer_id")
@@ -29,9 +29,8 @@ public class Reward extends BaseDate {
     @JoinColumn(name = "cafe_id")
     private Cafe cafe;
 
-    public Reward(String name, Boolean used, Customer customer, Cafe cafe) {
+    public Reward(String name, Customer customer, Cafe cafe) {
         this.name = name;
-        this.used = used;
         this.customer = customer;
         this.cafe = cafe;
     }

--- a/backend/src/main/java/com/stampcrush/backend/entity/reward/Reward.java
+++ b/backend/src/main/java/com/stampcrush/backend/entity/reward/Reward.java
@@ -28,4 +28,42 @@ public class Reward extends BaseDate {
     @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "cafe_id")
     private Cafe cafe;
+
+    protected Reward() {
+    }
+
+    public Reward(String name, Boolean used, Customer customer, Cafe cafe) {
+        this.name = name;
+        this.used = used;
+        this.customer = customer;
+        this.cafe = cafe;
+    }
+
+    public void useReward(Customer customer, Cafe cafe) {
+        if (used) {
+            throw new IllegalArgumentException("이미 사용된 리워드 입니다.");
+        }
+        if (isTemporaryCustomer()) {
+            throw new IllegalArgumentException("임시회원은 리워드를 사용할 수 없습니다.");
+        }
+        if (isNotPublisher(cafe)) {
+            throw new IllegalArgumentException("해당 카페에서 발행된 리워드가 아닙니다.");
+        }
+        if (isNotOwner(customer)) {
+            throw new IllegalArgumentException("해당 리워드의 소유자가 아닙니다.");
+        }
+        used = true;
+    }
+
+    private boolean isTemporaryCustomer() {
+        return !customer.isRegistered();
+    }
+
+    private boolean isNotPublisher(Cafe cafe) {
+        return !cafe.equals(this.cafe);
+    }
+
+    private boolean isNotOwner(Customer customer) {
+        return !customer.equals(this.customer);
+    }
 }

--- a/backend/src/main/java/com/stampcrush/backend/entity/reward/Reward.java
+++ b/backend/src/main/java/com/stampcrush/backend/entity/reward/Reward.java
@@ -29,14 +29,14 @@ public class Reward extends BaseDate {
     @JoinColumn(name = "cafe_id")
     private Cafe cafe;
 
-    protected Reward() {
-    }
-
     public Reward(String name, Boolean used, Customer customer, Cafe cafe) {
         this.name = name;
         this.used = used;
         this.customer = customer;
         this.cafe = cafe;
+    }
+
+    protected Reward() {
     }
 
     public void useReward(Customer customer, Cafe cafe) {

--- a/backend/src/main/java/com/stampcrush/backend/entity/user/Customer.java
+++ b/backend/src/main/java/com/stampcrush/backend/entity/user/Customer.java
@@ -20,4 +20,14 @@ public abstract class Customer {
     private String nickname;
 
     private String phoneNumber;
+
+    protected Customer() {
+    }
+
+    public Customer(String nickname, String phoneNumber) {
+        this.nickname = nickname;
+        this.phoneNumber = phoneNumber;
+    }
+
+    public abstract boolean isRegistered();
 }

--- a/backend/src/main/java/com/stampcrush/backend/entity/user/Customer.java
+++ b/backend/src/main/java/com/stampcrush/backend/entity/user/Customer.java
@@ -21,12 +21,12 @@ public abstract class Customer {
 
     private String phoneNumber;
 
-    protected Customer() {
-    }
-
     public Customer(String nickname, String phoneNumber) {
         this.nickname = nickname;
         this.phoneNumber = phoneNumber;
+    }
+
+    protected Customer() {
     }
 
     public abstract boolean isRegistered();

--- a/backend/src/main/java/com/stampcrush/backend/entity/user/Owner.java
+++ b/backend/src/main/java/com/stampcrush/backend/entity/user/Owner.java
@@ -19,4 +19,14 @@ public class Owner extends BaseDate {
     private String loginId;
     private String encryptedPassword;
     private String phoneNumber;
+
+    protected Owner() {
+    }
+
+    public Owner(String name, String loginId, String encryptedPassword, String phoneNumber) {
+        this.name = name;
+        this.loginId = loginId;
+        this.encryptedPassword = encryptedPassword;
+        this.phoneNumber = phoneNumber;
+    }
 }

--- a/backend/src/main/java/com/stampcrush/backend/entity/user/Owner.java
+++ b/backend/src/main/java/com/stampcrush/backend/entity/user/Owner.java
@@ -20,13 +20,13 @@ public class Owner extends BaseDate {
     private String encryptedPassword;
     private String phoneNumber;
 
-    protected Owner() {
-    }
-
     public Owner(String name, String loginId, String encryptedPassword, String phoneNumber) {
         this.name = name;
         this.loginId = loginId;
         this.encryptedPassword = encryptedPassword;
         this.phoneNumber = phoneNumber;
+    }
+
+    protected Owner() {
     }
 }

--- a/backend/src/main/java/com/stampcrush/backend/entity/user/RegisterCustomer.java
+++ b/backend/src/main/java/com/stampcrush/backend/entity/user/RegisterCustomer.java
@@ -12,13 +12,13 @@ public class RegisterCustomer extends Customer {
     private String loginId;
     private String encryptedPassword;
 
-    protected RegisterCustomer() {
-    }
-
     public RegisterCustomer(String nickname, String phoneNumber, String loginId, String encryptedPassword) {
         super(nickname, phoneNumber);
         this.loginId = loginId;
         this.encryptedPassword = encryptedPassword;
+    }
+
+    protected RegisterCustomer() {
     }
 
     @Override

--- a/backend/src/main/java/com/stampcrush/backend/entity/user/RegisterCustomer.java
+++ b/backend/src/main/java/com/stampcrush/backend/entity/user/RegisterCustomer.java
@@ -11,5 +11,18 @@ public class RegisterCustomer extends Customer {
 
     private String loginId;
     private String encryptedPassword;
-}
 
+    protected RegisterCustomer() {
+    }
+
+    public RegisterCustomer(String nickname, String phoneNumber, String loginId, String encryptedPassword) {
+        super(nickname, phoneNumber);
+        this.loginId = loginId;
+        this.encryptedPassword = encryptedPassword;
+    }
+
+    @Override
+    public boolean isRegistered() {
+        return true;
+    }
+}

--- a/backend/src/main/java/com/stampcrush/backend/entity/user/TemporaryCustomer.java
+++ b/backend/src/main/java/com/stampcrush/backend/entity/user/TemporaryCustomer.java
@@ -1,10 +1,21 @@
 package com.stampcrush.backend.entity.user;
 
-import com.stampcrush.backend.entity.user.Customer;
 import jakarta.persistence.DiscriminatorValue;
 import jakarta.persistence.Entity;
 
 @DiscriminatorValue("temporary")
 @Entity
 public class TemporaryCustomer extends Customer {
+
+    protected TemporaryCustomer() {
+    }
+
+    public TemporaryCustomer(String nickname, String phoneNumber) {
+        super(nickname, phoneNumber);
+    }
+
+    @Override
+    public boolean isRegistered() {
+        return false;
+    }
 }

--- a/backend/src/main/java/com/stampcrush/backend/entity/user/TemporaryCustomer.java
+++ b/backend/src/main/java/com/stampcrush/backend/entity/user/TemporaryCustomer.java
@@ -7,11 +7,11 @@ import jakarta.persistence.Entity;
 @Entity
 public class TemporaryCustomer extends Customer {
 
-    protected TemporaryCustomer() {
-    }
-
     public TemporaryCustomer(String nickname, String phoneNumber) {
         super(nickname, phoneNumber);
+    }
+
+    protected TemporaryCustomer() {
     }
 
     @Override

--- a/backend/src/main/java/com/stampcrush/backend/repository/reward/RewardRepository.java
+++ b/backend/src/main/java/com/stampcrush/backend/repository/reward/RewardRepository.java
@@ -3,5 +3,9 @@ package com.stampcrush.backend.repository.reward;
 import com.stampcrush.backend.entity.reward.Reward;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface RewardRepository extends JpaRepository<Reward, Long> {
+
+    List<Reward> findAllByCustomerIdAndCafeIdAndUsed(Long CustomerId, Long CafeId, boolean used);
 }

--- a/backend/src/main/java/com/stampcrush/backend/repository/user/RegisterCustomerRepository.java
+++ b/backend/src/main/java/com/stampcrush/backend/repository/user/RegisterCustomerRepository.java
@@ -1,0 +1,7 @@
+package com.stampcrush.backend.repository.user;
+
+import com.stampcrush.backend.entity.user.RegisterCustomer;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RegisterCustomerRepository extends JpaRepository<RegisterCustomer, Integer> {
+}

--- a/backend/src/main/java/com/stampcrush/backend/repository/user/TemporaryCustomerRepository.java
+++ b/backend/src/main/java/com/stampcrush/backend/repository/user/TemporaryCustomerRepository.java
@@ -1,0 +1,7 @@
+package com.stampcrush.backend.repository.user;
+
+import com.stampcrush.backend.entity.user.TemporaryCustomer;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TemporaryCustomerRepository extends JpaRepository<TemporaryCustomer, Long> {
+}

--- a/backend/src/main/java/com/stampcrush/backend/reward-request.http
+++ b/backend/src/main/java/com/stampcrush/backend/reward-request.http
@@ -1,0 +1,5 @@
+### 고객의 리워드 조회 요청
+
+GET localhost:8080/customers/1/rewards?cafeId=1&used=false
+Content-Type: application/json
+

--- a/backend/src/test/java/com/stampcrush/backend/application/reward/RewardServiceTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/application/reward/RewardServiceTest.java
@@ -69,7 +69,7 @@ class RewardServiceTest {
         registerCustomer_2 = registerCustomerRepository.save(new RegisterCustomer("registered2", "01044444444", "dsadsa@naver.com", "2345"));
         temporaryCustomer = temporaryCustomerRepository.save(new TemporaryCustomer("temporary", "01033333333"));
 
-        unusedReward = rewardRepository.save(new Reward("Americano", false, registerCustomer_1, cafe_1));
+        unusedReward = rewardRepository.save(new Reward("Americano", registerCustomer_1, cafe_1));
     }
 
     @Test
@@ -125,7 +125,7 @@ class RewardServiceTest {
     }
 
     @Test
-    void 이미_사용된_리워드를_사용려하면_예외를_던진다() {
+    void 이미_사용된_리워드를_사용하려하면_예외를_던진다() {
         //given
         RewardUsedUpdate rewardUsedUpdate = new RewardUsedUpdate(unusedReward.getId(), registerCustomer_1.getId(), cafe_1.getId(), true);
         rewardService.useReward(rewardUsedUpdate);

--- a/backend/src/test/java/com/stampcrush/backend/application/reward/RewardServiceTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/application/reward/RewardServiceTest.java
@@ -78,7 +78,7 @@ class RewardServiceTest {
         RewardUsedUpdate rewardUsedUpdate = new RewardUsedUpdate(unusedReward.getId(), registerCustomer_1.getId(), cafe_1.getId(), true);
 
         // when
-        rewardService.updateUsed(rewardUsedUpdate);
+        rewardService.useReward(rewardUsedUpdate);
 
         // then
         assertThat(unusedReward.getUsed()).isTrue();
@@ -90,7 +90,7 @@ class RewardServiceTest {
         RewardUsedUpdate rewardUsedUpdate = new RewardUsedUpdate(unusedReward.getId(), Long.MAX_VALUE, cafe_1.getId(), true);
 
         // when, then
-        assertThatThrownBy(() -> rewardService.updateUsed(rewardUsedUpdate))
+        assertThatThrownBy(() -> rewardService.useReward(rewardUsedUpdate))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
@@ -100,7 +100,7 @@ class RewardServiceTest {
         RewardUsedUpdate rewardUsedUpdate = new RewardUsedUpdate(Long.MAX_VALUE, registerCustomer_1.getId(), cafe_1.getId(), true);
 
         // when, then
-        assertThatThrownBy(() -> rewardService.updateUsed(rewardUsedUpdate))
+        assertThatThrownBy(() -> rewardService.useReward(rewardUsedUpdate))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
@@ -110,7 +110,7 @@ class RewardServiceTest {
         RewardUsedUpdate rewardUsedUpdate = new RewardUsedUpdate(unusedReward.getId(), registerCustomer_1.getId(), Long.MAX_VALUE, true);
 
         // when, then
-        assertThatThrownBy(() -> rewardService.updateUsed(rewardUsedUpdate))
+        assertThatThrownBy(() -> rewardService.useReward(rewardUsedUpdate))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
@@ -120,7 +120,7 @@ class RewardServiceTest {
         RewardUsedUpdate rewardUsedUpdate = new RewardUsedUpdate(unusedReward.getId(), temporaryCustomer.getId(), cafe_1.getId(), true);
 
         // when, then
-        assertThatThrownBy(() -> rewardService.updateUsed(rewardUsedUpdate))
+        assertThatThrownBy(() -> rewardService.useReward(rewardUsedUpdate))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
@@ -128,10 +128,10 @@ class RewardServiceTest {
     void 이미_사용된_리워드를_사용려하면_예외를_던진다() {
         //given
         RewardUsedUpdate rewardUsedUpdate = new RewardUsedUpdate(unusedReward.getId(), registerCustomer_1.getId(), cafe_1.getId(), true);
-        rewardService.updateUsed(rewardUsedUpdate);
+        rewardService.useReward(rewardUsedUpdate);
 
         // when, then
-        assertThatThrownBy(() -> rewardService.updateUsed(rewardUsedUpdate))
+        assertThatThrownBy(() -> rewardService.useReward(rewardUsedUpdate))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
@@ -141,7 +141,7 @@ class RewardServiceTest {
         RewardUsedUpdate rewardUsedUpdate = new RewardUsedUpdate(unusedReward.getId(), registerCustomer_1.getId(), cafe_2.getId(), true);
 
         // when, then
-        assertThatThrownBy(() -> rewardService.updateUsed(rewardUsedUpdate))
+        assertThatThrownBy(() -> rewardService.useReward(rewardUsedUpdate))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
@@ -151,7 +151,7 @@ class RewardServiceTest {
         RewardUsedUpdate rewardUsedUpdate = new RewardUsedUpdate(unusedReward.getId(), registerCustomer_2.getId(), cafe_1.getId(), true);
 
         // when, then
-        assertThatThrownBy(() -> rewardService.updateUsed(rewardUsedUpdate))
+        assertThatThrownBy(() -> rewardService.useReward(rewardUsedUpdate))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 

--- a/backend/src/test/java/com/stampcrush/backend/application/reward/RewardServiceTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/application/reward/RewardServiceTest.java
@@ -1,0 +1,154 @@
+package com.stampcrush.backend.application.reward;
+
+import com.stampcrush.backend.application.reward.dto.RewardUsedUpdate;
+import com.stampcrush.backend.entity.cafe.Cafe;
+import com.stampcrush.backend.entity.reward.Reward;
+import com.stampcrush.backend.entity.user.Customer;
+import com.stampcrush.backend.entity.user.Owner;
+import com.stampcrush.backend.entity.user.RegisterCustomer;
+import com.stampcrush.backend.entity.user.TemporaryCustomer;
+import com.stampcrush.backend.repository.cafe.CafeRepository;
+import com.stampcrush.backend.repository.reward.RewardRepository;
+import com.stampcrush.backend.repository.user.OwnerRepository;
+import com.stampcrush.backend.repository.user.RegisterCustomerRepository;
+import com.stampcrush.backend.repository.user.TemporaryCustomerRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@Transactional
+@SpringBootTest
+class RewardServiceTest {
+
+    @Autowired
+    private RewardService rewardService;
+
+    @Autowired
+    private RewardRepository rewardRepository;
+
+    @Autowired
+    private OwnerRepository ownerRepository;
+
+    @Autowired
+    private CafeRepository cafeRepository;
+
+    @Autowired
+    private RegisterCustomerRepository registerCustomerRepository;
+
+    @Autowired
+    private TemporaryCustomerRepository temporaryCustomerRepository;
+
+    private Owner owner_1;
+    private Owner owner_2;
+    private Cafe cafe_1;
+    private Cafe cafe_2;
+    private Customer registerCustomer_1;
+    private Customer registerCustomer_2;
+    private Customer temporaryCustomer;
+    private Reward reward;
+
+    @BeforeEach
+    void setUp() {
+        owner_1 = ownerRepository.save(new Owner("lisa", "lisa@naver.com", "1234", "01011111111"));
+        owner_2 = ownerRepository.save(new Owner("tommy", "tommy@naver.com", "5678", "01099999999"));
+
+        cafe_1 = cafeRepository.save(new Cafe("stamp-crush", LocalTime.of(18, 0), LocalTime.of(23, 59), "0211111111", "imageUrl", "잠실도로명", "14층", "11-11111", owner_1));
+        cafe_2 = cafeRepository.save(new Cafe("wrongCafe", LocalTime.of(18, 0), LocalTime.of(23, 59), "0211111111", "imageUrl", "잠실도로", "1층", "11-11111", owner_2));
+
+        registerCustomer_1 = registerCustomerRepository.save(new RegisterCustomer("registered", "01022222222", "ehdgur@naver.com", "1111"));
+        registerCustomer_2 = registerCustomerRepository.save(new RegisterCustomer("registered2", "01044444444", "dsadsa@naver.com", "2345"));
+        temporaryCustomer = temporaryCustomerRepository.save(new TemporaryCustomer("temporary", "01033333333"));
+
+        reward = rewardRepository.save(new Reward("Americano", false, registerCustomer_1, cafe_1));
+    }
+
+    @Test
+    void 리워드를_사용한다() {
+        // given
+        RewardUsedUpdate rewardUsedUpdate = new RewardUsedUpdate(reward.getId(), registerCustomer_1.getId(), cafe_1.getId(), true);
+
+        // when
+        rewardService.updateUsed(rewardUsedUpdate);
+
+        // then
+        assertThat(reward.getUsed()).isTrue();
+    }
+
+    @Test
+    void 존재하지_않는_리워드를_사용하려하면_예외를_던진다() {
+        // given
+        RewardUsedUpdate rewardUsedUpdate = new RewardUsedUpdate(reward.getId(), Long.MAX_VALUE, cafe_1.getId(), true);
+
+        // when, then
+        assertThatThrownBy(() -> rewardService.updateUsed(rewardUsedUpdate))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void 존재하지_않는_고객에_대한_리워드를_사용하려하면_예외를_던진다() {
+        // given
+        RewardUsedUpdate rewardUsedUpdate = new RewardUsedUpdate(Long.MAX_VALUE, registerCustomer_1.getId(), cafe_1.getId(), true);
+
+        // when, then
+        assertThatThrownBy(() -> rewardService.updateUsed(rewardUsedUpdate))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void 존재하지_않는_카페에서_리워드를_사용하려하면_예외를_던진다() {
+        // given
+        RewardUsedUpdate rewardUsedUpdate = new RewardUsedUpdate(reward.getId(), registerCustomer_1.getId(), Long.MAX_VALUE, true);
+
+        // when, then
+        assertThatThrownBy(() -> rewardService.updateUsed(rewardUsedUpdate))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void 임시회원이_리워드를_사용하려하면_예외를_던진다() {
+        //given
+        RewardUsedUpdate rewardUsedUpdate = new RewardUsedUpdate(reward.getId(), temporaryCustomer.getId(), cafe_1.getId(), true);
+
+        // when, then
+        assertThatThrownBy(() -> rewardService.updateUsed(rewardUsedUpdate))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void 이미_사용된_리워드를_사용려하면_예외를_던진다() {
+        //given
+        RewardUsedUpdate rewardUsedUpdate = new RewardUsedUpdate(reward.getId(), registerCustomer_1.getId(), cafe_1.getId(), true);
+        rewardService.updateUsed(rewardUsedUpdate);
+
+        // when, then
+        assertThatThrownBy(() -> rewardService.updateUsed(rewardUsedUpdate))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void 다른_카페에의해_생성된_리워드를_사용하려하면_예외를_던진다() {
+        //given
+        RewardUsedUpdate rewardUsedUpdate = new RewardUsedUpdate(reward.getId(), registerCustomer_1.getId(), cafe_2.getId(), true);
+
+        // when, then
+        assertThatThrownBy(() -> rewardService.updateUsed(rewardUsedUpdate))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void 소유자가_아닌_고객이_리워드를_사용하려하면_예외를_던진다() {
+        //given
+        RewardUsedUpdate rewardUsedUpdate = new RewardUsedUpdate(reward.getId(), registerCustomer_2.getId(), cafe_1.getId(), true);
+
+        // when, then
+        assertThatThrownBy(() -> rewardService.updateUsed(rewardUsedUpdate))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/backend/src/test/java/com/stampcrush/backend/entity/reward/RewardTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/entity/reward/RewardTest.java
@@ -1,0 +1,88 @@
+package com.stampcrush.backend.entity.reward;
+
+import com.stampcrush.backend.entity.cafe.Cafe;
+import com.stampcrush.backend.entity.user.Customer;
+import com.stampcrush.backend.entity.user.Owner;
+import com.stampcrush.backend.entity.user.RegisterCustomer;
+import com.stampcrush.backend.entity.user.TemporaryCustomer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.time.LocalTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DataJpaTest
+public class RewardTest {
+
+    private Cafe cafe_1;
+    private Cafe cafe_2;
+    private Customer registerCustomer_1;
+    private Customer registerCustomer_2;
+    private Customer temporaryCustomer;
+
+    @BeforeEach
+    void setUp() {
+        Owner owner_1 = new Owner("lisa", "lisa@naver.com", "1234", "01011111111");
+        Owner owner_2 = new Owner("tommy", "tommy@naver.com", "5678", "01099999999");
+        cafe_1 = new Cafe("stamp-crush", LocalTime.of(18, 0), LocalTime.of(23, 59), "0211111111", "imageUrl", "잠실도로명", "14층", "11-11111", owner_1);
+        cafe_2 = new Cafe("wrongCafe", LocalTime.of(18, 0), LocalTime.of(23, 59), "0211111111", "imageUrl", "잠실도로", "1층", "11-11111", owner_2);
+        registerCustomer_1 = new RegisterCustomer("registered", "01022222222", "ehdgur@naver.com", "1111");
+        registerCustomer_2 = new RegisterCustomer("registered2", "01044444444", "dsadsa@naver.com", "2345");
+        temporaryCustomer = new TemporaryCustomer("temporary", "01033333333");
+    }
+
+    @Test
+    void 가입회원이_리워드를_사용한다() {
+        // given
+        Reward reward = new Reward("Americano", false, registerCustomer_1, cafe_1);
+
+        // when
+        reward.useReward(registerCustomer_1, cafe_1);
+
+        // then
+        assertThat(reward.getUsed()).isTrue();
+    }
+
+    @Test
+    void 임시회원이_리워드를_사용하려하면_예외를_던진다() {
+        //given
+        Reward reward = new Reward("Americano", false, temporaryCustomer, cafe_1);
+
+        // when, then
+        assertThatThrownBy(() -> reward.useReward(temporaryCustomer, cafe_1))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void 이미_사용된_리워드를_사용려하면_예외를_던진다() {
+        // given
+        Reward reward = new Reward("Americano", true, registerCustomer_1, cafe_1);
+
+        // when, then
+        assertThatThrownBy(() -> reward.useReward(temporaryCustomer, cafe_1))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void 다른_카페에의해_생성된_리워드를_사용하려하면_예외를_던진다() {
+        // given
+        Reward reward = new Reward("Americano", true, registerCustomer_1, cafe_1);
+
+        // when, then
+        assertThatThrownBy(() -> reward.useReward(registerCustomer_1, cafe_2))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void 소유자가_아닌_고객이_리워드를_사용하려하면_예외를_던진다() {
+        // given
+        Reward reward = new Reward("Americano", true, registerCustomer_1, cafe_1);
+
+        // when, then
+        assertThatThrownBy(() -> reward.useReward(registerCustomer_2, cafe_1))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/backend/src/test/java/com/stampcrush/backend/entity/reward/RewardTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/entity/reward/RewardTest.java
@@ -37,7 +37,7 @@ public class RewardTest {
     @Test
     void 가입회원이_리워드를_사용한다() {
         // given
-        Reward reward = new Reward("Americano", false, registerCustomer_1, cafe_1);
+        Reward reward = new Reward("Americano", registerCustomer_1, cafe_1);
 
         // when
         reward.useReward(registerCustomer_1, cafe_1);
@@ -49,7 +49,7 @@ public class RewardTest {
     @Test
     void 임시회원이_리워드를_사용하려하면_예외를_던진다() {
         //given
-        Reward reward = new Reward("Americano", false, temporaryCustomer, cafe_1);
+        Reward reward = new Reward("Americano", temporaryCustomer, cafe_1);
 
         // when, then
         assertThatThrownBy(() -> reward.useReward(temporaryCustomer, cafe_1))
@@ -59,17 +59,18 @@ public class RewardTest {
     @Test
     void 이미_사용된_리워드를_사용려하면_예외를_던진다() {
         // given
-        Reward reward = new Reward("Americano", true, registerCustomer_1, cafe_1);
+        Reward reward = new Reward("Americano", registerCustomer_1, cafe_1);
+        reward.useReward(registerCustomer_1, cafe_1);
 
         // when, then
-        assertThatThrownBy(() -> reward.useReward(temporaryCustomer, cafe_1))
+        assertThatThrownBy(() -> reward.useReward(registerCustomer_1, cafe_1))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
     void 다른_카페에의해_생성된_리워드를_사용하려하면_예외를_던진다() {
         // given
-        Reward reward = new Reward("Americano", true, registerCustomer_1, cafe_1);
+        Reward reward = new Reward("Americano", registerCustomer_1, cafe_1);
 
         // when, then
         assertThatThrownBy(() -> reward.useReward(registerCustomer_1, cafe_2))
@@ -79,7 +80,7 @@ public class RewardTest {
     @Test
     void 소유자가_아닌_고객이_리워드를_사용하려하면_예외를_던진다() {
         // given
-        Reward reward = new Reward("Americano", true, registerCustomer_1, cafe_1);
+        Reward reward = new Reward("Americano", registerCustomer_1, cafe_1);
 
         // when, then
         assertThatThrownBy(() -> reward.useReward(registerCustomer_2, cafe_1))


### PR DESCRIPTION
## 주요 변경사항
- 등록회원, 임시회원의 레포지토리 생성
- 카페, 사장 생성자 추가
- 리워드 사용 기능 구현

## 리뷰어에게...
- 일단 주기를 짧게 가져가려고 리워드 사용 기능만 추가했습니다 !
- `RewardApiController`, `RewardService`, `Reward` 와 이에 관련된 테스트 위주로 주로 보시면 될 것 같아요!
- 패키지 구조는 일단 제 방식대로 했는데 여러분과의 협의가 필요합니다 !!
- 특히 `Request`, `Response`의 경우 여러계층에 의존적이지 않으므로, `api` 패키지 밑에 두었습니다.
- 메서드명과 클래스명에 대한 고민을 많이 했습니다. (추천받습니다)
- 현재 인수테스트는 다른 기능들(회원가입)이 추가되지 않고 Inmemory로 쓰기 때문에 매번 초기화되며 인증방식의 미결정으로 인해 구현하지 않았습니다.
- 테스트는 Inmemory h2 database로 쓰시는지 local h2를 쓰시는지 궁금하네요 ㅎㅎ (경험공유해주시면 감사합니다)
- `application.yml` 파일을 수정했는데 따로 올리지는 않았습니다 ! (클론받아서 돌려보시면 아마.. 안돌아가실것 같아요) 

## 리워드 사용

### Request

**Header**

```http
PATCH /customers/{customerId}/rewards/{rewardId} 
Header: owner 
```

**Body**
```json
{
	"cafeId": 1,
	"used": "true"
}
```

### Response

**Header**

```http
HTTP/1.1 200 OK
```

**Body**

None

## 리워드 조회

### Request

**Header**

```http
GET /customers/{customerId}/rewards?cafeId={cafeId}&used={false}
header: owner // 인증 
```

- owner 정보로 cafe가 이 owner의 건지 확인이 필요함.

### Response

**Header**

```http
HTTP/1.1 200 OK
Content-Type: application/json
```

**Body**
```json
{
	"rewards": [
		{
			"id": 1,
			"name": "아메리카노",
		},
		{
			"id" : 2,
			"name": "조각케익",
		}
	]
} 
```


## 관련 이슈

closes #82 #86 

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [x] `milestone` 설정
