### PR TITLE
[BE] feat: 전화번호로 고객을 조회한다/ 임시 고객을 생성한다

### DIFF
--- a/backend/src/main/java/com/stampcrush/backend/controller/CustomerController.java
+++ b/backend/src/main/java/com/stampcrush/backend/controller/CustomerController.java
@@ -4,19 +4,17 @@ import com.stampcrush.backend.service.CustomerService;
 import com.stampcrush.backend.service.CustomersResponse;
 import com.stampcrush.backend.service.TemporaryCustomerRequest;
 import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
 
+@RequiredArgsConstructor
 @RestController
 public class CustomerController {
 
     private final CustomerService customerService;
-
-    public CustomerController(CustomerService customerService) {
-        this.customerService = customerService;
-    }
 
     @GetMapping("/customers")
     public ResponseEntity<CustomersResponse> findCustomer(@RequestParam("phone-number") String phoneNumber) {

--- a/backend/src/main/java/com/stampcrush/backend/controller/CustomerController.java
+++ b/backend/src/main/java/com/stampcrush/backend/controller/CustomerController.java
@@ -1,14 +1,13 @@
 package com.stampcrush.backend.controller;
 
-import com.stampcrush.backend.service.CustomerResponse;
 import com.stampcrush.backend.service.CustomerService;
+import com.stampcrush.backend.service.CustomersResponse;
 import com.stampcrush.backend.service.TemporaryCustomerRequest;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
-import java.util.List;
 
 @RestController
 public class CustomerController {
@@ -20,12 +19,13 @@ public class CustomerController {
     }
 
     @GetMapping("/customers")
-    public ResponseEntity<List<CustomerResponse>> findCustomer(@RequestParam("phone-number") String phoneNumber) {
-        List<CustomerResponse> customers = customerService.findCustomer(phoneNumber);
+    public ResponseEntity<CustomersResponse> findCustomer(@RequestParam("phone-number") String phoneNumber) {
+        CustomersResponse customers = customerService.findCustomer(phoneNumber);
+
         return ResponseEntity.ok().body(customers);
     }
 
-    @PostMapping("temporary-customers")
+    @PostMapping("/temporary-customers")
     public ResponseEntity<Void> createTemporaryCustomer(@RequestBody @Valid TemporaryCustomerRequest temporaryCustomerRequest) {
         Long customerId = customerService.createTemporaryCustomer(temporaryCustomerRequest.getPhoneNumber());
 

--- a/backend/src/main/java/com/stampcrush/backend/controller/CustomerController.java
+++ b/backend/src/main/java/com/stampcrush/backend/controller/CustomerController.java
@@ -2,11 +2,12 @@ package com.stampcrush.backend.controller;
 
 import com.stampcrush.backend.service.CustomerResponse;
 import com.stampcrush.backend.service.CustomerService;
+import com.stampcrush.backend.service.TemporaryCustomerRequest;
+import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
+import java.net.URI;
 import java.util.List;
 
 @RestController
@@ -22,5 +23,12 @@ public class CustomerController {
     public ResponseEntity<List<CustomerResponse>> findCustomer(@RequestParam("phone-number") String phoneNumber) {
         List<CustomerResponse> customers = customerService.findCustomer(phoneNumber);
         return ResponseEntity.ok().body(customers);
+    }
+
+    @PostMapping("temporary-customers")
+    public ResponseEntity<Void> createTemporaryCustomer(@RequestBody @Valid TemporaryCustomerRequest temporaryCustomerRequest) {
+        Long customerId = customerService.createTemporaryCustomer(temporaryCustomerRequest.getPhoneNumber());
+
+        return ResponseEntity.created(URI.create("/customers/" + customerId)).build();
     }
 }

--- a/backend/src/main/java/com/stampcrush/backend/controller/CustomerController.java
+++ b/backend/src/main/java/com/stampcrush/backend/controller/CustomerController.java
@@ -1,0 +1,26 @@
+package com.stampcrush.backend.controller;
+
+import com.stampcrush.backend.service.CustomerResponse;
+import com.stampcrush.backend.service.CustomerService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+public class CustomerController {
+
+    private final CustomerService customerService;
+
+    public CustomerController(CustomerService customerService) {
+        this.customerService = customerService;
+    }
+
+    @GetMapping("/customers")
+    public ResponseEntity<List<CustomerResponse>> findCustomer(@RequestParam("phone-number") String phoneNumber) {
+        List<CustomerResponse> customers = customerService.findCustomer(phoneNumber);
+        return ResponseEntity.ok().body(customers);
+    }
+}

--- a/backend/src/main/java/com/stampcrush/backend/entity/user/Customer.java
+++ b/backend/src/main/java/com/stampcrush/backend/entity/user/Customer.java
@@ -1,11 +1,16 @@
 package com.stampcrush.backend.entity.user;
 
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import static jakarta.persistence.GenerationType.IDENTITY;
 import static jakarta.persistence.InheritanceType.JOINED;
+import static lombok.AccessLevel.PROTECTED;
 
+@AllArgsConstructor
+@NoArgsConstructor(access = PROTECTED)
 @Getter
 @Entity
 @DiscriminatorColumn(name = "dtype")

--- a/backend/src/main/java/com/stampcrush/backend/entity/user/RegisterCustomer.java
+++ b/backend/src/main/java/com/stampcrush/backend/entity/user/RegisterCustomer.java
@@ -3,7 +3,11 @@ package com.stampcrush.backend.entity.user;
 import jakarta.persistence.DiscriminatorValue;
 import jakarta.persistence.Entity;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+import static lombok.AccessLevel.PROTECTED;
+
+@NoArgsConstructor(access = PROTECTED)
 @Getter
 @DiscriminatorValue("register")
 @Entity
@@ -11,5 +15,10 @@ public class RegisterCustomer extends Customer {
 
     private String loginId;
     private String encryptedPassword;
-}
 
+    public RegisterCustomer(String nickname, String phoneNumber, String loginId, String encryptedPassword) {
+        super(null, nickname, phoneNumber);
+        this.loginId = loginId;
+        this.encryptedPassword = encryptedPassword;
+    }
+}

--- a/backend/src/main/java/com/stampcrush/backend/entity/user/TemporaryCustomer.java
+++ b/backend/src/main/java/com/stampcrush/backend/entity/user/TemporaryCustomer.java
@@ -1,10 +1,17 @@
 package com.stampcrush.backend.entity.user;
 
-import com.stampcrush.backend.entity.user.Customer;
 import jakarta.persistence.DiscriminatorValue;
 import jakarta.persistence.Entity;
+import lombok.NoArgsConstructor;
 
+import static lombok.AccessLevel.PROTECTED;
+
+@NoArgsConstructor(access = PROTECTED)
 @DiscriminatorValue("temporary")
 @Entity
 public class TemporaryCustomer extends Customer {
+
+    public TemporaryCustomer(String nickname, String phoneNumber) {
+        super(null, nickname, phoneNumber);
+    }
 }

--- a/backend/src/main/java/com/stampcrush/backend/repository/user/CustomerRepository.java
+++ b/backend/src/main/java/com/stampcrush/backend/repository/user/CustomerRepository.java
@@ -3,5 +3,10 @@ package com.stampcrush.backend.repository.user;
 import com.stampcrush.backend.entity.user.Customer;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface CustomerRepository extends JpaRepository<Customer, Long> {
+
+    //    Optional<Customer> findByPhoneNumber(String phoneNumber);
+    List<Customer> findByphoneNumber(String phoneNumber);
 }

--- a/backend/src/main/java/com/stampcrush/backend/repository/user/CustomerRepository.java
+++ b/backend/src/main/java/com/stampcrush/backend/repository/user/CustomerRepository.java
@@ -6,7 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface CustomerRepository extends JpaRepository<Customer, Long> {
-
-    //    Optional<Customer> findByPhoneNumber(String phoneNumber);
+    
     List<Customer> findByphoneNumber(String phoneNumber);
 }

--- a/backend/src/main/java/com/stampcrush/backend/service/CustomerResponse.java
+++ b/backend/src/main/java/com/stampcrush/backend/service/CustomerResponse.java
@@ -1,0 +1,22 @@
+package com.stampcrush.backend.service;
+
+import com.stampcrush.backend.entity.user.Customer;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+import static lombok.AccessLevel.PRIVATE;
+
+@EqualsAndHashCode
+@AllArgsConstructor(access = PRIVATE)
+@Getter
+public class CustomerResponse {
+
+    private final Long id;
+    private String nickname;
+    private String phoneNumber;
+
+    public static CustomerResponse from(Customer customer) {
+        return new CustomerResponse(customer.getId(), customer.getNickname(), customer.getPhoneNumber());
+    }
+}

--- a/backend/src/main/java/com/stampcrush/backend/service/CustomerService.java
+++ b/backend/src/main/java/com/stampcrush/backend/service/CustomerService.java
@@ -1,0 +1,37 @@
+package com.stampcrush.backend.service;
+
+import com.stampcrush.backend.entity.user.Customer;
+import com.stampcrush.backend.repository.user.CustomerRepository;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@AllArgsConstructor
+@Service
+public class CustomerService {
+
+    private final CustomerRepository customerRepository;
+
+//    리스트가 아니라 CustomerResponse 를 반환하고 존재하지 않을 때는 인증되지 않았다는 에러를 내려줘야 하는것이 아닐지
+//    public List<CustomerResponse> findCustomer(String phoneNumber) {
+//        try {
+//            Customer customer = customerRepository.findByphoneNumber(phoneNumber)
+//                    .orElseThrow(() -> new IllegalArgumentException("해당 번호로 조회되는 고객이 없습니다"));
+//            return List.of(CustomerResponse.from(customer));
+//        } catch (IllegalArgumentException e) {
+//            return Collections.emptyList();
+//        }
+//    }
+
+    public List<CustomerResponse> findCustomer(String phoneNumber) {
+        try {
+            List<Customer> customers = customerRepository.findByphoneNumber(phoneNumber);
+            return customers.stream().map(CustomerResponse::from).collect(Collectors.toList());
+        } catch (IllegalArgumentException e) {
+            return Collections.emptyList();
+        }
+    }
+}

--- a/backend/src/main/java/com/stampcrush/backend/service/CustomerService.java
+++ b/backend/src/main/java/com/stampcrush/backend/service/CustomerService.java
@@ -6,9 +6,9 @@ import com.stampcrush.backend.repository.user.CustomerRepository;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
+
+import static java.util.stream.Collectors.toList;
 
 @AllArgsConstructor
 @Service
@@ -16,30 +16,19 @@ public class CustomerService {
 
     private final CustomerRepository customerRepository;
 
-//    리스트가 아니라 CustomerResponse 를 반환하고 존재하지 않을 때는 인증되지 않았다는 에러를 내려줘야 하는것이 아닐지
-//    public List<CustomerResponse> findCustomer(String phoneNumber) {
-//        try {
-//            Customer customer = customerRepository.findByphoneNumber(phoneNumber)
-//                    .orElseThrow(() -> new IllegalArgumentException("해당 번호로 조회되는 고객이 없습니다"));
-//            return List.of(CustomerResponse.from(customer));
-//        } catch (IllegalArgumentException e) {
-//            return Collections.emptyList();
-//        }
-//    }
-
     public CustomersResponse findCustomer(String phoneNumber) {
-        try {
-            List<Customer> customers = customerRepository.findByphoneNumber(phoneNumber);
+        List<Customer> customers = customerRepository.findByphoneNumber(phoneNumber);
 
-            return new CustomersResponse(customers.stream()
-                    .map(CustomerResponse::from)
-                    .collect(Collectors.toList()));
-        } catch (IllegalArgumentException e) {
-            return new CustomersResponse(Collections.emptyList());
-        }
+        return new CustomersResponse(customers.stream()
+                .map(CustomerResponse::from)
+                .collect(toList()));
     }
 
     public Long createTemporaryCustomer(String phoneNumber) {
+        if (!customerRepository.findByphoneNumber(phoneNumber).isEmpty()) {
+            throw new IllegalArgumentException("이미 존재하는 회원입니다");
+        }
+
         String nickname = phoneNumber.substring(phoneNumber.length() - 4);
         TemporaryCustomer temporaryCustomer = new TemporaryCustomer(nickname, phoneNumber);
 

--- a/backend/src/main/java/com/stampcrush/backend/service/CustomerService.java
+++ b/backend/src/main/java/com/stampcrush/backend/service/CustomerService.java
@@ -27,12 +27,15 @@ public class CustomerService {
 //        }
 //    }
 
-    public List<CustomerResponse> findCustomer(String phoneNumber) {
+    public CustomersResponse findCustomer(String phoneNumber) {
         try {
             List<Customer> customers = customerRepository.findByphoneNumber(phoneNumber);
-            return customers.stream().map(CustomerResponse::from).collect(Collectors.toList());
+
+            return new CustomersResponse(customers.stream()
+                    .map(CustomerResponse::from)
+                    .collect(Collectors.toList()));
         } catch (IllegalArgumentException e) {
-            return Collections.emptyList();
+            return new CustomersResponse(Collections.emptyList());
         }
     }
 

--- a/backend/src/main/java/com/stampcrush/backend/service/CustomerService.java
+++ b/backend/src/main/java/com/stampcrush/backend/service/CustomerService.java
@@ -1,6 +1,7 @@
 package com.stampcrush.backend.service;
 
 import com.stampcrush.backend.entity.user.Customer;
+import com.stampcrush.backend.entity.user.TemporaryCustomer;
 import com.stampcrush.backend.repository.user.CustomerRepository;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -33,5 +34,14 @@ public class CustomerService {
         } catch (IllegalArgumentException e) {
             return Collections.emptyList();
         }
+    }
+
+    public Long createTemporaryCustomer(String phoneNumber) {
+        String nickname = phoneNumber.substring(phoneNumber.length() - 4);
+        TemporaryCustomer temporaryCustomer = new TemporaryCustomer(nickname, phoneNumber);
+
+        TemporaryCustomer savedTemporaryCustomer = customerRepository.save(temporaryCustomer);
+
+        return savedTemporaryCustomer.getId();
     }
 }

--- a/backend/src/main/java/com/stampcrush/backend/service/CustomersResponse.java
+++ b/backend/src/main/java/com/stampcrush/backend/service/CustomersResponse.java
@@ -1,0 +1,17 @@
+package com.stampcrush.backend.service;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+import static lombok.AccessLevel.PRIVATE;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = PRIVATE)
+public class CustomersResponse {
+
+    private List<CustomerResponse> customer;
+}

--- a/backend/src/main/java/com/stampcrush/backend/service/TemporaryCustomerRequest.java
+++ b/backend/src/main/java/com/stampcrush/backend/service/TemporaryCustomerRequest.java
@@ -1,0 +1,15 @@
+package com.stampcrush.backend.service;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class TemporaryCustomerRequest {
+
+    @NotNull
+    private String phoneNumber;
+}

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/CustomerIntegrationTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/CustomerIntegrationTest.java
@@ -1,0 +1,83 @@
+package com.stampcrush.backend.acceptance;
+
+import com.stampcrush.backend.entity.user.Customer;
+import com.stampcrush.backend.entity.user.RegisterCustomer;
+import com.stampcrush.backend.entity.user.TemporaryCustomer;
+import com.stampcrush.backend.repository.user.CustomerRepository;
+import com.stampcrush.backend.service.CustomerResponse;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CustomerIntegrationTest extends IntegrationTest {
+
+    @Autowired
+    private CustomerRepository customerRepository;
+
+    @Test
+    void 전화번호로_가입_고객을_조회한다() {
+        // given
+        Customer customer = new RegisterCustomer("제나", "01012345678", "jena", "1234");
+        customerRepository.save(customer);
+//        Customer customer2 = new RegisterCustomer("제나2", "01012345678", "jena2", "12234");
+//        customerRepository.save(customer2);
+
+        // when
+        ExtractableResponse<Response> response = requestFindCustomerByPhoneNumber("01012345678");
+        List<CustomerResponse> customers = response.jsonPath().getList(".", CustomerResponse.class);
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+        assertThat(customers).containsExactly(CustomerResponse.from(customer));
+
+        customerRepository.deleteAll();
+    }
+
+    @Test
+    void 전화번호로_임시_고객을_조회한다() {
+        // given
+        Customer customer = new TemporaryCustomer("제나임시", "01012345678");
+        customerRepository.save(customer);
+
+        // when
+        ExtractableResponse<Response> response = requestFindCustomerByPhoneNumber("01012345678");
+        List<CustomerResponse> customers = response.jsonPath().getList(".", CustomerResponse.class);
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+        assertThat(customers).containsExactly(CustomerResponse.from(customer));
+
+        customerRepository.deleteAll();
+    }
+
+    @Test
+    void 고객이_존재하지_않는_경우_빈_배열을_반환한다() {
+        // given, when
+        ExtractableResponse<Response> response = requestFindCustomerByPhoneNumber("01012345678");
+        List<CustomerResponse> customers = response.jsonPath().getList(".", CustomerResponse.class);
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+        assertThat(customers.size()).isEqualTo(0);
+
+        customerRepository.deleteAll();
+    }
+
+    private ExtractableResponse<Response> requestFindCustomerByPhoneNumber(String phoneNumber) {
+        return given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .param("phone-number", phoneNumber)
+                .when()
+                .get("/customers")
+                .then()
+                .log().all()
+                .extract();
+    }
+}

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/CustomerIntegrationTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/CustomerIntegrationTest.java
@@ -5,6 +5,7 @@ import com.stampcrush.backend.entity.user.RegisterCustomer;
 import com.stampcrush.backend.entity.user.TemporaryCustomer;
 import com.stampcrush.backend.repository.user.CustomerRepository;
 import com.stampcrush.backend.service.CustomerResponse;
+import com.stampcrush.backend.service.CustomersResponse;
 import com.stampcrush.backend.service.TemporaryCustomerRequest;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
@@ -12,9 +13,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-
-import java.util.List;
-import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -33,11 +31,11 @@ public class CustomerIntegrationTest extends IntegrationTest {
 
         // when
         ExtractableResponse<Response> response = requestFindCustomerByPhoneNumber("01012345678");
-        List<CustomerResponse> customers = response.jsonPath().getList(".", CustomerResponse.class);
+        CustomersResponse customers = response.body().as(CustomersResponse.class);
 
         // then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
-        assertThat(customers).containsExactly(CustomerResponse.from(customer));
+        assertThat(customers.getCustomer()).containsExactly(CustomerResponse.from(customer));
 
         customerRepository.deleteAll();
     }
@@ -50,11 +48,11 @@ public class CustomerIntegrationTest extends IntegrationTest {
 
         // when
         ExtractableResponse<Response> response = requestFindCustomerByPhoneNumber("01012345678");
-        List<CustomerResponse> customers = response.jsonPath().getList(".", CustomerResponse.class);
+        CustomersResponse customers = response.body().as(CustomersResponse.class);
 
         // then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
-        assertThat(customers).containsExactly(CustomerResponse.from(customer));
+        assertThat(customers.getCustomer()).containsExactly(CustomerResponse.from(customer));
 
         customerRepository.deleteAll();
     }
@@ -63,11 +61,11 @@ public class CustomerIntegrationTest extends IntegrationTest {
     void 고객이_존재하지_않는_경우_빈_배열을_반환한다() {
         // given, when
         ExtractableResponse<Response> response = requestFindCustomerByPhoneNumber("01012345678");
-        List<CustomerResponse> customers = response.jsonPath().getList(".", CustomerResponse.class);
+        CustomersResponse customers = response.body().as(CustomersResponse.class);
 
         // then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
-        assertThat(customers.size()).isEqualTo(0);
+        assertThat(customers.getCustomer().size()).isEqualTo(0);
 
         customerRepository.deleteAll();
     }

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/IntegrationTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/IntegrationTest.java
@@ -1,0 +1,27 @@
+package com.stampcrush.backend.acceptance;
+
+import io.restassured.RestAssured;
+import io.restassured.specification.RequestSpecification;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(ReplaceUnderscores.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class IntegrationTest {
+
+    @LocalServerPort
+    private int port;
+
+    public static RequestSpecification given() {
+        return RestAssured.given().log().all();
+    }
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
+}


### PR DESCRIPTION
## 주요 변경사항

- 전화번호로 고객을 조회하는 API 를 작성했습니다
- 임시 고객을 생성하는 API 를 구현했습니다


## 리뷰어에게...

### 전화번호로 고객을 조회하는 API 관련

```javascript
{
	"customer": [
		{
			"id": 1,
			"nickname": "윤생1234",
			"phoneNumber": "01023456778"
		}
	]
}
```

가 명세이나 

```javascript
[
       {
		"id": 1,
		"nickname": "윤생1234",
		"phoneNumber": "01023456778"
	}
]
```

형식으로 반환하게 바꾸면 어떨까요?? (key 값을 customer 라고 이름을 붙여주려면 Response 의 필드에 List\<CustomerResponse\> 가 들어가는 Response 를 하나 더 구현해야 해서 불필요하다고 느껴졌습니다)

- 코드를 작성하다보니 전화번호에 맞는 Customer 가 있으면 해당 Customer만 보내주고 없으면 인증이 안되었다고 봐도 될 것 같아CustomerNotFoundException 인 에러를 던지는 편이 낫지 않을지 의견을 제시합니다
(현재 주석처리 해둔 코드의 반환타입을 CustomerResponse 로 하고, Customer 를 못찾았을때 해당 커스텀 예외를 던지는 방향)
- Header의 Authorization 부분에 Owner 의 인증 정보가 들어오고 Owner 가 아니면 고객 조회를 못하는 것을 추가로 구현해야 합니다

### 임시 고객 생성 API 관련
- controller -> service 로 리퀘스트를 넘길 때 따로 Dto 를 사용하지 않고 그냥 String 으로 핸드폰 번호를 보냈습니다. 우리 서비스는 핸드폰 번호만 있어도 임시 가입이 되는 서비스이니 Service 의 해당 메서드는 매개변수로 핸드폰 번호만 필요할 것이고, 다른 컨트롤러가 해당 메서드를 사용할때도 핸드폰번호만 보내주면 될 거 같아 굳이 Dto 로 감싸줄 필요가 있을까 싶었습니다! 

### 공통
- 인수 테스트 작성 시 테스트 격리가 어려워서 우선 deleteAll() 메서드를 사용했습니다
- Response, Request 객체의 패키지 위치를 통일해야합니다! 저는 기존에는 dto 패키지에 다 몰아넣었었습니다..

## 관련 이슈

closes #79, #80

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [x] `milestone` 설정
