### PR TITLE
[BE] feat: 카페의 고객 목록 조회, 현재 스탬프 쌓고 있는 쿠폰 정보 조회 구현

### DIFF
--- a/backend/src/main/java/com/stampcrush/backend/api/CouponController.java
+++ b/backend/src/main/java/com/stampcrush/backend/api/CouponController.java
@@ -2,11 +2,15 @@ package com.stampcrush.backend.api;
 
 import com.stampcrush.backend.application.coupon.CouponService;
 import com.stampcrush.backend.application.coupon.dto.CafeCustomersResponseDto;
+import com.stampcrush.backend.application.coupon.dto.CustomerUsingCouponResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RequiredArgsConstructor
 @RestController
@@ -17,5 +21,10 @@ public class CouponController {
     @GetMapping("/cafes/{cafeId}/customers")
     public ResponseEntity<CafeCustomersResponseDto> readCustomersByCafe(@PathVariable Long cafeId) {
         return ResponseEntity.ok(couponService.findCouponsByCafe(cafeId));
+    }
+
+    @GetMapping("/customers/{customerId}/coupons")
+    public ResponseEntity<List<CustomerUsingCouponResponseDto>> readCustomerUsingCouponByCafe(@PathVariable Long customerId, @RequestParam Long cafeId, @RequestParam boolean active) {
+        return ResponseEntity.ok(couponService.findUsingCoupon(cafeId, customerId));
     }
 }

--- a/backend/src/main/java/com/stampcrush/backend/api/CouponController.java
+++ b/backend/src/main/java/com/stampcrush/backend/api/CouponController.java
@@ -1,0 +1,21 @@
+package com.stampcrush.backend.api;
+
+import com.stampcrush.backend.application.coupon.CouponService;
+import com.stampcrush.backend.application.coupon.dto.CafeCustomersResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+public class CouponController {
+
+    private final CouponService couponService;
+
+    @GetMapping("/cafes/{cafeId}/customers")
+    public ResponseEntity<CafeCustomersResponseDto> readCustomersByCafe(@PathVariable Long cafeId) {
+        return ResponseEntity.ok(couponService.findCouponsByCafe(cafeId));
+    }
+}

--- a/backend/src/main/java/com/stampcrush/backend/application/coupon/CouponService.java
+++ b/backend/src/main/java/com/stampcrush/backend/application/coupon/CouponService.java
@@ -70,7 +70,8 @@ public class CouponService {
         customers.add(new CafeCustomerInfoResponseDto(
                 customer.getId(),
                 customer.getNickname(),
-                stampCount, rewardCount,
+                stampCount,
+                rewardCount,
                 visitCount,
                 firstVisitDate,
                 customer.isRegistered()

--- a/backend/src/main/java/com/stampcrush/backend/application/coupon/CouponService.java
+++ b/backend/src/main/java/com/stampcrush/backend/application/coupon/CouponService.java
@@ -1,0 +1,71 @@
+package com.stampcrush.backend.application.coupon;
+
+import com.stampcrush.backend.application.coupon.dto.CafeCustomerInfoResponseDto;
+import com.stampcrush.backend.application.coupon.dto.CafeCustomersResponseDto;
+import com.stampcrush.backend.entity.cafe.Cafe;
+import com.stampcrush.backend.entity.coupon.Coupon;
+import com.stampcrush.backend.entity.user.Customer;
+import com.stampcrush.backend.repository.cafe.CafeRepository;
+import com.stampcrush.backend.repository.coupon.CouponRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class CouponService {
+
+    private final CouponRepository couponRepository;
+    private final CafeRepository cafeRepository;
+
+    public CafeCustomersResponseDto findCouponsByCafe(Long cafeId) {
+        Cafe cafe = cafeRepository.findById(cafeId).orElseThrow(() -> new NoSuchElementException("존재하지 않는 카페 입니다."));
+
+        Map<Customer, List<Coupon>> couponsByCustomer = getCouponsByCustomer(cafe);
+        List<CafeCustomerInfoResponseDto> customers = new ArrayList<>();
+        for (Customer customer : couponsByCustomer.keySet()) {
+            List<Coupon> coupons = couponsByCustomer.get(customer);
+            int stampCount = 0;
+            int rewardCount = 0;
+            int visitCount = 0;
+            LocalDateTime firstVisitDate = LocalDateTime.MAX;
+            for (Coupon coupon : coupons) {
+                if (coupon.isUsing()) {
+                    stampCount = coupon.getStampCount();
+                }
+                if (coupon.isRewarded()) {
+                    rewardCount++;
+                }
+                visitCount += coupon.calculateVisitCount();
+                firstVisitDate = coupon.compareVisitTime(firstVisitDate);
+            }
+            addCustomerInfo(customers, customer, stampCount, rewardCount, visitCount, firstVisitDate);
+        }
+        return new CafeCustomersResponseDto(customers);
+    }
+
+    private Map<Customer, List<Coupon>> getCouponsByCustomer(Cafe cafe) {
+        List<Coupon> coupons = couponRepository.findByCafe(cafe);
+        return coupons.stream()
+                .collect(Collectors.groupingBy(Coupon::getCustomer));
+    }
+
+    private static void addCustomerInfo(List<CafeCustomerInfoResponseDto> customers, Customer customer, int stampCount, int rewardCount, int visitCount, LocalDateTime firstVisitDate) {
+        customers.add(new CafeCustomerInfoResponseDto(
+                customer.getId(),
+                customer.getNickname(),
+                stampCount, rewardCount,
+                visitCount,
+                firstVisitDate,
+                customer.isRegistered()
+        ));
+    }
+}

--- a/backend/src/main/java/com/stampcrush/backend/application/coupon/CouponService.java
+++ b/backend/src/main/java/com/stampcrush/backend/application/coupon/CouponService.java
@@ -2,11 +2,14 @@ package com.stampcrush.backend.application.coupon;
 
 import com.stampcrush.backend.application.coupon.dto.CafeCustomerInfoResponseDto;
 import com.stampcrush.backend.application.coupon.dto.CafeCustomersResponseDto;
+import com.stampcrush.backend.application.coupon.dto.CustomerUsingCouponResponseDto;
 import com.stampcrush.backend.entity.cafe.Cafe;
 import com.stampcrush.backend.entity.coupon.Coupon;
+import com.stampcrush.backend.entity.coupon.CouponStatus;
 import com.stampcrush.backend.entity.user.Customer;
 import com.stampcrush.backend.repository.cafe.CafeRepository;
 import com.stampcrush.backend.repository.coupon.CouponRepository;
+import com.stampcrush.backend.repository.user.CustomerRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -25,6 +28,7 @@ public class CouponService {
 
     private final CouponRepository couponRepository;
     private final CafeRepository cafeRepository;
+    private final CustomerRepository customerRepository;
 
     public CafeCustomersResponseDto findCouponsByCafe(Long cafeId) {
         Cafe cafe = cafeRepository.findById(cafeId).orElseThrow(() -> new NoSuchElementException("존재하지 않는 카페 입니다."));
@@ -38,13 +42,17 @@ public class CouponService {
             int visitCount = 0;
             LocalDateTime firstVisitDate = LocalDateTime.MAX;
             for (Coupon coupon : coupons) {
+                // USING상태의 쿠폰이라면 스탬프 개수 적용
                 if (coupon.isUsing()) {
                     stampCount = coupon.getStampCount();
                 }
+                // REWARD상태의 쿠폰이라면 rewardCount증가
                 if (coupon.isRewarded()) {
                     rewardCount++;
                 }
+                // Coupon에 찍힌 stamp들의 createdAt을 set에 add한 뒤, set.size()를 통해 방문횟수 계산
                 visitCount += coupon.calculateVisitCount();
+                // 첫 방문 일자는 coupon들의 createdAt을 계산해 가장 빠른 날짜로 갱신
                 firstVisitDate = coupon.compareVisitTime(firstVisitDate);
             }
             addCustomerInfo(customers, customer, stampCount, rewardCount, visitCount, firstVisitDate);
@@ -67,5 +75,22 @@ public class CouponService {
                 firstVisitDate,
                 customer.isRegistered()
         ));
+    }
+
+    public List<CustomerUsingCouponResponseDto> findUsingCoupon(Long cafeId, Long customerId) {
+        Cafe cafe = cafeRepository.findById(cafeId).orElseThrow(() -> new NoSuchElementException("존재하지 않는 카페 입니다."));
+        Customer customer = customerRepository.findById(customerId).orElseThrow(() -> new NoSuchElementException("존재하지 않는 고객 입니다."));
+
+        List<Coupon> coupons = couponRepository.findByCafeAndCustomerAndStatus(cafe, customer, CouponStatus.USING);
+        return coupons.stream()
+                .map(coupon -> new CustomerUsingCouponResponseDto(
+                        coupon.getId(),
+                        customerId,
+                        customer.getNickname(),
+                        coupon.getStampCount(),
+                        coupon.calculateExpireDate(),
+                        false
+                ))
+                .collect(Collectors.toList());
     }
 }

--- a/backend/src/main/java/com/stampcrush/backend/application/coupon/dto/CafeCustomerInfoResponseDto.java
+++ b/backend/src/main/java/com/stampcrush/backend/application/coupon/dto/CafeCustomerInfoResponseDto.java
@@ -1,12 +1,13 @@
 package com.stampcrush.backend.application.coupon.dto;
 
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 
 import java.time.LocalDateTime;
-import java.util.Objects;
 
 @ToString
+@EqualsAndHashCode
 @Getter
 public class CafeCustomerInfoResponseDto {
 
@@ -33,18 +34,5 @@ public class CafeCustomerInfoResponseDto {
         this.visitCount = visitCount;
         this.firstVisitDate = firstVisitDate;
         this.isRegistered = isRegistered;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        CafeCustomerInfoResponseDto that = (CafeCustomerInfoResponseDto) o;
-        return stampCount == that.stampCount && rewardCount == that.rewardCount && visitCount == that.visitCount && isRegistered == that.isRegistered && Objects.equals(id, that.id) && Objects.equals(nickname, that.nickname) && Objects.equals(firstVisitDate, that.firstVisitDate);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(id, nickname, stampCount, rewardCount, visitCount, firstVisitDate, isRegistered);
     }
 }

--- a/backend/src/main/java/com/stampcrush/backend/application/coupon/dto/CafeCustomerInfoResponseDto.java
+++ b/backend/src/main/java/com/stampcrush/backend/application/coupon/dto/CafeCustomerInfoResponseDto.java
@@ -1,0 +1,53 @@
+package com.stampcrush.backend.application.coupon.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Getter;
+import lombok.ToString;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+@ToString
+@Getter
+public class CafeCustomerInfoResponseDto {
+
+    private final Long id;
+    private final String nickname;
+    private final int stampCount;
+    private final int rewardCount;
+    private final int visitCount;
+
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    private final LocalDateTime firstVisitDate;
+
+    private final boolean isRegistered;
+
+    public CafeCustomerInfoResponseDto(Long id,
+                                       String nickname,
+                                       int stampCount,
+                                       int rewardCount,
+                                       int visitCount,
+                                       LocalDateTime firstVisitDate,
+                                       boolean isRegistered) {
+        this.id = id;
+        this.nickname = nickname;
+        this.stampCount = stampCount;
+        this.rewardCount = rewardCount;
+        this.visitCount = visitCount;
+        this.firstVisitDate = firstVisitDate;
+        this.isRegistered = isRegistered;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CafeCustomerInfoResponseDto that = (CafeCustomerInfoResponseDto) o;
+        return stampCount == that.stampCount && rewardCount == that.rewardCount && visitCount == that.visitCount && isRegistered == that.isRegistered && Objects.equals(id, that.id) && Objects.equals(nickname, that.nickname) && Objects.equals(firstVisitDate, that.firstVisitDate);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, nickname, stampCount, rewardCount, visitCount, firstVisitDate, isRegistered);
+    }
+}

--- a/backend/src/main/java/com/stampcrush/backend/application/coupon/dto/CafeCustomerInfoResponseDto.java
+++ b/backend/src/main/java/com/stampcrush/backend/application/coupon/dto/CafeCustomerInfoResponseDto.java
@@ -1,6 +1,5 @@
 package com.stampcrush.backend.application.coupon.dto;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Getter;
 import lombok.ToString;
 
@@ -16,8 +15,6 @@ public class CafeCustomerInfoResponseDto {
     private final int stampCount;
     private final int rewardCount;
     private final int visitCount;
-
-    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private final LocalDateTime firstVisitDate;
 
     private final boolean isRegistered;

--- a/backend/src/main/java/com/stampcrush/backend/application/coupon/dto/CafeCustomersResponseDto.java
+++ b/backend/src/main/java/com/stampcrush/backend/application/coupon/dto/CafeCustomersResponseDto.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 @Getter
 public class CafeCustomersResponseDto {
+
     private final List<CafeCustomerInfoResponseDto> customers;
 
     public CafeCustomersResponseDto(List<CafeCustomerInfoResponseDto> customers) {

--- a/backend/src/main/java/com/stampcrush/backend/application/coupon/dto/CafeCustomersResponseDto.java
+++ b/backend/src/main/java/com/stampcrush/backend/application/coupon/dto/CafeCustomersResponseDto.java
@@ -1,0 +1,14 @@
+package com.stampcrush.backend.application.coupon.dto;
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class CafeCustomersResponseDto {
+    private final List<CafeCustomerInfoResponseDto> customers;
+
+    public CafeCustomersResponseDto(List<CafeCustomerInfoResponseDto> customers) {
+        this.customers = customers;
+    }
+}

--- a/backend/src/main/java/com/stampcrush/backend/application/coupon/dto/CustomerUsingCouponResponseDto.java
+++ b/backend/src/main/java/com/stampcrush/backend/application/coupon/dto/CustomerUsingCouponResponseDto.java
@@ -1,11 +1,12 @@
 package com.stampcrush.backend.application.coupon.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
-import java.util.Objects;
 
+@EqualsAndHashCode
 @Getter
 public class CustomerUsingCouponResponseDto {
 
@@ -13,7 +14,7 @@ public class CustomerUsingCouponResponseDto {
     private final Long customerId;
     private final String nickname;
     private final int stampCount;
-    
+
     @JsonFormat(pattern = "yyyy:MM:dd")
     private final LocalDateTime expireDate;
     private final boolean isPrevious;
@@ -31,18 +32,5 @@ public class CustomerUsingCouponResponseDto {
         this.stampCount = stampCount;
         this.expireDate = expireDate;
         this.isPrevious = isPrevious;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        CustomerUsingCouponResponseDto that = (CustomerUsingCouponResponseDto) o;
-        return getStampCount() == that.getStampCount() && isPrevious() == that.isPrevious() && Objects.equals(getId(), that.getId()) && Objects.equals(getCustomerId(), that.getCustomerId()) && Objects.equals(getNickname(), that.getNickname()) && Objects.equals(getExpireDate(), that.getExpireDate());
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(getId(), getCustomerId(), getNickname(), getStampCount(), getExpireDate(), isPrevious());
     }
 }

--- a/backend/src/main/java/com/stampcrush/backend/application/coupon/dto/CustomerUsingCouponResponseDto.java
+++ b/backend/src/main/java/com/stampcrush/backend/application/coupon/dto/CustomerUsingCouponResponseDto.java
@@ -1,0 +1,47 @@
+package com.stampcrush.backend.application.coupon.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+@Getter
+public class CustomerUsingCouponResponseDto {
+
+    private final Long id;
+    private final Long customerId;
+    private final String nickname;
+    private final int stampCount;
+    @JsonFormat(pattern = "yyyy:MM:dd")
+    private final LocalDateTime expireDate;
+    private final boolean isPrevious;
+
+    public CustomerUsingCouponResponseDto(Long id,
+                                          Long customerId,
+                                          String nickname,
+                                          int stampCount,
+                                          LocalDateTime expireDate,
+                                          boolean isPrevious
+    ) {
+        this.id = id;
+        this.customerId = customerId;
+        this.nickname = nickname;
+        this.stampCount = stampCount;
+        this.expireDate = expireDate;
+        this.isPrevious = isPrevious;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CustomerUsingCouponResponseDto that = (CustomerUsingCouponResponseDto) o;
+        return getStampCount() == that.getStampCount() && isPrevious() == that.isPrevious() && Objects.equals(getId(), that.getId()) && Objects.equals(getCustomerId(), that.getCustomerId()) && Objects.equals(getNickname(), that.getNickname()) && Objects.equals(getExpireDate(), that.getExpireDate());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getId(), getCustomerId(), getNickname(), getStampCount(), getExpireDate(), isPrevious());
+    }
+}

--- a/backend/src/main/java/com/stampcrush/backend/application/coupon/dto/CustomerUsingCouponResponseDto.java
+++ b/backend/src/main/java/com/stampcrush/backend/application/coupon/dto/CustomerUsingCouponResponseDto.java
@@ -1,6 +1,8 @@
 package com.stampcrush.backend.application.coupon.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.stampcrush.backend.entity.coupon.Coupon;
+import com.stampcrush.backend.entity.user.Customer;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
@@ -19,12 +21,13 @@ public class CustomerUsingCouponResponseDto {
     private final LocalDateTime expireDate;
     private final boolean isPrevious;
 
-    public CustomerUsingCouponResponseDto(Long id,
-                                          Long customerId,
-                                          String nickname,
-                                          int stampCount,
-                                          LocalDateTime expireDate,
-                                          boolean isPrevious
+    public CustomerUsingCouponResponseDto(
+            Long id,
+            Long customerId,
+            String nickname,
+            int stampCount,
+            LocalDateTime expireDate,
+            boolean isPrevious
     ) {
         this.id = id;
         this.customerId = customerId;
@@ -32,5 +35,15 @@ public class CustomerUsingCouponResponseDto {
         this.stampCount = stampCount;
         this.expireDate = expireDate;
         this.isPrevious = isPrevious;
+    }
+
+    public static CustomerUsingCouponResponseDto of(Coupon coupon, Customer customer, boolean isPrevious) {
+        return new CustomerUsingCouponResponseDto(
+                coupon.getId(),
+                customer.getId(),
+                customer.getNickname(),
+                coupon.getStampCount(),
+                coupon.calculateExpireDate(),
+                isPrevious);
     }
 }

--- a/backend/src/main/java/com/stampcrush/backend/application/coupon/dto/CustomerUsingCouponResponseDto.java
+++ b/backend/src/main/java/com/stampcrush/backend/application/coupon/dto/CustomerUsingCouponResponseDto.java
@@ -13,6 +13,7 @@ public class CustomerUsingCouponResponseDto {
     private final Long customerId;
     private final String nickname;
     private final int stampCount;
+    
     @JsonFormat(pattern = "yyyy:MM:dd")
     private final LocalDateTime expireDate;
     private final boolean isPrevious;

--- a/backend/src/main/java/com/stampcrush/backend/entity/coupon/Coupon.java
+++ b/backend/src/main/java/com/stampcrush/backend/entity/coupon/Coupon.java
@@ -7,8 +7,10 @@ import jakarta.persistence.*;
 import lombok.Getter;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static jakarta.persistence.FetchType.EAGER;
 import static jakarta.persistence.FetchType.LAZY;
@@ -52,5 +54,35 @@ public class Coupon extends BaseDate {
     }
 
     protected Coupon() {
+    }
+
+    public void reward() {
+        this.status = CouponStatus.REWARDED;
+    }
+
+    public boolean isUsing() {
+        return this.status == CouponStatus.USING;
+    }
+
+    public boolean isRewarded() {
+        return this.status == CouponStatus.REWARDED;
+    }
+
+    public int getStampCount() {
+        return stamps.size();
+    }
+
+    public int calculateVisitCount() {
+        return stamps.stream()
+                .map(BaseDate::getCreatedAt)
+                .collect(Collectors.toSet())
+                .size();
+    }
+
+    public LocalDateTime compareVisitTime(LocalDateTime visitTime) {
+        if (this.getCreatedAt().isBefore(visitTime)) {
+            return this.getCreatedAt();
+        }
+        return visitTime;
     }
 }

--- a/backend/src/main/java/com/stampcrush/backend/entity/coupon/Coupon.java
+++ b/backend/src/main/java/com/stampcrush/backend/entity/coupon/Coupon.java
@@ -43,14 +43,19 @@ public class Coupon extends BaseDate {
     @JoinColumn(name = "coupon_design_id")
     private CouponDesign couponDesign;
 
+    @OneToOne(fetch = LAZY)
+    @JoinColumn(name = "coupon_policy_id")
+    private CouponPolicy couponPolicy;
+
     @OneToMany(mappedBy = "coupon", cascade = CascadeType.ALL, fetch = EAGER)
     private List<Stamp> stamps = new ArrayList<>();
 
-    public Coupon(LocalDate expiredDate, Customer customer, Cafe cafe, CouponDesign couponDesign) {
+    public Coupon(LocalDate expiredDate, Customer customer, Cafe cafe, CouponDesign couponDesign, CouponPolicy couponPolicy) {
         this.expiredDate = expiredDate;
         this.customer = customer;
         this.cafe = cafe;
         this.couponDesign = couponDesign;
+        this.couponPolicy = couponPolicy;
     }
 
     protected Coupon() {
@@ -84,5 +89,9 @@ public class Coupon extends BaseDate {
             return this.getCreatedAt();
         }
         return visitTime;
+    }
+
+    public LocalDateTime calculateExpireDate() {
+        return this.getCreatedAt().plusMonths(this.couponPolicy.getExpiredPeriod());
     }
 }

--- a/backend/src/main/java/com/stampcrush/backend/entity/coupon/Coupon.java
+++ b/backend/src/main/java/com/stampcrush/backend/entity/coupon/Coupon.java
@@ -12,7 +12,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static jakarta.persistence.FetchType.EAGER;
 import static jakarta.persistence.FetchType.LAZY;
 import static jakarta.persistence.GenerationType.IDENTITY;
 
@@ -47,7 +46,7 @@ public class Coupon extends BaseDate {
     @JoinColumn(name = "coupon_policy_id")
     private CouponPolicy couponPolicy;
 
-    @OneToMany(mappedBy = "coupon", cascade = CascadeType.ALL, fetch = EAGER)
+    @OneToMany(mappedBy = "coupon", cascade = CascadeType.ALL, fetch = LAZY)
     private List<Stamp> stamps = new ArrayList<>();
 
     public Coupon(LocalDate expiredDate, Customer customer, Cafe cafe, CouponDesign couponDesign, CouponPolicy couponPolicy) {

--- a/backend/src/main/java/com/stampcrush/backend/entity/coupon/Coupon.java
+++ b/backend/src/main/java/com/stampcrush/backend/entity/coupon/Coupon.java
@@ -1,13 +1,16 @@
 package com.stampcrush.backend.entity.coupon;
 
-import com.stampcrush.backend.entity.user.Customer;
 import com.stampcrush.backend.entity.baseentity.BaseDate;
 import com.stampcrush.backend.entity.cafe.Cafe;
+import com.stampcrush.backend.entity.user.Customer;
 import jakarta.persistence.*;
 import lombok.Getter;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 
+import static jakarta.persistence.FetchType.EAGER;
 import static jakarta.persistence.FetchType.LAZY;
 import static jakarta.persistence.GenerationType.IDENTITY;
 
@@ -22,9 +25,9 @@ public class Coupon extends BaseDate {
     private LocalDate expiredDate;
 
     @Enumerated(EnumType.STRING)
-    private CouponStatus status;
+    private CouponStatus status = CouponStatus.USING;
 
-    private Boolean deleted;
+    private Boolean deleted = Boolean.TRUE;
 
     @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "customer_id")
@@ -37,4 +40,17 @@ public class Coupon extends BaseDate {
     @OneToOne(fetch = LAZY)
     @JoinColumn(name = "coupon_design_id")
     private CouponDesign couponDesign;
+
+    @OneToMany(mappedBy = "coupon", cascade = CascadeType.ALL, fetch = EAGER)
+    private List<Stamp> stamps = new ArrayList<>();
+
+    public Coupon(LocalDate expiredDate, Customer customer, Cafe cafe, CouponDesign couponDesign) {
+        this.expiredDate = expiredDate;
+        this.customer = customer;
+        this.cafe = cafe;
+        this.couponDesign = couponDesign;
+    }
+
+    protected Coupon() {
+    }
 }

--- a/backend/src/main/java/com/stampcrush/backend/entity/coupon/CouponPolicy.java
+++ b/backend/src/main/java/com/stampcrush/backend/entity/coupon/CouponPolicy.java
@@ -21,4 +21,13 @@ public class CouponPolicy extends BaseDate {
     private String rewardName;
 
     private Integer expiredPeriod;
+
+    public CouponPolicy(Integer maxStampCount, String rewardName, Integer expiredPeriod) {
+        this.maxStampCount = maxStampCount;
+        this.rewardName = rewardName;
+        this.expiredPeriod = expiredPeriod;
+    }
+
+    protected CouponPolicy() {
+    }
 }

--- a/backend/src/main/java/com/stampcrush/backend/entity/coupon/Stamp.java
+++ b/backend/src/main/java/com/stampcrush/backend/entity/coupon/Stamp.java
@@ -1,7 +1,6 @@
 package com.stampcrush.backend.entity.coupon;
 
 import com.stampcrush.backend.entity.baseentity.BaseDate;
-import com.stampcrush.backend.entity.coupon.Coupon;
 import jakarta.persistence.*;
 import lombok.Getter;
 
@@ -19,4 +18,9 @@ public class Stamp extends BaseDate {
     @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "coupon_id")
     private Coupon coupon;
+
+    public void registerCoupon(Coupon coupon) {
+        this.coupon = coupon;
+        coupon.getStamps().add(this);
+    }
 }

--- a/backend/src/main/java/com/stampcrush/backend/entity/user/Customer.java
+++ b/backend/src/main/java/com/stampcrush/backend/entity/user/Customer.java
@@ -20,4 +20,6 @@ public abstract class Customer {
     private String nickname;
 
     private String phoneNumber;
+
+    public abstract boolean isRegistered();
 }

--- a/backend/src/main/java/com/stampcrush/backend/entity/user/RegisterCustomer.java
+++ b/backend/src/main/java/com/stampcrush/backend/entity/user/RegisterCustomer.java
@@ -11,5 +11,18 @@ public class RegisterCustomer extends Customer {
 
     private String loginId;
     private String encryptedPassword;
+
+    public RegisterCustomer(String loginId, String encryptedPassword) {
+        this.loginId = loginId;
+        this.encryptedPassword = encryptedPassword;
+    }
+
+    protected RegisterCustomer() {
+    }
+
+    @Override
+    public boolean isRegistered() {
+        return true;
+    }
 }
 

--- a/backend/src/main/java/com/stampcrush/backend/entity/user/TemporaryCustomer.java
+++ b/backend/src/main/java/com/stampcrush/backend/entity/user/TemporaryCustomer.java
@@ -1,10 +1,14 @@
 package com.stampcrush.backend.entity.user;
 
-import com.stampcrush.backend.entity.user.Customer;
 import jakarta.persistence.DiscriminatorValue;
 import jakarta.persistence.Entity;
 
 @DiscriminatorValue("temporary")
 @Entity
 public class TemporaryCustomer extends Customer {
+
+    @Override
+    public boolean isRegistered() {
+        return false;
+    }
 }

--- a/backend/src/main/java/com/stampcrush/backend/repository/coupon/CouponRepository.java
+++ b/backend/src/main/java/com/stampcrush/backend/repository/coupon/CouponRepository.java
@@ -1,7 +1,17 @@
 package com.stampcrush.backend.repository.coupon;
 
+import com.stampcrush.backend.entity.cafe.Cafe;
 import com.stampcrush.backend.entity.coupon.Coupon;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface CouponRepository extends JpaRepository<Coupon, Long> {
+
+    //    @Query("select cp from Coupon cp left join fetch cp.stamps join fetch cp.cafe join fetch cp.customer where cp.cafe = :cafe")
+//    @Query("select cp from Coupon cp join fetch cp.cafe join fetch cp.customer where cp.cafe = :cafe")
+    @Query("select distinct cp from Coupon cp left join fetch cp.stamps join fetch cp.cafe join fetch cp.customer where cp.cafe = :cafe")
+    List<Coupon> findByCafe(@Param("cafe") Cafe cafe);
 }

--- a/backend/src/main/java/com/stampcrush/backend/repository/coupon/CouponRepository.java
+++ b/backend/src/main/java/com/stampcrush/backend/repository/coupon/CouponRepository.java
@@ -2,6 +2,9 @@ package com.stampcrush.backend.repository.coupon;
 
 import com.stampcrush.backend.entity.cafe.Cafe;
 import com.stampcrush.backend.entity.coupon.Coupon;
+import com.stampcrush.backend.entity.coupon.CouponStatus;
+import com.stampcrush.backend.entity.user.Customer;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -10,8 +13,9 @@ import java.util.List;
 
 public interface CouponRepository extends JpaRepository<Coupon, Long> {
 
-    //    @Query("select cp from Coupon cp left join fetch cp.stamps join fetch cp.cafe join fetch cp.customer where cp.cafe = :cafe")
-//    @Query("select cp from Coupon cp join fetch cp.cafe join fetch cp.customer where cp.cafe = :cafe")
     @Query("select distinct cp from Coupon cp left join fetch cp.stamps join fetch cp.cafe join fetch cp.customer where cp.cafe = :cafe")
     List<Coupon> findByCafe(@Param("cafe") Cafe cafe);
+
+    @EntityGraph(attributePaths = {"couponPolicy"})
+    List<Coupon> findByCafeAndCustomerAndStatus(@Param("cafe") Cafe cafe, @Param("customer") Customer customer, @Param("status") CouponStatus status);
 }

--- a/backend/src/test/java/com/stampcrush/backend/application/coupon/CouponServiceTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/application/coupon/CouponServiceTest.java
@@ -1,0 +1,152 @@
+package com.stampcrush.backend.application.coupon;
+
+import com.stampcrush.backend.application.coupon.dto.CafeCustomerInfoResponseDto;
+import com.stampcrush.backend.application.coupon.dto.CafeCustomersResponseDto;
+import com.stampcrush.backend.entity.cafe.Cafe;
+import com.stampcrush.backend.entity.coupon.Coupon;
+import com.stampcrush.backend.entity.coupon.CouponDesign;
+import com.stampcrush.backend.entity.coupon.Stamp;
+import com.stampcrush.backend.entity.user.RegisterCustomer;
+import com.stampcrush.backend.entity.user.TemporaryCustomer;
+import com.stampcrush.backend.repository.cafe.CafeRepository;
+import com.stampcrush.backend.repository.coupon.CouponDesignRepository;
+import com.stampcrush.backend.repository.coupon.CouponRepository;
+import com.stampcrush.backend.repository.user.RegisterCustomerRepository;
+import com.stampcrush.backend.repository.user.TemporaryCustomersRepository;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.NoSuchElementException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SuppressWarnings("NonAsciiCharacters")
+@Transactional
+@SpringBootTest
+class CouponServiceTest {
+
+    @Autowired
+    private CouponService couponService;
+
+    @Autowired
+    private CouponRepository couponRepository;
+
+    @Autowired
+    private TemporaryCustomersRepository temporaryCustomersRepository;
+
+    @Autowired
+    private RegisterCustomerRepository registerCustomerRepository;
+
+    @Autowired
+    private CafeRepository cafeRepository;
+
+    @Autowired
+    private CouponDesignRepository couponDesignRepository;
+
+    @Autowired
+    private EntityManager em;
+
+    private TemporaryCustomer tmpCustomer1;
+    private TemporaryCustomer tmpCustomer2;
+    private TemporaryCustomer tmpCustomer3;
+
+    private RegisterCustomer registerCustomer1;
+    private RegisterCustomer registerCustomer2;
+
+    private Cafe cafe1;
+    private Cafe cafe2;
+
+    private CouponDesign couponDesign1;
+    private CouponDesign couponDesign2;
+    private CouponDesign couponDesign3;
+    private CouponDesign couponDesign4;
+    private CouponDesign couponDesign5;
+
+    @BeforeEach
+    void setUp() {
+        tmpCustomer1 = temporaryCustomersRepository.save(new TemporaryCustomer());
+        tmpCustomer2 = temporaryCustomersRepository.save(new TemporaryCustomer());
+        tmpCustomer3 = temporaryCustomersRepository.save(new TemporaryCustomer());
+
+        registerCustomer1 = registerCustomerRepository.save(new RegisterCustomer("id1", "pw1"));
+        registerCustomer2 = registerCustomerRepository.save(new RegisterCustomer("id2", "pw2"));
+
+        cafe1 = cafeRepository.save(new Cafe());
+        cafe2 = cafeRepository.save(new Cafe());
+
+        couponDesign1 = couponDesignRepository.save(new CouponDesign());
+        couponDesign2 = couponDesignRepository.save(new CouponDesign());
+        couponDesign3 = couponDesignRepository.save(new CouponDesign());
+        couponDesign4 = couponDesignRepository.save(new CouponDesign());
+        couponDesign5 = couponDesignRepository.save(new CouponDesign());
+    }
+
+    @Test
+    void 조회하려는_카페가_존재하지_않으면_예외발생() {
+        assertThatThrownBy(() -> couponService.findCouponsByCafe(100L))
+                .isInstanceOf(NoSuchElementException.class);
+    }
+
+    @Test
+    void 카페_별_고객들의_정보를_조회한다() {
+        // given
+        // coupon1, REWARD상태, cafe1 -> stamp0개, 임시유저
+        // coupon2, USING상태, cafe1 -> stamp1개
+        // coupon3, USING상태, cafe2 -> stamp1개
+        // coupon4, USING상태, cafe2 -> stamp0개
+        // coupon5, USING상태, cafe2 -> stamp0개
+        Coupon coupon1 = new Coupon(LocalDate.EPOCH, tmpCustomer1, cafe1, couponDesign1);
+        Stamp stamp1 = new Stamp();
+        Stamp stamp2 = new Stamp();
+        stamp1.registerCoupon(coupon1);
+        stamp2.registerCoupon(coupon1);
+        Coupon savedCoupon = couponRepository.save(coupon1);
+        savedCoupon.reward();
+
+        Coupon coupon2 = new Coupon(LocalDate.EPOCH, registerCustomer1, cafe1, couponDesign2);
+        Stamp stamp3 = new Stamp();
+        stamp3.registerCoupon(coupon2);
+        couponRepository.save(coupon2);
+
+        Coupon coupon3 = new Coupon(LocalDate.EPOCH, tmpCustomer2, cafe2, couponDesign3);
+        Stamp stamp4 = new Stamp();
+        stamp4.registerCoupon(coupon3);
+        couponRepository.save(coupon3);
+
+        Coupon coupon4 = new Coupon(LocalDate.EPOCH, tmpCustomer3, cafe2, couponDesign4);
+        couponRepository.save(coupon4);
+
+        Coupon coupon5 = new Coupon(LocalDate.EPOCH, registerCustomer2, cafe2, couponDesign5);
+        couponRepository.save(coupon5);
+
+        // when
+        CafeCustomersResponseDto customers = couponService.findCouponsByCafe(cafe1.getId());
+
+        CafeCustomerInfoResponseDto customer1Info = new CafeCustomerInfoResponseDto(
+                tmpCustomer1.getId(),
+                tmpCustomer1.getNickname(),
+                0,
+                1,
+                2,
+                coupon1.getCreatedAt(),
+                false
+        );
+
+        CafeCustomerInfoResponseDto customer2Info = new CafeCustomerInfoResponseDto(
+                registerCustomer1.getId(),
+                registerCustomer1.getNickname(),
+                1,
+                0,
+                1,
+                coupon2.getCreatedAt(),
+                true
+        );
+        assertThat(customers.getCustomers()).containsExactlyInAnyOrder(customer1Info, customer2Info);
+    }
+}

--- a/backend/src/test/java/com/stampcrush/backend/application/coupon/CouponServiceTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/application/coupon/CouponServiceTest.java
@@ -188,4 +188,30 @@ class CouponServiceTest {
                 false);
         assertThat(result).containsExactly(customerUsingCoupon);
     }
+
+    @Test
+    void 첫_방문일자를_계산한다() {
+        CouponDesign couponDesign6 = couponDesignRepository.save(new CouponDesign());
+        CouponPolicy couponPolicy6 = couponPolicyRepository.save(new CouponPolicy(10, "아메리카노", 10));
+
+        Coupon coupon6 = new Coupon(LocalDate.now(), tmpCustomer1, cafe1, couponDesign6, couponPolicy6);
+        Stamp stamp6 = new Stamp();
+
+        stamp6.registerCoupon(coupon6);
+        couponRepository.save(coupon6);
+
+        CafeCustomersResponseDto customersResponseDto = couponService.findCouponsByCafe(cafe1.getId());
+        // 첫 방문일자는 먼저 저장된 coupon1의 createdAt이어야 한다.
+        CafeCustomerInfoResponseDto expected = new CafeCustomerInfoResponseDto(
+                tmpCustomer1.getId(),
+                tmpCustomer1.getNickname(),
+                coupon6.getStampCount(),
+                1,
+                3,
+                coupon1.getCreatedAt(),
+                false
+        );
+
+        assertThat(customersResponseDto.getCustomers()).containsAnyOf(expected);
+    }
 }

--- a/backend/src/test/java/com/stampcrush/backend/entity/coupon/CouponTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/entity/coupon/CouponTest.java
@@ -14,7 +14,7 @@ class CouponTest {
 
     @Test
     void 쿠폰이_현재_USING_상태인지_확인한다() {
-        Coupon coupon = new Coupon(LocalDate.EPOCH, new TemporaryCustomer(), new Cafe(), new CouponDesign());
+        Coupon coupon = new Coupon(LocalDate.EPOCH, new TemporaryCustomer(), new Cafe(), new CouponDesign(), new CouponPolicy());
         assertAll(
                 () -> assertThat(coupon.isUsing()).isTrue(),
                 () -> assertThat(coupon.isRewarded()).isFalse()
@@ -23,7 +23,7 @@ class CouponTest {
 
     @Test
     void 쿠폰이_현재_REWARD_상태인지_확인한다() {
-        Coupon coupon = new Coupon(LocalDate.EPOCH, new TemporaryCustomer(), new Cafe(), new CouponDesign());
+        Coupon coupon = new Coupon(LocalDate.EPOCH, new TemporaryCustomer(), new Cafe(), new CouponDesign(), new CouponPolicy());
         coupon.reward();
         assertAll(
                 () -> assertThat(coupon.isUsing()).isFalse(),

--- a/backend/src/test/java/com/stampcrush/backend/entity/coupon/CouponTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/entity/coupon/CouponTest.java
@@ -9,6 +9,7 @@ import java.time.LocalDate;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+@SuppressWarnings("NonAsciiCharacters")
 class CouponTest {
 
     @Test

--- a/backend/src/test/java/com/stampcrush/backend/entity/coupon/CouponTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/entity/coupon/CouponTest.java
@@ -1,0 +1,32 @@
+package com.stampcrush.backend.entity.coupon;
+
+import com.stampcrush.backend.entity.cafe.Cafe;
+import com.stampcrush.backend.entity.user.TemporaryCustomer;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+class CouponTest {
+
+    @Test
+    void 쿠폰이_현재_USING_상태인지_확인한다() {
+        Coupon coupon = new Coupon(LocalDate.EPOCH, new TemporaryCustomer(), new Cafe(), new CouponDesign());
+        assertAll(
+                () -> assertThat(coupon.isUsing()).isTrue(),
+                () -> assertThat(coupon.isRewarded()).isFalse()
+        );
+    }
+
+    @Test
+    void 쿠폰이_현재_REWARD_상태인지_확인한다() {
+        Coupon coupon = new Coupon(LocalDate.EPOCH, new TemporaryCustomer(), new Cafe(), new CouponDesign());
+        coupon.reward();
+        assertAll(
+                () -> assertThat(coupon.isUsing()).isFalse(),
+                () -> assertThat(coupon.isRewarded()).isTrue()
+        );
+    }
+}

--- a/backend/src/test/java/com/stampcrush/backend/repository/coupon/CouponRepositoryTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/repository/coupon/CouponRepositoryTest.java
@@ -1,16 +1,12 @@
 package com.stampcrush.backend.repository.coupon;
 
 import com.stampcrush.backend.entity.cafe.Cafe;
-import com.stampcrush.backend.entity.coupon.Coupon;
-import com.stampcrush.backend.entity.coupon.CouponDesign;
-import com.stampcrush.backend.entity.coupon.CouponStatus;
-import com.stampcrush.backend.entity.coupon.Stamp;
+import com.stampcrush.backend.entity.coupon.*;
 import com.stampcrush.backend.entity.user.RegisterCustomer;
 import com.stampcrush.backend.entity.user.TemporaryCustomer;
 import com.stampcrush.backend.repository.cafe.CafeRepository;
 import com.stampcrush.backend.repository.user.RegisterCustomerRepository;
 import com.stampcrush.backend.repository.user.TemporaryCustomersRepository;
-import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -42,7 +38,7 @@ class CouponRepositoryTest {
     private CouponDesignRepository couponDesignRepository;
 
     @Autowired
-    private EntityManager em;
+    private CouponPolicyRepository couponPolicyRepository;
 
     private TemporaryCustomer tmpCustomer1;
     private TemporaryCustomer tmpCustomer2;
@@ -59,6 +55,12 @@ class CouponRepositoryTest {
     private CouponDesign couponDesign3;
     private CouponDesign couponDesign4;
     private CouponDesign couponDesign5;
+
+    private CouponPolicy couponPolicy1;
+    private CouponPolicy couponPolicy2;
+    private CouponPolicy couponPolicy3;
+    private CouponPolicy couponPolicy4;
+    private CouponPolicy couponPolicy5;
 
     // coupon1, REWARD상태, cafe1 -> stamp2개
     // coupon2, USING상태, cafe1 -> stamp1개
@@ -89,7 +91,13 @@ class CouponRepositoryTest {
         couponDesign4 = couponDesignRepository.save(new CouponDesign());
         couponDesign5 = couponDesignRepository.save(new CouponDesign());
 
-        coupon1 = new Coupon(LocalDate.EPOCH, tmpCustomer1, cafe1, couponDesign1);
+        couponPolicy1 = couponPolicyRepository.save(new CouponPolicy(10, "아메리카노", 8));
+        couponPolicy2 = couponPolicyRepository.save(new CouponPolicy(10, "아메리카노", 8));
+        couponPolicy3 = couponPolicyRepository.save(new CouponPolicy(10, "아메리카노", 8));
+        couponPolicy4 = couponPolicyRepository.save(new CouponPolicy(10, "아메리카노", 8));
+        couponPolicy5 = couponPolicyRepository.save(new CouponPolicy(10, "아메리카노", 8));
+
+        coupon1 = new Coupon(LocalDate.EPOCH, tmpCustomer1, cafe1, couponDesign1, couponPolicy1);
         Stamp stamp1 = new Stamp();
         Stamp stamp2 = new Stamp();
         stamp1.registerCoupon(coupon1);
@@ -97,20 +105,20 @@ class CouponRepositoryTest {
         Coupon save = couponRepository.save(coupon1);
         save.reward();
 
-        coupon2 = new Coupon(LocalDate.EPOCH, registerCustomer1, cafe1, couponDesign2);
+        coupon2 = new Coupon(LocalDate.EPOCH, registerCustomer1, cafe1, couponDesign2, couponPolicy2);
         Stamp stamp3 = new Stamp();
         stamp3.registerCoupon(coupon2);
         couponRepository.save(coupon2);
 
-        coupon3 = new Coupon(LocalDate.EPOCH, tmpCustomer2, cafe2, couponDesign3);
+        coupon3 = new Coupon(LocalDate.EPOCH, tmpCustomer2, cafe2, couponDesign3, couponPolicy3);
         Stamp stamp4 = new Stamp();
         stamp4.registerCoupon(coupon3);
         couponRepository.save(coupon3);
 
-        coupon4 = new Coupon(LocalDate.EPOCH, tmpCustomer3, cafe2, couponDesign4);
+        coupon4 = new Coupon(LocalDate.EPOCH, tmpCustomer3, cafe2, couponDesign4, couponPolicy4);
         couponRepository.save(coupon4);
 
-        coupon5 = new Coupon(LocalDate.EPOCH, registerCustomer2, cafe2, couponDesign5);
+        coupon5 = new Coupon(LocalDate.EPOCH, registerCustomer2, cafe2, couponDesign5, couponPolicy5);
         couponRepository.save(coupon5);
     }
 
@@ -142,7 +150,7 @@ class CouponRepositoryTest {
 
     @Test
     void 쿠폰O_카페에_스탬프를_적립하고_있는_고객의_쿠폰을_조회한다() {
-        
+
         List<Coupon> customerCoupon = couponRepository.findByCafeAndCustomerAndStatus(cafe2, tmpCustomer3, CouponStatus.USING);
         assertThat(customerCoupon).containsExactly(coupon4);
     }

--- a/backend/src/test/java/com/stampcrush/backend/repository/coupon/CouponRepositoryTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/repository/coupon/CouponRepositoryTest.java
@@ -13,6 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -143,15 +144,21 @@ class CouponRepositoryTest {
 
     @Test
     void 쿠폰X_카페에_스탬프를_적립하고_있는_고객의_쿠폰을_조회한다() {
-
         List<Coupon> customerCoupon = couponRepository.findByCafeAndCustomerAndStatus(cafe1, tmpCustomer1, CouponStatus.USING);
         assertThat(customerCoupon).isEmpty();
     }
 
     @Test
     void 쿠폰O_카페에_스탬프를_적립하고_있는_고객의_쿠폰을_조회한다() {
-
         List<Coupon> customerCoupon = couponRepository.findByCafeAndCustomerAndStatus(cafe2, tmpCustomer3, CouponStatus.USING);
         assertThat(customerCoupon).containsExactly(coupon4);
+    }
+
+    @Test
+    void 쿠폰의_유효기간_만료일을_계산한다() {
+        LocalDateTime expiredDate = coupon1.calculateExpireDate();
+        LocalDateTime expected = coupon1.getCreatedAt().plusMonths(couponPolicy1.getExpiredPeriod());
+
+        assertThat(expiredDate).isEqualTo(expected);
     }
 }

--- a/backend/src/test/java/com/stampcrush/backend/repository/coupon/CouponRepositoryTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/repository/coupon/CouponRepositoryTest.java
@@ -161,4 +161,11 @@ class CouponRepositoryTest {
 
         assertThat(expiredDate).isEqualTo(expected);
     }
+
+    // 첫 방문일자 구하기 위한 기능
+    @Test
+    void 쿠폰들의_createdAt을_비교한다() {
+        LocalDateTime visitTime = coupon1.compareVisitTime(coupon5.getCreatedAt());
+        assertThat(visitTime).isEqualTo(coupon1.getCreatedAt());
+    }
 }

--- a/backend/src/test/java/com/stampcrush/backend/repository/coupon/CouponRepositoryTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/repository/coupon/CouponRepositoryTest.java
@@ -1,0 +1,128 @@
+package com.stampcrush.backend.repository.coupon;
+
+import com.stampcrush.backend.entity.cafe.Cafe;
+import com.stampcrush.backend.entity.coupon.Coupon;
+import com.stampcrush.backend.entity.coupon.CouponDesign;
+import com.stampcrush.backend.entity.coupon.Stamp;
+import com.stampcrush.backend.entity.user.RegisterCustomer;
+import com.stampcrush.backend.entity.user.TemporaryCustomer;
+import com.stampcrush.backend.repository.cafe.CafeRepository;
+import com.stampcrush.backend.repository.user.RegisterCustomerRepository;
+import com.stampcrush.backend.repository.user.TemporaryCustomersRepository;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DataJpaTest
+class CouponRepositoryTest {
+
+    @Autowired
+    private CouponRepository couponRepository;
+
+    @Autowired
+    private TemporaryCustomersRepository temporaryCustomersRepository;
+
+    @Autowired
+    private RegisterCustomerRepository registerCustomerRepository;
+
+    @Autowired
+    private CafeRepository cafeRepository;
+
+    @Autowired
+    private CouponDesignRepository couponDesignRepository;
+
+    @Autowired
+    private EntityManager em;
+
+    private TemporaryCustomer tmpCustomer1;
+    private TemporaryCustomer tmpCustomer2;
+    private TemporaryCustomer tmpCustomer3;
+
+    private RegisterCustomer registerCustomer1;
+    private RegisterCustomer registerCustomer2;
+
+    private Cafe cafe1;
+    private Cafe cafe2;
+
+    private CouponDesign couponDesign1;
+    private CouponDesign couponDesign2;
+    private CouponDesign couponDesign3;
+    private CouponDesign couponDesign4;
+    private CouponDesign couponDesign5;
+
+    @BeforeEach
+    void setUp() {
+        tmpCustomer1 = temporaryCustomersRepository.save(new TemporaryCustomer());
+        tmpCustomer2 = temporaryCustomersRepository.save(new TemporaryCustomer());
+        tmpCustomer3 = temporaryCustomersRepository.save(new TemporaryCustomer());
+
+        registerCustomer1 = registerCustomerRepository.save(new RegisterCustomer("id1", "pw1"));
+        registerCustomer2 = registerCustomerRepository.save(new RegisterCustomer("id2", "pw2"));
+
+        cafe1 = cafeRepository.save(new Cafe());
+        cafe2 = cafeRepository.save(new Cafe());
+
+        couponDesign1 = couponDesignRepository.save(new CouponDesign());
+        couponDesign2 = couponDesignRepository.save(new CouponDesign());
+        couponDesign3 = couponDesignRepository.save(new CouponDesign());
+        couponDesign4 = couponDesignRepository.save(new CouponDesign());
+        couponDesign5 = couponDesignRepository.save(new CouponDesign());
+    }
+
+    @Test
+    void 카페에_맞는_쿠폰_정보를_조회한다() {
+        // given
+        // coupon1, REWARD상태, cafe1 -> stamp2개
+        // coupon2, USING상태, cafe1 -> stamp1개
+        // coupon3, USING상태, cafe2 -> stamp1개
+        // coupon4, USING상태, cafe2 -> stamp0개
+        // coupon5, USING상태, cafe2 -> stamp0개
+        Coupon coupon1 = new Coupon(LocalDate.EPOCH, tmpCustomer1, cafe1, couponDesign1);
+        Stamp stamp1 = new Stamp();
+        Stamp stamp2 = new Stamp();
+        stamp1.registerCoupon(coupon1);
+        stamp2.registerCoupon(coupon1);
+        Coupon save = couponRepository.save(coupon1);
+        save.reward();
+
+        Coupon coupon2 = new Coupon(LocalDate.EPOCH, registerCustomer1, cafe1, couponDesign2);
+        Stamp stamp3 = new Stamp();
+        stamp3.registerCoupon(coupon2);
+        couponRepository.save(coupon2);
+
+        Coupon coupon3 = new Coupon(LocalDate.EPOCH, tmpCustomer2, cafe2, couponDesign3);
+        Stamp stamp4 = new Stamp();
+        stamp4.registerCoupon(coupon3);
+        couponRepository.save(coupon3);
+
+        Coupon coupon4 = new Coupon(LocalDate.EPOCH, tmpCustomer3, cafe2, couponDesign4);
+        couponRepository.save(coupon4);
+
+        Coupon coupon5 = new Coupon(LocalDate.EPOCH, registerCustomer2, cafe2, couponDesign5);
+        couponRepository.save(coupon5);
+
+        // when
+        List<Coupon> couponsCafe1 = couponRepository.findByCafe(cafe1);
+        List<Coupon> couponsCafe2 = couponRepository.findByCafe(cafe2);
+
+        //then
+        assertAll(
+                () -> assertThat(couponsCafe1.size()).isEqualTo(2),
+                () -> assertThat(couponsCafe1).containsExactlyInAnyOrder(coupon1, coupon2),
+                () -> assertThat(couponsCafe1.get(0).getStamps().size()).isEqualTo(2),
+                () -> assertThat(couponsCafe1).doesNotContain(coupon3, coupon4, coupon5),
+                () -> assertThat(couponsCafe2.size()).isEqualTo(3),
+                () -> assertThat(couponsCafe2).containsExactlyInAnyOrder(coupon3, coupon4, coupon5),
+                () -> assertThat(couponsCafe2).doesNotContain(coupon1, coupon2)
+        );
+    }
+}


### PR DESCRIPTION
## 주요 변경사항

- Coupon의 stamp개수를 쉽게 조회하기 위해 Stamp와 양방향 연관관계를 설정했습니다.
- 해당 기능이 고객 정보, 쿠폰 정보, 스탬프 정보를 모두 반환하는 기능이라 패키지 구조를 고민해봤습니다.
    - 대부분의 정보를 조회하기 위해선 Coupon을 중심으로 join이 발생했기 때문에 coupon패키지로 정했습니다.
- 기존 엔티티에서 Coupon과 CouponPolicy연관관계가 없어서 이를 추가했습니다.

## 리뷰어에게...

- Coupon이 Customer, CouponPolicy, CouponDesign, Cafe와 연관관계가 있어서 테스트하기 위한 사전 데이터를 추가하는 코드가 상당히 길어졌습니다..
    - 그래서 이 연관관계를 꼭 객체로 해야하는지에 대해서 한 번 얘기해보면 좋을 것 같습니다! id로 풀 수도 있다고 하더라구요. 관련 세미나 영상 링크 걸어놓겠습니다. 영상이 길긴한데 보면 도움이 많이 될 것 같아요 ㅎ
    - [우아한 객체지향 세미나](https://www.youtube.com/watch?v=dJ5C4qRqAgA&t=3956s)
- `현재 스탬프 쌓고 있는 쿠폰 정보 조회 구현`에서 해당 쿠폰이 이전 정책인지 알려주는 `isPrevious`를 구하기 위해 노력해봤는데, 현재 저희 ERD구조에서는 시간이 조금 걸릴 것 같아서 일단 false로 고정했습니다.
    - 해당 부분은 시간이 조금 더 필요할 것 같아요..
- Controller에서 외부로 반환하는 DTO의 경우 제대로 동작하는지 확인해보기 위해선 관련 엔티티에 모든 정보를 다 넣어야하기 때문에 우선 service에서 반환된 DTO를 그대로 반환하게 했습니다.. 이건 모든 코드를 합치고 더미데이터를 넣든가 연관관계를 약하게 풀고 나서 수정하겠습니다..!

closes #72 

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [x] `milestone` 설정
