### PR TITLE
[BE] fix: 카페 등록 API 수정한다

### DIFF
--- a/backend/src/main/java/com/stampcrush/backend/api/cafe/CafeApiController.java
+++ b/backend/src/main/java/com/stampcrush/backend/api/cafe/CafeApiController.java
@@ -37,10 +37,6 @@ public class CafeApiController {
         CafeCreateDto cafeCreateDto = new CafeCreateDto(
                 1L,
                 cafeCreateRequest.getName(),
-                cafeCreateRequest.getOpenTime(),
-                cafeCreateRequest.getCloseTime(),
-                cafeCreateRequest.getTelephoneNumber(),
-                cafeCreateRequest.getCafeImageUrl(),
                 cafeCreateRequest.getRoadAddress(),
                 cafeCreateRequest.getDetailAddress(),
                 cafeCreateRequest.getBusinessRegistrationNumber());

--- a/backend/src/main/java/com/stampcrush/backend/api/cafe/request/CafeCreateRequest.java
+++ b/backend/src/main/java/com/stampcrush/backend/api/cafe/request/CafeCreateRequest.java
@@ -2,25 +2,12 @@ package com.stampcrush.backend.api.cafe.request;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import org.springframework.format.annotation.DateTimeFormat;
-
-import java.time.LocalTime;
 
 @Getter
 @RequiredArgsConstructor
 public class CafeCreateRequest {
 
     private final String name;
-
-    @DateTimeFormat(pattern = "HH:mm")
-    private final LocalTime openTime;
-
-    @DateTimeFormat(pattern = "HH:mm")
-    private final LocalTime closeTime;
-
-    private final String telephoneNumber;
-
-    private final String cafeImageUrl;
 
     private final String roadAddress;
 

--- a/backend/src/main/java/com/stampcrush/backend/application/cafe/CafeService.java
+++ b/backend/src/main/java/com/stampcrush/backend/application/cafe/CafeService.java
@@ -44,10 +44,6 @@ public class CafeService {
                 .orElseThrow(() -> new IllegalArgumentException("회원가입을 먼저 진행해주세요."));
         Cafe cafe = new Cafe(
                 cafeCreateDto.getName(),
-                cafeCreateDto.getOpenTime(),
-                cafeCreateDto.getCloseTime(),
-                cafeCreateDto.getTelephoneNumber(),
-                cafeCreateDto.getCafeImageUrl(),
                 cafeCreateDto.getRoadAddress(),
                 cafeCreateDto.getDetailAddress(),
                 cafeCreateDto.getBusinessRegistrationNumber(),

--- a/backend/src/main/java/com/stampcrush/backend/application/cafe/dto/CafeCreateDto.java
+++ b/backend/src/main/java/com/stampcrush/backend/application/cafe/dto/CafeCreateDto.java
@@ -2,9 +2,6 @@ package com.stampcrush.backend.application.cafe.dto;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import org.springframework.format.annotation.DateTimeFormat;
-
-import java.time.LocalTime;
 
 @Getter
 @RequiredArgsConstructor
@@ -13,16 +10,6 @@ public class CafeCreateDto {
     private final Long ownerId;
 
     private final String name;
-
-    @DateTimeFormat(pattern = "HH:mm")
-    private final LocalTime openTime;
-
-    @DateTimeFormat(pattern = "HH:mm")
-    private final LocalTime closeTime;
-
-    private final String telephoneNumber;
-
-    private final String cafeImageUrl;
 
     private final String roadAddress;
 

--- a/backend/src/main/java/com/stampcrush/backend/entity/cafe/Cafe.java
+++ b/backend/src/main/java/com/stampcrush/backend/entity/cafe/Cafe.java
@@ -46,6 +46,10 @@ public class Cafe extends BaseDate {
     @OneToMany(mappedBy = "cafe")
     private List<CafePolicy> policies = new ArrayList<>();
 
+    public Cafe(String name, String roadAddress, String detailAddress, String businessRegistrationNumber, Owner owner) {
+        this(name, null, null, null, null, roadAddress, detailAddress, businessRegistrationNumber, owner);
+    }
+
     public Cafe(String name, LocalTime openTime, LocalTime closeTime, String telephoneNumber, String cafeImageUrl, String roadAddress, String detailAddress, String businessRegistrationNumber, Owner owner) {
         this.name = name;
         this.openTime = openTime;

--- a/backend/src/test/java/com/stampcrush/backend/application/cafe/CafeServiceTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/application/cafe/CafeServiceTest.java
@@ -177,10 +177,6 @@ public class CafeServiceTest {
         return new CafeCreateDto(
                 owner_1.getId(),
                 "윤생까페",
-                LocalTime.of(12, 30),
-                LocalTime.of(18, 30),
-                "0211111111",
-                "http://www.cafeImage.com",
                 "잠실동12길",
                 "14층",
                 "11111111");


### PR DESCRIPTION
## 주요 변경사항
- 카페 등록 API 요청 스펙을 변경한다.

``` json
POST /cafes HTTP/1.1


{
    "businessRegistrationNumber": "101-3852-97"
    "name": "우아한커피",
    "roadAddress": "서울시 송파구 올림픽0로 35다길",
    "detailAddress": "루터회관 14층"
}
```
## 리뷰어에게...
- 요청 스펙, 서비스에 넘기는 스펙, 카페 생성자 추가만 되었습니다 ^^

## 관련 이슈

closes #113 

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [x] `milestone` 설정
