### PR TITLE
[FE] feat: 카페 등록 페이지에 도로명 주소 검색 API를 추가한다. 

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,6 +5,7 @@
   "license": "MIT",
   "dependencies": {
     "react": "^18.2.0",
+    "react-daum-postcode": "^3.1.3",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.14.1",
     "styled-components": "^6.0.2"

--- a/frontend/src/pages/Admin/RegisterCafe/index.tsx
+++ b/frontend/src/pages/Admin/RegisterCafe/index.tsx
@@ -1,8 +1,8 @@
-import { FormEventHandler, MouseEventHandler, useRef } from 'react';
+import { FormEventHandler, MouseEventHandler, useRef, useState } from 'react';
 import Button from '../../../components/Button';
 import { Input } from '../../../components/Input';
-import Template from '../../../components/Template';
 import { ContentContainer, InputWithButtonWrapper, RegisterCafeInputForm, Title } from './style';
+import { Address, useDaumPostcodePopup } from 'react-daum-postcode';
 
 const RegisterCafe = () => {
   const businessRegistrationNumberInputRef = useRef<HTMLInputElement>(null);
@@ -10,78 +10,99 @@ const RegisterCafe = () => {
   const roadAddressInputRef = useRef<HTMLInputElement>(null);
   const detailAddressInputRef = useRef<HTMLInputElement>(null);
 
+  const [roadAddress, setRoadAddress] = useState('');
+
+  const openPostcodePopup = useDaumPostcodePopup();
+
+  const handleComplete = (data: Address) => {
+    let fullAddress = data.address;
+    let extraAddress = '';
+
+    if (data.addressType === 'R') {
+      if (data.bname !== '') {
+        extraAddress += data.bname;
+      }
+      if (data.buildingName !== '') {
+        extraAddress += extraAddress !== '' ? `, ${data.buildingName}` : data.buildingName;
+      }
+      fullAddress += extraAddress !== '' ? ` (${extraAddress})` : '';
+    }
+
+    setRoadAddress(fullAddress);
+  };
+
+  const handleClick = () => {
+    openPostcodePopup({ onComplete: handleComplete });
+  };
+
   const certifyUser: MouseEventHandler<HTMLButtonElement> = () => {
     alert(businessRegistrationNumberInputRef.current?.value);
   };
 
-  const findRoadAddress: MouseEventHandler<HTMLButtonElement> = () => {
-    alert(roadAddressInputRef.current?.value);
-  };
-
   const submitCafeInfo: FormEventHandler<HTMLFormElement> = (event) => {
     event.preventDefault();
-    alert(
-      `사업자등록번호 ${businessRegistrationNumberInputRef.current?.value}
+    if (roadAddressInputRef.current && detailAddressInputRef.current)
+      alert(
+        `사업자등록번호 ${businessRegistrationNumberInputRef.current?.value}
       카페명 ${cafeNameInputRef.current?.value}
-      카페 주소 ${roadAddressInputRef.current?.value}
-      상세 주소 ${detailAddressInputRef.current?.value}
+      카페 주소 ${roadAddressInputRef.current.value + detailAddressInputRef.current.value}
       `,
-    );
+      );
   };
 
   return (
-    <Template>
-      <ContentContainer>
-        <RegisterCafeInputForm onSubmit={submitCafeInfo}>
-          <Title>내 카페 등록</Title>
-          <InputWithButtonWrapper>
-            <Input
-              id={'business-registration-number-input'}
-              ref={businessRegistrationNumberInputRef}
-              label={'사업자등록번호'}
-              width={410}
-              placeholder={'사업자등록번호를 입력해주세요.'}
-              required={true}
-            />
-            <Button type="button" variant={'primary'} size={'medium'} onClick={certifyUser}>
-              인증하기
-            </Button>
-          </InputWithButtonWrapper>
+    <ContentContainer>
+      <RegisterCafeInputForm onSubmit={submitCafeInfo}>
+        <Title>내 카페 등록</Title>
+        <InputWithButtonWrapper>
           <Input
-            id={'cafe-name-input'}
-            ref={cafeNameInputRef}
-            label={'카페명'}
-            width={550}
-            placeholder={'카페명을 입력해주세요.'}
+            id={'business-registration-number-input'}
+            ref={businessRegistrationNumberInputRef}
+            label={'사업자등록번호'}
+            width={410}
+            placeholder={'사업자등록번호를 입력해주세요.'}
             required={true}
           />
-          <InputWithButtonWrapper>
-            <Input
-              id={'cafe-address-input'}
-              ref={roadAddressInputRef}
-              label={'카페 주소'}
-              width={410}
-              placeholder={'카페 주소를 입력해주세요.'}
-              required={true}
-            />
-            <Button type="button" variant={'primary'} size={'medium'} onClick={findRoadAddress}>
-              주소 찾기
-            </Button>
-          </InputWithButtonWrapper>
-          <Input
-            id={'detailed-address-input'}
-            ref={detailAddressInputRef}
-            label={'상세 주소'}
-            width={550}
-            placeholder={'상세 주소를 입력해주세요.'}
-            required={true}
-          />
-          <Button type="submit" id="register-cafe-submit-btn" variant={'primary'} size={'medium'}>
-            등록하기
+          <Button type="button" variant={'primary'} size={'medium'} onClick={certifyUser}>
+            인증하기
           </Button>
-        </RegisterCafeInputForm>
-      </ContentContainer>
-    </Template>
+        </InputWithButtonWrapper>
+        <Input
+          id={'cafe-name-input'}
+          ref={cafeNameInputRef}
+          label={'카페명'}
+          width={550}
+          placeholder={'카페명을 입력해주세요.'}
+          required={true}
+        />
+        <InputWithButtonWrapper>
+          <Input
+            id={'cafe-address-input'}
+            ref={roadAddressInputRef}
+            label={'카페 주소'}
+            value={roadAddress}
+            width={410}
+            placeholder={'카페 주소를 입력해주세요.'}
+            required={true}
+          />
+          <Button type="button" variant={'primary'} size={'medium'} onClick={handleClick}>
+            주소 찾기
+          </Button>
+        </InputWithButtonWrapper>
+        <Input
+          id={'detailed-address-input'}
+          ref={detailAddressInputRef}
+          label={'상세 주소'}
+          width={550}
+          placeholder={'상세 주소를 입력해주세요.'}
+          required={true}
+        />
+
+        <Button type="submit" id="register-cafe-submit-btn" variant={'primary'} size={'medium'}>
+          등록하기
+        </Button>
+      </RegisterCafeInputForm>
+    </ContentContainer>
   );
 };
 

--- a/frontend/src/pages/Admin/RegisterCafe/index.tsx
+++ b/frontend/src/pages/Admin/RegisterCafe/index.tsx
@@ -63,7 +63,7 @@ const RegisterCafe = () => {
             placeholder={'사업자등록번호를 입력해주세요.'}
             required={true}
           />
-          <Button type="button" variant={'primary'} size={'medium'} onClick={certifyUser}>
+          <Button type="button" variant={'secondary'} size={'medium'} onClick={certifyUser}>
             인증하기
           </Button>
         </InputWithButtonWrapper>
@@ -85,7 +85,7 @@ const RegisterCafe = () => {
             placeholder={'카페 주소를 입력해주세요.'}
             required={true}
           />
-          <Button type="button" variant={'primary'} size={'medium'} onClick={handleClick}>
+          <Button type="button" variant={'secondary'} size={'medium'} onClick={handleClick}>
             주소 찾기
           </Button>
         </InputWithButtonWrapper>

--- a/frontend/src/pages/Admin/RegisterCafe/style.tsx
+++ b/frontend/src/pages/Admin/RegisterCafe/style.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 export const ContentContainer = styled.main`
   display: flex;
   justify-content: center;
+  padding-top: 48px;
 `;
 
 export const RegisterCafeInputForm = styled.form`
@@ -13,10 +14,7 @@ export const RegisterCafeInputForm = styled.form`
   position: relative;
 
   & > button {
-    position: absolute;
-    right: 0;
-    bottom: -100px;
-
+    margin-left: auto;
     width: 160px;
     height: 56px;
 


### PR DESCRIPTION
## 주요 변경사항

- [x] 카페 등록 페이지의 주소 찾기 버튼을 눌러 도로명 주소 API를 사용하여 주소를 찾을 수 있다.
- [x] 그 외 스타일

## 리뷰어에게...

주소 찾기 팝업
<img width="715" alt="스크린샷 2023-07-17 오후 8 46 16" src="https://github.com/woowacourse-teams/2023-stamp-crush/assets/90092440/4902e7f0-d71b-4487-a9f5-bb2604285f19">

검색 결과 화면
<img width="575" alt="스크린샷 2023-07-17 오후 8 46 38" src="https://github.com/woowacourse-teams/2023-stamp-crush/assets/90092440/339908de-ac98-49c0-9971-f87ee401991a">

## 관련 이슈

closes #111 

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [x] `milestone` 설정
