### PR TITLE
[BE] feat: 커스텀 예외에 String만을 파라미터로 받는 생성자 추가

### DIFF
--- a/backend/src/main/java/com/stampcrush/backend/exception/BadRequestException.java
+++ b/backend/src/main/java/com/stampcrush/backend/exception/BadRequestException.java
@@ -2,6 +2,10 @@ package com.stampcrush.backend.exception;
 
 public class BadRequestException extends StampCrushException {
 
+    public BadRequestException(String message) {
+        super(message);
+    }
+
     public BadRequestException(Throwable cause) {
         super(cause);
     }

--- a/backend/src/main/java/com/stampcrush/backend/exception/ForbiddenException.java
+++ b/backend/src/main/java/com/stampcrush/backend/exception/ForbiddenException.java
@@ -2,6 +2,10 @@ package com.stampcrush.backend.exception;
 
 public class ForbiddenException extends StampCrushException {
 
+    public ForbiddenException(String message) {
+        super(message);
+    }
+
     public ForbiddenException(Throwable cause) {
         super(cause);
     }

--- a/backend/src/main/java/com/stampcrush/backend/exception/NotFoundException.java
+++ b/backend/src/main/java/com/stampcrush/backend/exception/NotFoundException.java
@@ -2,6 +2,10 @@ package com.stampcrush.backend.exception;
 
 public class NotFoundException extends StampCrushException {
 
+    public NotFoundException(String message) {
+        super(message);
+    }
+
     public NotFoundException(Throwable cause) {
         super(cause);
     }

--- a/backend/src/main/java/com/stampcrush/backend/exception/StampCrushException.java
+++ b/backend/src/main/java/com/stampcrush/backend/exception/StampCrushException.java
@@ -2,6 +2,10 @@ package com.stampcrush.backend.exception;
 
 public class StampCrushException extends RuntimeException {
 
+    public StampCrushException(String message) {
+        super(message);
+    }
+
     public StampCrushException(Throwable cause) {
         super(cause);
     }

--- a/backend/src/main/java/com/stampcrush/backend/exception/UnAuthorizationException.java
+++ b/backend/src/main/java/com/stampcrush/backend/exception/UnAuthorizationException.java
@@ -2,6 +2,10 @@ package com.stampcrush.backend.exception;
 
 public class UnAuthorizationException extends StampCrushException {
 
+    public UnAuthorizationException(String message) {
+        super(message);
+    }
+
     public UnAuthorizationException(Throwable cause) {
         super(cause);
     }


### PR DESCRIPTION
## 주요 변경사항

- 커스텀 예외 5개에 생성자 한개 추가했음.

## 리뷰어에게...

- 이후에 있을 리팩터링을 위해서 빠른 머지가 필요함

## 관련 이슈

closes #128 

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [x] `milestone` 설정
