### PR TITLE
[BE] feat: 현재 적립중인 쿠폰 데이터에 maxStampCount를 추가한다

### DIFF
--- a/backend/src/main/java/com/stampcrush/backend/api/coupon/response/CustomerAccumulatingCouponFindResponse.java
+++ b/backend/src/main/java/com/stampcrush/backend/api/coupon/response/CustomerAccumulatingCouponFindResponse.java
@@ -33,7 +33,7 @@ public class CustomerAccumulatingCouponFindResponse {
                 serviceDto.getStampCount(),
                 serviceDto.getExpireDate(),
                 serviceDto.isPrevious(),
-                10
+                serviceDto.getMaxStampCount()
         );
     }
 }

--- a/backend/src/main/java/com/stampcrush/backend/application/coupon/dto/CustomerAccumulatingCouponFindResultDto.java
+++ b/backend/src/main/java/com/stampcrush/backend/application/coupon/dto/CustomerAccumulatingCouponFindResultDto.java
@@ -2,15 +2,13 @@ package com.stampcrush.backend.application.coupon.dto;
 
 import com.stampcrush.backend.entity.coupon.Coupon;
 import com.stampcrush.backend.entity.user.Customer;
-import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.time.LocalDateTime;
 
 import static lombok.AccessLevel.PUBLIC;
 
+@ToString
 @EqualsAndHashCode
 @AllArgsConstructor
 @NoArgsConstructor(access = PUBLIC)
@@ -33,7 +31,7 @@ public class CustomerAccumulatingCouponFindResultDto {
                 coupon.getStampCount(),
                 coupon.calculateExpireDate(),
                 isPrevious,
-                10
+                coupon.getCouponMaxStampCount()
         );
     }
 }

--- a/backend/src/main/java/com/stampcrush/backend/entity/coupon/Coupon.java
+++ b/backend/src/main/java/com/stampcrush/backend/entity/coupon/Coupon.java
@@ -111,6 +111,10 @@ public class Coupon extends BaseDate {
         }
     }
 
+    public int getCouponMaxStampCount() {
+        return couponPolicy.getMaxStampCount();
+    }
+
     public String getRewardName() {
         return couponPolicy.getRewardName();
     }

--- a/backend/src/test/java/com/stampcrush/backend/application/coupon/CouponServiceTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/application/coupon/CouponServiceTest.java
@@ -289,15 +289,26 @@ class CouponServiceTest {
     @Test
     void 존재O_현재_스탬프를_모으고_있는_쿠폰_정보를_조회한다() {
         // when
-        List<CustomerAccumulatingCouponFindResultDto> result = couponService.findAccumulatingCoupon(cafe1.getId(), registerCustomer1.getId());
+        TemporaryCustomer leo = temporaryCustomerRepository.save(new TemporaryCustomer("leo", "1234"));
+        CouponDesign couponDesign = couponDesignRepository.save(new CouponDesign("front", "back", "stamp"));
+        CouponPolicy couponPolicy = couponPolicyRepository.save(new CouponPolicy(20, "아메리카노", 8));
+
+        Coupon coupon = new Coupon(LocalDate.EPOCH, leo, cafe1, couponDesign, couponPolicy);
+        Stamp stamp1 = new Stamp();
+        Stamp stamp2 = new Stamp();
+        stamp1.registerCoupon(coupon);
+        stamp2.registerCoupon(coupon);
+        couponRepository.save(coupon);
+
+        List<CustomerAccumulatingCouponFindResultDto> result = couponService.findAccumulatingCoupon(cafe1.getId(), leo.getId());
         CustomerAccumulatingCouponFindResultDto customerUsingCoupon = new CustomerAccumulatingCouponFindResultDto(
-                coupon2.getId(),
-                registerCustomer1.getId(),
-                registerCustomer1.getNickname(),
-                coupon2.getStampCount(),
-                coupon2.calculateExpireDate(),
+                coupon.getId(),
+                leo.getId(),
+                leo.getNickname(),
+                coupon.getStampCount(),
+                coupon.calculateExpireDate(),
                 false,
-                10);
+                20);
 
         //then
         assertThat(result).containsExactly(customerUsingCoupon);


### PR DESCRIPTION
## 주요 변경사항

- 고객이 카페에서 적립중인 쿠폰의 maxStampCount데이터를 추가했습니다.

## 리뷰어에게...

- 기존 테스트코드인 `존재O_현재_스탬프를_모으고_있는_쿠폰_정보를_조회한다`에서 새로운 쿠폰 정책을 만들어 기존 정책과 다른 maxStampCount를 생성해서 검증하는 방식으로 테스트 코드를 수정했습니다.
- 이 부분은 제가 실수로 PR #190 에서 분기를 따지 못했는데요.. 변경 사항은 되게 적습니다.
    1. Coupon엔티티의 getCouponMaxStampCount메서드 추가
    2. CustomerAccumulatingCouponFindResponse에서 maxStampCount설정하는 부분 상수 고정이 아닌 parameter.getMaxStampCount()로 변경
    3. CustomerAccumulatingCouponFindResultDto도 2번과 마찬가지로 수정
- 혹시 충돌나면 위 3가지 부분만 봐주시면 됩니다!

## 관련 이슈

closes #163 

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [x] `milestone` 설정
