### PR TITLE
[BE] feat: github action ci 트리거 조건에서 push 조건 삭제

### DIFF
--- a/.github/workflows/backend_ci.yml
+++ b/.github/workflows/backend_ci.yml
@@ -1,11 +1,6 @@
 name: 스탬프크러쉬 백엔드 CI 테스트 자동화
 
 on:
-  push:
-    branches:
-      - main
-      - develop
-    paths: 'backend/**'
   pull_request:
     branches:
       - main


### PR DESCRIPTION
## 주요 변경사항

- github action ci 트리거 조건에서 push 조건 삭제

## 리뷰어에게...

- PR 생성 후 추가 push 동작 시 워크 플로우 동작 다시 하는거 확인했습니다

## 관련 이슈

closes

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [x] `milestone` 설정
