### PR TITLE
[BE] feat: 2차 구현기능 API 에 /admin prefix 를 적용한다(사장모드)

### DIFF
--- a/backend/src/main/java/com/stampcrush/backend/api/cafe/CafeApiController.java
+++ b/backend/src/main/java/com/stampcrush/backend/api/cafe/CafeApiController.java
@@ -16,7 +16,7 @@ import java.util.List;
 
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("/api/cafes")
+@RequestMapping("/api/admin/cafes")
 public class CafeApiController {
 
     private final CafeService cafeService;

--- a/backend/src/main/java/com/stampcrush/backend/api/cafe/CafeCouponSettingApiController.java
+++ b/backend/src/main/java/com/stampcrush/backend/api/cafe/CafeCouponSettingApiController.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("/api/coupon-setting")
+@RequestMapping("/api/admin/coupon-setting")
 public class CafeCouponSettingApiController {
 
     private final CafeCouponSettingService cafeCouponSettingService;

--- a/backend/src/main/java/com/stampcrush/backend/api/coupon/CouponApiController.java
+++ b/backend/src/main/java/com/stampcrush/backend/api/coupon/CouponApiController.java
@@ -17,7 +17,7 @@ import java.util.List;
 
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("/api")
+@RequestMapping("/api/admin")
 public class CouponApiController {
 
     private final CouponService couponService;

--- a/backend/src/main/java/com/stampcrush/backend/api/customer/CustomerApiController.java
+++ b/backend/src/main/java/com/stampcrush/backend/api/customer/CustomerApiController.java
@@ -17,7 +17,7 @@ import static java.util.stream.Collectors.toList;
 
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("/api")
+@RequestMapping("/api/admin")
 public class CustomerApiController {
 
     private final CustomerService customerService;

--- a/backend/src/main/java/com/stampcrush/backend/api/reward/RewardApiController.java
+++ b/backend/src/main/java/com/stampcrush/backend/api/reward/RewardApiController.java
@@ -17,7 +17,7 @@ import java.util.List;
 
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("/api/customers/{customerId}/rewards")
+@RequestMapping("/api/admin/customers/{customerId}/rewards")
 public class RewardApiController {
 
     private final RewardService rewardService;

--- a/backend/src/main/java/com/stampcrush/backend/api/sample/SampleCouponApiController.java
+++ b/backend/src/main/java/com/stampcrush/backend/api/sample/SampleCouponApiController.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("/api/coupon-samples")
+@RequestMapping("/api/admin/coupon-samples")
 public class SampleCouponApiController {
 
     private final SampleCouponService sampleCouponService;

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/CafeCouponSettingIntegrationTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/CafeCouponSettingIntegrationTest.java
@@ -112,7 +112,7 @@ public class CafeCouponSettingIntegrationTest extends AcceptanceTest {
                 .body(request)
 
                 .when()
-                .post("/api/coupon-setting?cafe-id=" + savedCafe.getId())
+                .post("/api/admin/coupon-setting?cafe-id=" + savedCafe.getId())
 
                 .then()
                 .log().all()

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/CustomerIntegrationTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/CustomerIntegrationTest.java
@@ -99,7 +99,7 @@ public class CustomerIntegrationTest extends AcceptanceTest {
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .body(temporaryCustomerCreateRequest)
                 .when()
-                .post("/api/temporary-customers")
+                .post("/api/admin/temporary-customers")
                 .then()
                 .statusCode(BAD_REQUEST.value())
                 .extract();
@@ -110,7 +110,7 @@ public class CustomerIntegrationTest extends AcceptanceTest {
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .param("phone-number", phoneNumber)
                 .when()
-                .get("/api/customers")
+                .get("/api/admin/customers")
                 .then()
                 .log().all()
                 .extract();
@@ -121,7 +121,7 @@ public class CustomerIntegrationTest extends AcceptanceTest {
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .body(request)
                 .when()
-                .post("/api/temporary-customers")
+                .post("/api/admin/temporary-customers")
                 .then()
                 .statusCode(HttpStatus.CREATED.value())
                 .extract();

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/SampleCouponIntegrationTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/SampleCouponIntegrationTest.java
@@ -50,7 +50,7 @@ public class SampleCouponIntegrationTest extends AcceptanceTest {
                 .log().all()
 
                 .when()
-                .get("/api/coupon-samples")
+                .get("/api/admin/coupon-samples")
 
                 .then()
                 .extract();
@@ -71,7 +71,7 @@ public class SampleCouponIntegrationTest extends AcceptanceTest {
                 .log().all()
 
                 .when()
-                .get("/api/coupon-samples?max-stamp-count=8")
+                .get("/api/admin/coupon-samples?max-stamp-count=8")
 
                 .then()
                 .extract();
@@ -92,7 +92,7 @@ public class SampleCouponIntegrationTest extends AcceptanceTest {
                 .log().all()
 
                 .when()
-                .get("/api/coupon-samples?max-stamp-count=10")
+                .get("/api/admin/coupon-samples?max-stamp-count=10")
 
                 .then()
                 .extract();


### PR DESCRIPTION
## 주요 변경사항

- 2차 데모데이 시 구현한 API 에 대해서 사장모드일때 /admin prefix 를 적용했습니다
- 테스트 코드 URL 도 수정했습니다

## 리뷰어에게...

- 혹시 실수했는지도 몰라요 꼼꼼히 부탁드립니다 ! 

## 관련 이슈

closes #229 

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [x] `milestone` 설정
