### PR TITLE
[FE] feat: 쿠폰리스트 컴포넌트 및 페이지 구현

### DIFF
--- a/frontend/src/Router.tsx
+++ b/frontend/src/Router.tsx
@@ -32,10 +32,7 @@ const AdminRoot = () => {
 const CustomerRoot = () => {
   return (
     <>
-      <Header />
-      <Template>
-        <Outlet />
-      </Template>
+      <Outlet />
     </>
   );
 };

--- a/frontend/src/Router.tsx
+++ b/frontend/src/Router.tsx
@@ -71,10 +71,9 @@ const Router = () => {
       element: <CustomerRoot />,
       errorElement: <NotFound />,
       children: [
-        { index: true, element: <CustomerList /> },
+        { index: true, element: <CouponList /> },
         { path: 'login', element: <Login /> },
         { path: 'sign-up', element: <SignUp /> },
-        { path: 'coupon-list', element: <CouponList /> },
         { path: '/my-page', element: <MyPage /> },
         { path: '/history', element: <History /> },
       ],

--- a/frontend/src/api/get.ts
+++ b/frontend/src/api/get.ts
@@ -23,3 +23,7 @@ export const getReward = async (customerId: number | undefined, cafeId: number) 
 export const getCouponSamples = async (maxStampCount: number) => {
   return await api.get(`/coupon-samples?max-stamp-count=${maxStampCount}`);
 };
+
+export const getCoupons = async () => {
+  return await api.get('/coupons');
+};

--- a/frontend/src/custom.d.ts
+++ b/frontend/src/custom.d.ts
@@ -1,1 +1,2 @@
-declare module "*.png";
+declare module '*.png';
+declare module '*.svg';

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -8,6 +8,7 @@ import {
   samples8,
   mockCoupons,
   cafeCustomer,
+  customerCoupons,
 } from './mockData';
 
 const customerList = [...customers];
@@ -187,7 +188,7 @@ export const handlers = [
     return res(ctx.status(200), ctx.json({ customers: cafeCustomer }));
   }),
 
-  // 리워드 사용 기능
+  // 고객 쿠폰 목록 조회
   rest.patch('/customers/:customerId/rewards/:rewardId', async (req, res, ctx) => {
     const { customerId, rewardId } = req.params;
     const { cafeId, used } = await req.json();
@@ -197,5 +198,9 @@ export const handlers = [
     }
 
     return res(ctx.status(200));
+  }),
+
+  rest.get('/coupons', (req, res, ctx) => {
+    return res(ctx.status(200), ctx.json(customerCoupons));
   }),
 ];

--- a/frontend/src/mocks/mockData.ts
+++ b/frontend/src/mocks/mockData.ts
@@ -239,6 +239,7 @@ interface MockCustomer {
   nickname: string;
   phoneNumber: string;
 }
+
 export const customers: MockCustomer[] = [
   { id: 1, nickname: '윤생', phoneNumber: '01011112222' },
   { id: 2, nickname: '라잇', phoneNumber: '01033334444' },
@@ -300,3 +301,163 @@ export const cafeCustomer = [
     maxStampCount: 8,
   },
 ];
+
+export const customerCoupons = {
+  coupons: [
+    {
+      cafeInfo: {
+        id: 1,
+        name: '우아한카페',
+      },
+      couponInfos: [
+        {
+          id: 1,
+          isFavorites: true,
+          status: 'ACCUMULATING',
+          stampCount: 3,
+          maxStampCount: 8,
+          rewardName: '아메리카노',
+          frontImageUrl: 'https://source.unsplash.com/random',
+          backImageUrl: 'https://source.unsplash.com/random',
+          stampImageUrl: 'https://source.unsplash.com/random',
+          coordinates: [
+            {
+              order: 1,
+              xCoordinate: 2,
+              yCoordinate: 5,
+            },
+            {
+              order: 2,
+              xCoordinate: 5,
+              yCoordinate: 5,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      cafeInfo: {
+        id: 2,
+        name: '윤생카페',
+      },
+      couponInfos: [
+        {
+          id: 2,
+          isFavorites: false,
+          status: 'ACCUMULATING',
+          stampCount: 3,
+          maxStampCount: 8,
+          rewardName: '아메리카노',
+          frontImageUrl: 'https://source.unsplash.com/random',
+          backImageUrl: 'https://source.unsplash.com/random',
+          stampImageUrl: 'https://source.unsplash.com/random',
+          coordinates: [
+            {
+              order: 1,
+              xCoordinate: 2,
+              yCoordinate: 5,
+            },
+            {
+              order: 2,
+              xCoordinate: 5,
+              yCoordinate: 5,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      cafeInfo: {
+        id: 3,
+        name: '카페, 빛',
+      },
+      couponInfos: [
+        {
+          id: 3,
+          isFavorites: true,
+          status: 'ACCUMULATING',
+          stampCount: 3,
+          maxStampCount: 8,
+          rewardName: '아메리카노',
+          frontImageUrl: 'https://source.unsplash.com/random',
+          backImageUrl: 'https://source.unsplash.com/random',
+          stampImageUrl: 'https://source.unsplash.com/random',
+          coordinates: [
+            {
+              order: 1,
+              xCoordinate: 2,
+              yCoordinate: 5,
+            },
+            {
+              order: 2,
+              xCoordinate: 5,
+              yCoordinate: 5,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      cafeInfo: {
+        id: 4,
+        name: '블럭레고카페',
+      },
+      couponInfos: [
+        {
+          id: 4,
+          isFavorites: true,
+          status: 'ACCUMULATING',
+          stampCount: 3,
+          maxStampCount: 8,
+          rewardName: '아메리카노',
+          frontImageUrl: 'https://source.unsplash.com/random',
+          backImageUrl: 'https://source.unsplash.com/random',
+          stampImageUrl: 'https://source.unsplash.com/random',
+          coordinates: [
+            {
+              order: 1,
+              xCoordinate: 2,
+              yCoordinate: 5,
+            },
+            {
+              order: 2,
+              xCoordinate: 5,
+              yCoordinate: 5,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      cafeInfo: {
+        id: 5,
+        name: '크러쉬카페',
+      },
+      couponInfos: [
+        {
+          id: 5,
+          isFavorites: true,
+          status: 'ACCUMULATING',
+          stampCount: 3,
+          maxStampCount: 8,
+          rewardName: '아메리카노',
+          frontImageUrl: 'https://source.unsplash.com/random',
+          backImageUrl: 'https://source.unsplash.com/random',
+          stampImageUrl: 'https://source.unsplash.com/random',
+          coordinates: [
+            {
+              order: 1,
+              xCoordinate: 2,
+              yCoordinate: 5,
+            },
+            {
+              order: 2,
+              xCoordinate: 5,
+              yCoordinate: 5,
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};

--- a/frontend/src/pages/CouponList/Coupon/index.tsx
+++ b/frontend/src/pages/CouponList/Coupon/index.tsx
@@ -1,0 +1,21 @@
+import { BackImage, CouponContainer, CouponWrapper, FrontImage, StampImage } from './style';
+import { ImgHTMLAttributes } from 'react';
+
+interface CouponProps extends ImgHTMLAttributes<HTMLImageElement> {
+  frontImageUrl?: string;
+  backImageUrl?: string;
+}
+
+const Coupon = ({ frontImageUrl, backImageUrl, ...props }: CouponProps) => {
+  return (
+    <CouponContainer>
+      <CouponWrapper>
+        <FrontImage src={frontImageUrl} {...props} />
+        <BackImage src={backImageUrl} {...props} />
+      </CouponWrapper>
+      <StampImage />
+    </CouponContainer>
+  );
+};
+
+export default Coupon;

--- a/frontend/src/pages/CouponList/Coupon/index.tsx
+++ b/frontend/src/pages/CouponList/Coupon/index.tsx
@@ -1,21 +1,12 @@
-import { BackImage, CouponContainer, CouponWrapper, FrontImage, StampImage } from './style';
-import { ImgHTMLAttributes } from 'react';
+import { CouponWrapper } from './style';
 
-interface CouponProps extends ImgHTMLAttributes<HTMLImageElement> {
-  frontImageUrl?: string;
-  backImageUrl?: string;
+interface CouponProps {
+  frontImageUrl: string;
+  onClick: () => void;
 }
 
-const Coupon = ({ frontImageUrl, backImageUrl, ...props }: CouponProps) => {
-  return (
-    <CouponContainer>
-      <CouponWrapper>
-        <FrontImage src={frontImageUrl} {...props} />
-        <BackImage src={backImageUrl} {...props} />
-      </CouponWrapper>
-      <StampImage />
-    </CouponContainer>
-  );
+const Coupon = ({ frontImageUrl, onClick }: CouponProps) => {
+  return <CouponWrapper src={frontImageUrl} onClick={onClick}></CouponWrapper>;
 };
 
 export default Coupon;

--- a/frontend/src/pages/CouponList/Coupon/index.tsx
+++ b/frontend/src/pages/CouponList/Coupon/index.tsx
@@ -6,7 +6,7 @@ interface CouponProps {
 }
 
 const Coupon = ({ frontImageUrl, onClick }: CouponProps) => {
-  return <CouponWrapper src={frontImageUrl} onClick={onClick}></CouponWrapper>;
+  return <CouponWrapper src={frontImageUrl} onClick={onClick} />;
 };
 
 export default Coupon;

--- a/frontend/src/pages/CouponList/Coupon/style.tsx
+++ b/frontend/src/pages/CouponList/Coupon/style.tsx
@@ -1,58 +1,13 @@
 import { styled } from 'styled-components';
 
-export const CouponContainer = styled.div`
-  display: flex;
-  position: relative;
+export const CouponWrapper = styled.img`
   width: 270px;
-  min-height: 150px;
-  perspective: 1100px;
-  transition: all 0.4s;
+  height: 150px;
+  position: absolute;
+  top: 60%;
+  bottom: 40%;
+  transform: translate(50%, -50%);
+  transition: transform 0.1s;
+  object-fit: cover;
   box-shadow: 0px -10px 15px -2px rgba(0, 0, 0, 0.25);
-`;
-
-export const CouponWrapper = styled.div`
-  position: absolute;
-  width: 100%;
-  height: 100%;
-  transform-style: preserve-3d;
-  backface-visibility: hidden;
-  transition: all 0.4s;
-  scroll-snap-align: end;
-
-  &:active {
-    transform: rotateY(180deg);
-  }
-`;
-
-export const CouponImage = styled.img`
-  position: absolute;
-  width: 100%;
-  height: 100%;
-  transform-style: preserve-3d;
-  backface-visibility: hidden;
-  z-index: 2;
-`;
-
-export const FrontImage = styled(CouponImage)`
-  z-index: 10;
-`;
-
-export const BackImage = styled(CouponImage)`
-  transform: rotateY(180deg);
-  z-index: 0;
-`;
-
-export const StampImage = styled.img`
-  ${CouponWrapper}:active + & {
-    visibility: visible;
-  }
-
-  visibility: hidden;
-  width: 30px;
-  height: 30px;
-  position: absolute;
-  top: 20px;
-  left: 20px;
-  background: yellow;
-  z-index: 1;
 `;

--- a/frontend/src/pages/CouponList/Coupon/style.tsx
+++ b/frontend/src/pages/CouponList/Coupon/style.tsx
@@ -1,0 +1,58 @@
+import { styled } from 'styled-components';
+
+export const CouponContainer = styled.div`
+  display: flex;
+  position: relative;
+  width: 270px;
+  min-height: 150px;
+  perspective: 1100px;
+  transition: all 0.4s;
+  box-shadow: 0px -10px 15px -2px rgba(0, 0, 0, 0.25);
+`;
+
+export const CouponWrapper = styled.div`
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  transform-style: preserve-3d;
+  backface-visibility: hidden;
+  transition: all 0.4s;
+  scroll-snap-align: end;
+
+  &:active {
+    transform: rotateY(180deg);
+  }
+`;
+
+export const CouponImage = styled.img`
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  transform-style: preserve-3d;
+  backface-visibility: hidden;
+  z-index: 2;
+`;
+
+export const FrontImage = styled(CouponImage)`
+  z-index: 10;
+`;
+
+export const BackImage = styled(CouponImage)`
+  transform: rotateY(180deg);
+  z-index: 0;
+`;
+
+export const StampImage = styled.img`
+  ${CouponWrapper}:active + & {
+    visibility: visible;
+  }
+
+  visibility: hidden;
+  width: 30px;
+  height: 30px;
+  position: absolute;
+  top: 20px;
+  left: 20px;
+  background: yellow;
+  z-index: 1;
+`;

--- a/frontend/src/pages/CouponList/index.tsx
+++ b/frontend/src/pages/CouponList/index.tsx
@@ -1,7 +1,34 @@
-import React from 'react';
+import Coupon from './Coupon';
+import { CouponListContainer, Test } from './style';
+import { useRef, useState } from 'react';
+
+const randomColor = ['blue', 'orange', 'green', 'pink'];
 
 const CouponList = () => {
-  return <div>CouponList</div>;
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [coupons, setCoupons] = useState<string[]>(randomColor);
+  const couponListContainerRef = useRef<HTMLDivElement>(null);
+  const [isLast, setIsLast] = useState(false);
+
+  const swapCoupon = (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
+    const card = couponListContainerRef.current?.lastElementChild as HTMLDivElement;
+    if (e.target !== card) return;
+
+    setIsLast(true);
+
+    setTimeout(() => {
+      setIsLast(false);
+      couponListContainerRef.current?.prepend(card);
+    }, 700);
+  };
+
+  return (
+    <CouponListContainer ref={couponListContainerRef} onClick={swapCoupon} $isLast={isLast}>
+      {coupons.map((color, index) => (
+        <Test key={index} style={{ background: color }} />
+      ))}
+    </CouponListContainer>
+  );
 };
 
 export default CouponList;

--- a/frontend/src/pages/CouponList/index.tsx
+++ b/frontend/src/pages/CouponList/index.tsx
@@ -1,33 +1,69 @@
 import Coupon from './Coupon';
-import { CouponListContainer, Test } from './style';
+import { CafeName, CouponListContainer } from './style';
 import { useRef, useState } from 'react';
+import { getCoupons } from '../../api/get';
+import { useQuery } from '@tanstack/react-query';
 
-const randomColor = ['blue', 'orange', 'green', 'pink'];
+interface CouponType {
+  cafeInfo: {
+    id: number;
+    name: string;
+  };
+  couponInfos: [
+    {
+      id: number;
+      isFavorites: boolean;
+      stampCount: number;
+      maxStampCount: number;
+      rewardName: string;
+      frontImageUrl: string;
+      backImageUrl: string;
+      stampImageUrl: string;
+      // TODO: coordinate
+    },
+  ];
+}
 
 const CouponList = () => {
-  const [currentIndex, setCurrentIndex] = useState(0);
-  const [coupons, setCoupons] = useState<string[]>(randomColor);
+  const [currentCafeIndex, setCurrentCafeIndex] = useState(0);
   const couponListContainerRef = useRef<HTMLDivElement>(null);
   const [isLast, setIsLast] = useState(false);
+  const { data, status } = useQuery<{ coupons: CouponType[] }>(['coupons'], getCoupons, {});
 
-  const swapCoupon = (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
-    const card = couponListContainerRef.current?.lastElementChild as HTMLDivElement;
-    if (e.target !== card) return;
+  if (status === 'error') return <>에러가 발생했습니다.</>;
+  if (status === 'loading') return <>로딩 중입니다.</>;
 
+  const swapCoupon = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (!couponListContainerRef.current) return;
+
+    const coupon = couponListContainerRef.current.lastElementChild;
+    if (e.target !== coupon) return;
     setIsLast(true);
 
     setTimeout(() => {
       setIsLast(false);
-      couponListContainerRef.current?.prepend(card);
+      couponListContainerRef.current?.prepend(coupon);
     }, 700);
   };
 
+  const changeCurrentCafeIndex = (index: number) => () => {
+    setCurrentCafeIndex(index);
+  };
+
   return (
-    <CouponListContainer ref={couponListContainerRef} onClick={swapCoupon} $isLast={isLast}>
-      {coupons.map((color, index) => (
-        <Test key={index} style={{ background: color }} />
-      ))}
-    </CouponListContainer>
+    <>
+      <CafeName>{data.coupons[currentCafeIndex].cafeInfo.name}</CafeName>
+      <CouponListContainer ref={couponListContainerRef} onClick={swapCoupon} $isLast={isLast}>
+        {data.coupons.map(({ cafeInfo, couponInfos }, index) => (
+          <Coupon
+            key={cafeInfo.id}
+            frontImageUrl={couponInfos[0].frontImageUrl}
+            data-index={index}
+            onClick={changeCurrentCafeIndex(index)}
+          />
+        ))}
+      </CouponListContainer>
+    </>
   );
 };
 

--- a/frontend/src/pages/CouponList/style.tsx
+++ b/frontend/src/pages/CouponList/style.tsx
@@ -5,10 +5,16 @@ interface StyledListProps {
   $isLast: boolean;
 }
 
+export const CafeName = styled.span`
+  font-size: 36px;
+  font-weight: 700;
+`;
+
 export const CouponListContainer = styled.div<StyledListProps>`
-  width: 500px;
-  height: 500px;
+  display: flex;
+  justify-content: center;
   position: relative;
+  height: 100vh;
 
   :nth-last-child(1) {
     transform: translateY(15px) scale(1.05);
@@ -32,14 +38,4 @@ export const CouponListContainer = styled.div<StyledListProps>`
   :nth-last-child(n + 4) {
     transform: translateY(-30px) scale(0.9);
   }
-`;
-
-export const Test = styled.div`
-  width: 270px;
-  height: 150px;
-  position: absolute;
-  top: 50%;
-  bottom: 50%;
-  transform: translate(50%, -50%);
-  transition: transform 0.1s;
 `;

--- a/frontend/src/pages/CouponList/style.tsx
+++ b/frontend/src/pages/CouponList/style.tsx
@@ -1,0 +1,45 @@
+import { css, styled } from 'styled-components';
+import { swap } from '../../style/keyframes';
+
+interface StyledListProps {
+  $isLast: boolean;
+}
+
+export const CouponListContainer = styled.div<StyledListProps>`
+  width: 500px;
+  height: 500px;
+  position: relative;
+
+  :nth-last-child(1) {
+    transform: translateY(15px) scale(1.05);
+    animation: ${({ $isLast }) =>
+      $isLast
+        ? css`
+            ${swap} 0.7s forwards
+          `
+        : 'none'};
+    cursor: pointer;
+    &:hover {
+      transform: scale(1.1);
+    }
+  }
+  :nth-last-child(2) {
+    transform: translateY(0px) scale(1);
+  }
+  :nth-last-child(3) {
+    transform: translateY(-15px) scale(0.95);
+  }
+  :nth-last-child(n + 4) {
+    transform: translateY(-30px) scale(0.9);
+  }
+`;
+
+export const Test = styled.div`
+  width: 270px;
+  height: 150px;
+  position: absolute;
+  top: 50%;
+  bottom: 50%;
+  transform: translate(50%, -50%);
+  transition: transform 0.1s;
+`;

--- a/frontend/src/style/keyframes.ts
+++ b/frontend/src/style/keyframes.ts
@@ -1,0 +1,12 @@
+import { keyframes } from 'styled-components';
+
+export const swap = keyframes`
+  50% {
+    transform: translateY(-200px) scale(0.55) rotate(-15deg);
+    animation-timing-function: ease-in;
+  }
+  100% {
+    transform: translateY(-45px) scale(0.85);
+    z-index: -1;
+  }
+`;


### PR DESCRIPTION
## 주요 변경사항
- 현재 쿠폰 리스트 부분만 구현되어있습니다.




![ezgif-3-bb35b073e4](https://github.com/woowacourse-teams/2023-stamp-crush/assets/62367797/e802a6cd-d390-4944-a052-8699c79436c5)



## 리뷰어에게...
레고와 페어프로그래밍하였습니다!

해당 페이지가 머지된 후에는 
추후에 고객모드 Header와, 레고가 만든 ProgressBar를 페이지에 넣어서 구현하면 될 듯합니다.

## 관련 이슈

closes #220 #205 

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [x] `milestone` 설정
