### PR TITLE
[BE] feat: 카페 정보 수정 API를 구현한다.

### DIFF
--- a/backend/src/main/java/com/stampcrush/backend/api/cafe/CafeApiController.java
+++ b/backend/src/main/java/com/stampcrush/backend/api/cafe/CafeApiController.java
@@ -1,11 +1,13 @@
 package com.stampcrush.backend.api.cafe;
 
 import com.stampcrush.backend.api.cafe.request.CafeCreateRequest;
+import com.stampcrush.backend.api.cafe.request.CafeUpdateRequest;
 import com.stampcrush.backend.api.cafe.response.CafeFindResponse;
 import com.stampcrush.backend.api.cafe.response.CafesFindResponse;
 import com.stampcrush.backend.application.cafe.CafeService;
 import com.stampcrush.backend.application.cafe.dto.CafeCreateDto;
 import com.stampcrush.backend.application.cafe.dto.CafeFindResultDto;
+import com.stampcrush.backend.application.cafe.dto.CafeUpdateDto;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -16,7 +18,7 @@ import java.util.List;
 
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("/api/cafes")
+@RequestMapping("/api/admin/cafes")
 public class CafeApiController {
 
     private final CafeService cafeService;
@@ -44,5 +46,21 @@ public class CafeApiController {
                 cafeCreateRequest.getBusinessRegistrationNumber());
         Long cafeId = cafeService.createCafe(cafeCreateDto);
         return ResponseEntity.created(URI.create("/cafes/" + cafeId)).build();
+    }
+
+    @PatchMapping("/{cafeId}")
+    ResponseEntity<Void> updateCafe(
+            @PathVariable Long cafeId,
+            @RequestBody @Valid CafeUpdateRequest cafeUpdateRequest
+    ) {
+        CafeUpdateDto cafeUpdateDto = new CafeUpdateDto(
+                cafeUpdateRequest.getOpenTime(),
+                cafeUpdateRequest.getCloseTime(),
+                cafeUpdateRequest.getTelephoneNumber(),
+                cafeUpdateRequest.getCafeImageUrl()
+        );
+
+        cafeService.updateCafeInfo(cafeUpdateDto, cafeId);
+        return ResponseEntity.ok().build();
     }
 }

--- a/backend/src/main/java/com/stampcrush/backend/api/cafe/CafeApiController.java
+++ b/backend/src/main/java/com/stampcrush/backend/api/cafe/CafeApiController.java
@@ -51,13 +51,13 @@ public class CafeApiController {
     @PatchMapping("/{cafeId}")
     ResponseEntity<Void> updateCafe(
             @PathVariable Long cafeId,
-            @RequestBody @Valid CafeUpdateRequest cafeUpdateRequest
+            @RequestBody @Valid CafeUpdateRequest request
     ) {
         CafeUpdateDto cafeUpdateDto = new CafeUpdateDto(
-                cafeUpdateRequest.getOpenTime(),
-                cafeUpdateRequest.getCloseTime(),
-                cafeUpdateRequest.getTelephoneNumber(),
-                cafeUpdateRequest.getCafeImageUrl()
+                request.getOpenTime(),
+                request.getCloseTime(),
+                request.getTelephoneNumber(),
+                request.getCafeImageUrl()
         );
 
         cafeService.updateCafeInfo(cafeUpdateDto, cafeId);

--- a/backend/src/main/java/com/stampcrush/backend/api/cafe/CafeApiController.java
+++ b/backend/src/main/java/com/stampcrush/backend/api/cafe/CafeApiController.java
@@ -53,12 +53,7 @@ public class CafeApiController {
             @PathVariable Long cafeId,
             @RequestBody @Valid CafeUpdateRequest request
     ) {
-        CafeUpdateDto cafeUpdateDto = new CafeUpdateDto(
-                request.getOpenTime(),
-                request.getCloseTime(),
-                request.getTelephoneNumber(),
-                request.getCafeImageUrl()
-        );
+        CafeUpdateDto cafeUpdateDto = request.toServiceDto();
 
         cafeService.updateCafeInfo(cafeUpdateDto, cafeId);
         return ResponseEntity.ok().build();

--- a/backend/src/main/java/com/stampcrush/backend/api/cafe/request/CafeUpdateRequest.java
+++ b/backend/src/main/java/com/stampcrush/backend/api/cafe/request/CafeUpdateRequest.java
@@ -1,0 +1,33 @@
+package com.stampcrush.backend.api.cafe.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalTime;
+
+import static lombok.AccessLevel.PROTECTED;
+
+@NoArgsConstructor(access = PROTECTED)
+@AllArgsConstructor
+@Getter
+public class CafeUpdateRequest {
+
+    @NotNull
+    @NotBlank
+    private LocalTime openTime;
+
+    @NotNull
+    @NotBlank
+    private LocalTime closeTime;
+
+    @NotNull
+    @NotBlank
+    private String telephoneNumber;
+
+    @NotNull
+    @NotBlank
+    private String cafeImageUrl;
+}

--- a/backend/src/main/java/com/stampcrush/backend/api/cafe/request/CafeUpdateRequest.java
+++ b/backend/src/main/java/com/stampcrush/backend/api/cafe/request/CafeUpdateRequest.java
@@ -1,5 +1,6 @@
 package com.stampcrush.backend.api.cafe.request;
 
+import com.stampcrush.backend.application.cafe.dto.CafeUpdateDto;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -20,4 +21,13 @@ public class CafeUpdateRequest {
     private String telephoneNumber;
 
     private String cafeImageUrl;
+
+    public CafeUpdateDto toServiceDto() {
+        return new CafeUpdateDto(
+                this.openTime,
+                this.closeTime,
+                this.telephoneNumber,
+                this.cafeImageUrl
+        );
+    }
 }

--- a/backend/src/main/java/com/stampcrush/backend/api/cafe/request/CafeUpdateRequest.java
+++ b/backend/src/main/java/com/stampcrush/backend/api/cafe/request/CafeUpdateRequest.java
@@ -1,7 +1,5 @@
 package com.stampcrush.backend.api.cafe.request;
 
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -15,19 +13,11 @@ import static lombok.AccessLevel.PROTECTED;
 @Getter
 public class CafeUpdateRequest {
 
-    @NotNull
-    @NotBlank
     private LocalTime openTime;
 
-    @NotNull
-    @NotBlank
     private LocalTime closeTime;
 
-    @NotNull
-    @NotBlank
     private String telephoneNumber;
 
-    @NotNull
-    @NotBlank
     private String cafeImageUrl;
 }

--- a/backend/src/main/java/com/stampcrush/backend/application/cafe/CafeService.java
+++ b/backend/src/main/java/com/stampcrush/backend/application/cafe/CafeService.java
@@ -107,7 +107,7 @@ public class CafeService {
     public void updateCafeInfo(CafeUpdateDto cafeUpdateDto, Long cafeId) {
         Cafe cafe = cafeRepository.findById(cafeId)
                 .orElseThrow(() -> new CafeNotFoundException("존재하지 않는 카페 입니다."));
-        cafe.update(
+        cafe.updateCafeAdditionalInformation(
                 cafeUpdateDto.getOpenTime(),
                 cafeUpdateDto.getCloseTime(),
                 cafeUpdateDto.getTelephoneNumber(),

--- a/backend/src/main/java/com/stampcrush/backend/application/cafe/CafeService.java
+++ b/backend/src/main/java/com/stampcrush/backend/application/cafe/CafeService.java
@@ -2,6 +2,7 @@ package com.stampcrush.backend.application.cafe;
 
 import com.stampcrush.backend.application.cafe.dto.CafeCreateDto;
 import com.stampcrush.backend.application.cafe.dto.CafeFindResultDto;
+import com.stampcrush.backend.application.cafe.dto.CafeUpdateDto;
 import com.stampcrush.backend.entity.cafe.Cafe;
 import com.stampcrush.backend.entity.cafe.CafeCouponDesign;
 import com.stampcrush.backend.entity.cafe.CafePolicy;
@@ -11,6 +12,7 @@ import com.stampcrush.backend.entity.sample.SampleFrontImage;
 import com.stampcrush.backend.entity.sample.SampleStampCoordinate;
 import com.stampcrush.backend.entity.sample.SampleStampImage;
 import com.stampcrush.backend.entity.user.Owner;
+import com.stampcrush.backend.exception.CafeNotFoundException;
 import com.stampcrush.backend.exception.OwnerNotFoundException;
 import com.stampcrush.backend.repository.cafe.CafeCouponDesignRepository;
 import com.stampcrush.backend.repository.cafe.CafePolicyRepository;
@@ -100,5 +102,16 @@ public class CafeService {
         return cafes.stream()
                 .map(CafeFindResultDto::from)
                 .toList();
+    }
+
+    public void updateCafeInfo(CafeUpdateDto cafeUpdateDto, Long cafeId) {
+        Cafe cafe = cafeRepository.findById(cafeId)
+                .orElseThrow(() -> new CafeNotFoundException("존재하지 않는 카페 입니다."));
+        cafe.update(
+                cafeUpdateDto.getOpenTime(),
+                cafeUpdateDto.getCloseTime(),
+                cafeUpdateDto.getTelephoneNumber(),
+                cafeUpdateDto.getCafeImageUrl()
+        );
     }
 }

--- a/backend/src/main/java/com/stampcrush/backend/application/cafe/dto/CafeUpdateDto.java
+++ b/backend/src/main/java/com/stampcrush/backend/application/cafe/dto/CafeUpdateDto.java
@@ -10,9 +10,9 @@ import java.time.LocalTime;
 @AllArgsConstructor
 public class CafeUpdateDto {
 
-    private LocalTime openTime;
-    private LocalTime closeTime;
-    private String telephoneNumber;
-    private String cafeImageUrl;
+    private final LocalTime openTime;
+    private final LocalTime closeTime;
+    private final String telephoneNumber;
+    private final String cafeImageUrl;
     // introduction이 현재 Cafe엔티티에 없음
 }

--- a/backend/src/main/java/com/stampcrush/backend/application/cafe/dto/CafeUpdateDto.java
+++ b/backend/src/main/java/com/stampcrush/backend/application/cafe/dto/CafeUpdateDto.java
@@ -1,0 +1,18 @@
+package com.stampcrush.backend.application.cafe.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalTime;
+
+
+@Getter
+@AllArgsConstructor
+public class CafeUpdateDto {
+
+    private LocalTime openTime;
+    private LocalTime closeTime;
+    private String telephoneNumber;
+    private String cafeImageUrl;
+    // introduction이 현재 Cafe엔티티에 없음
+}

--- a/backend/src/main/java/com/stampcrush/backend/entity/cafe/Cafe.java
+++ b/backend/src/main/java/com/stampcrush/backend/entity/cafe/Cafe.java
@@ -64,4 +64,11 @@ public class Cafe extends BaseDate {
 
     protected Cafe() {
     }
+
+    public void update(LocalTime openTime, LocalTime closeTime, String telephoneNumber, String cafeImageUrl) {
+        this.openTime = openTime;
+        this.closeTime = closeTime;
+        this.telephoneNumber = telephoneNumber;
+        this.cafeImageUrl = cafeImageUrl;
+    }
 }

--- a/backend/src/main/java/com/stampcrush/backend/entity/cafe/Cafe.java
+++ b/backend/src/main/java/com/stampcrush/backend/entity/cafe/Cafe.java
@@ -65,7 +65,7 @@ public class Cafe extends BaseDate {
     protected Cafe() {
     }
 
-    public void update(LocalTime openTime, LocalTime closeTime, String telephoneNumber, String cafeImageUrl) {
+    public void updateCafeAdditionalInformation(LocalTime openTime, LocalTime closeTime, String telephoneNumber, String cafeImageUrl) {
         this.openTime = openTime;
         this.closeTime = closeTime;
         this.telephoneNumber = telephoneNumber;

--- a/backend/src/test/java/com/stampcrush/backend/application/cafe/CafeServiceTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/application/cafe/CafeServiceTest.java
@@ -34,6 +34,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 @Transactional
 @SpringBootTest
@@ -232,7 +233,12 @@ public class CafeServiceTest {
         );
 
         // then
-        assertThat(hadiCafe.getCafeImageUrl()).isEqualTo(cafeUpdateDto.getCafeImageUrl());
+        assertAll(
+                () -> assertThat(hadiCafe.getCafeImageUrl()).isEqualTo(cafeUpdateDto.getCafeImageUrl()),
+                () -> assertThat(hadiCafe.getTelephoneNumber()).isEqualTo(cafeUpdateDto.getTelephoneNumber()),
+                () -> assertThat(hadiCafe.getOpenTime()).isEqualTo(cafeUpdateDto.getOpenTime()),
+                () -> assertThat(hadiCafe.getCloseTime()).isEqualTo(cafeUpdateDto.getCloseTime())
+        );
     }
 
     private Cafe createCafe() {

--- a/backend/src/test/java/com/stampcrush/backend/application/cafe/CafeServiceTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/application/cafe/CafeServiceTest.java
@@ -225,7 +225,7 @@ public class CafeServiceTest {
                 "99999",
                 "image"
         );
-        hadiCafe.update(
+        hadiCafe.updateCafeAdditionalInformation(
                 cafeUpdateDto.getOpenTime(),
                 cafeUpdateDto.getCloseTime(),
                 cafeUpdateDto.getTelephoneNumber(),

--- a/backend/src/test/java/com/stampcrush/backend/application/cafe/CafeServiceTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/application/cafe/CafeServiceTest.java
@@ -1,6 +1,7 @@
 package com.stampcrush.backend.application.cafe;
 
 import com.stampcrush.backend.application.cafe.dto.CafeCreateDto;
+import com.stampcrush.backend.application.cafe.dto.CafeUpdateDto;
 import com.stampcrush.backend.entity.cafe.Cafe;
 import com.stampcrush.backend.entity.cafe.CafeCouponDesign;
 import com.stampcrush.backend.entity.cafe.CafePolicy;
@@ -211,8 +212,31 @@ public class CafeServiceTest {
         assertThat(cafes.size()).isEqualTo(expectedSize);
     }
 
-    private void createCafe() {
-        cafeRepository.save(
+    @Test
+    void 카페정보를_수정한다() {
+        // given
+        Cafe hadiCafe = createCafe();
+
+        // when
+        CafeUpdateDto cafeUpdateDto = new CafeUpdateDto(
+                LocalTime.of(12, 30),
+                LocalTime.of(18, 30),
+                "99999",
+                "image"
+        );
+        hadiCafe.update(
+                cafeUpdateDto.getOpenTime(),
+                cafeUpdateDto.getCloseTime(),
+                cafeUpdateDto.getTelephoneNumber(),
+                cafeUpdateDto.getCafeImageUrl()
+        );
+
+        // then
+        assertThat(hadiCafe.getCafeImageUrl()).isEqualTo(cafeUpdateDto.getCafeImageUrl());
+    }
+
+    private Cafe createCafe() {
+        return cafeRepository.save(
                 new Cafe(
                         "하디까페",
                         LocalTime.of(12, 30),


### PR DESCRIPTION
## 주요 변경사항

- cafe controller, service에 기능 관련된 코드가 추가 됐습니다.
- update는 변경감지를 통해 진행했고, Cafe엔티티 안에 update메서드를 만들었습니다.
- update메서드에서 dto참조는 일부러 안했습니다! 도메인이 dto를 참조하는게 좋다고 생각하지 않기 때문입니다.

## 리뷰어에게...

- 제가 구현한 API스펙의 introduction이 현재 Cafe엔티티에는 없습니다. 추가를 할까 하다가 테이블을 건드리는 일이라 정확한 진행상황을 모르는 제가 추가하기엔 애매하다고 판단되어 우선 introduction을 빼고 진행했습니다.

- 인수 테스트 역시 템플릿 등 인수 테스트를 어떻게 진행하기로 했는지 파악하지 못하고 있기 때문에, 생략했습니다. 이 부분은 파악하는대로 제가 코드 작성하겠습니다.

## 관련 이슈

- openTime, closeTime관련 유효성 검증을 어떤 방식으로 하는게 좋을지 얘기해보면 좋을 것 같아요. 제가 생각한 유효성 검증이 필요한 것은 1. Null인지 2. hour(0~24), minute(0~60)의 범위 검증 3. closeTime이 openTime보다 늦는지. 이 정도가 있는 것 같아요. 이걸 커스텀 어노테이션으로 할 수도 있고, 생성자 안에서 할 수도 있을 것 같은데 어디서 하는게 괜찮다고 생각하시나요?

정해지는대로 코드 치겠습니다!

유효성 검증과, 인수 테스트를 제외하니 코드는 얼마 안되네요.. 배려해주셔서 감사합니다 ㅎㅎ
내일 일과시간에 리뷰 해주시면 예비군 끝나고 수정하기 위해서 미리 PR올리겠습니다! 

closes #231 

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [x] `milestone` 설정
