### PR TITLE
[BE] fix: Coupon 엔티티 deleted 기본값 Boolean.TRUE 삭제

### DIFF
--- a/backend/src/main/java/com/stampcrush/backend/entity/coupon/Coupon.java
+++ b/backend/src/main/java/com/stampcrush/backend/entity/coupon/Coupon.java
@@ -31,7 +31,7 @@ public class Coupon extends BaseDate {
     @Enumerated(EnumType.STRING)
     private CouponStatus status = CouponStatus.ACCUMULATING;
 
-    private Boolean deleted = Boolean.TRUE;
+    private Boolean deleted;
 
     @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "customer_id")


### PR DESCRIPTION
## 주요 변경사항


![image](https://github.com/woowacourse-teams/2023-stamp-crush/assets/107979804/b157ff1d-e9e0-4004-9025-bb1dd24a5e12)

![image](https://github.com/woowacourse-teams/2023-stamp-crush/assets/107979804/b0779436-4de0-4f9b-9621-bc285cac16fc)


## 리뷰어에게...

## 관련 이슈

closes #245 

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [x] `milestone` 설정
