### PR TITLE
[BE] refactor: PersistenceConfig 추가하고 JpaAuditing 어노테이션 이동

### DIFF
--- a/backend/src/main/java/com/stampcrush/backend/BackendApplication.java
+++ b/backend/src/main/java/com/stampcrush/backend/BackendApplication.java
@@ -2,10 +2,8 @@ package com.stampcrush.backend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
-@EnableJpaAuditing
 public class BackendApplication {
 
     public static void main(String[] args) {

--- a/backend/src/main/java/com/stampcrush/backend/config/PersistenceConfig.java
+++ b/backend/src/main/java/com/stampcrush/backend/config/PersistenceConfig.java
@@ -3,7 +3,7 @@ package com.stampcrush.backend.config;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-@Configuration
+@Configuration(proxyBeanMethods = false)
 @EnableJpaAuditing
 public class PersistenceConfig {
 }

--- a/backend/src/main/java/com/stampcrush/backend/config/PersistenceConfig.java
+++ b/backend/src/main/java/com/stampcrush/backend/config/PersistenceConfig.java
@@ -1,0 +1,9 @@
+package com.stampcrush.backend.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class PersistenceConfig {
+}


### PR DESCRIPTION
## 주요 변경사항

- SpringBootApplication 에 붙어있던 @EnableJpaAuditing 어노테이션을 따로 Configuration 클래스를 만들어서 분리했습니다

## 리뷰어에게...

- [분리한 이유 참고 글](https://docs.spring.io/spring-boot/docs/current/reference/html/features.html#features.testing.spring-boot-applications.user-configuration-and-slicing)
    - SpringBootApplication 이 테스트의 소스 구성이기 때문에 모든 슬라이스 테스트는 JpaAuditing 을 활성화하려고 시도합니다.         
    - 그래서 @WebMvcTest 를 실행하면 Jpa 관련한 빈이 로드가 되지 않기 때문에 테스트가 실행이 되지 않습니다
- 결론
    - 테스트 슬라이스는 @Configuration 클래스를 스캐닝하지 않기 때문에 원활한 슬라이스 테스트를 위해 @SpringBootApplication와 @EnableJpaAuditing를 분리했습니다

## 관련 이슈

closes #260 

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [x] `milestone` 설정
