### PR TITLE
[BE] refactor: 스탬프 발급 코드 리팩터링

### DIFF
--- a/backend/src/main/java/com/stampcrush/backend/application/coupon/CouponService.java
+++ b/backend/src/main/java/com/stampcrush/backend/application/coupon/CouponService.java
@@ -159,7 +159,7 @@ public class CouponService {
             throw new IllegalArgumentException();
         }
 
-        Integer earningStampCount = stampCreateDto.getEarningStampCount();
+        int earningStampCount = stampCreateDto.getEarningStampCount();
 
         if (coupon.isLessThanMaxStampAfterAccumulateStamp(earningStampCount)) {
             coupon.accumulate(earningStampCount);
@@ -171,7 +171,7 @@ public class CouponService {
             return;
         }
 
-        int restStampCount = coupon.getCouponMaxStampCount() - coupon.getStampCount();
+        int restStampCount = coupon.calculateRestStampCountForReward();
         for (int i = 0; i < restStampCount; i++) {
             coupon.accumulateEarningStamp(1);
         }

--- a/backend/src/main/java/com/stampcrush/backend/application/coupon/CouponService.java
+++ b/backend/src/main/java/com/stampcrush/backend/application/coupon/CouponService.java
@@ -106,10 +106,8 @@ public class CouponService {
                 .orElseThrow(IllegalArgumentException::new);
         Cafe cafe = cafeRepository.findById(cafeId)
                 .orElseThrow(IllegalArgumentException::new);
-        CafePolicy cafePolicy = cafePolicyRepository.findByCafe(cafe)
-                .orElseThrow(IllegalArgumentException::new);
-        CafeCouponDesign cafeCouponDesign = cafeCouponDesignRepository.findByCafe(cafe)
-                .orElseThrow(IllegalArgumentException::new);
+        CafePolicy cafePolicy = findCafePolicy(cafe);
+        CafeCouponDesign cafeCouponDesign = findCafeCouponDesign(cafe);
         List<Coupon> existCoupons = couponRepository.findByCafeAndCustomerAndStatus(cafe, customer, CouponStatus.ACCUMULATING);
         if (!existCoupons.isEmpty()) {
             for (Coupon coupon : existCoupons) {
@@ -134,22 +132,14 @@ public class CouponService {
     }
 
     public void createStamp(StampCreateDto stampCreateDto) {
-        Owner owner = ownerRepository.findById(stampCreateDto.getOwnerId())
-                .orElseThrow(IllegalArgumentException::new);
-        Customer customer = customerRepository.findById(stampCreateDto.getCustomerId())
-                .orElseThrow(IllegalArgumentException::new);
-
+        Owner owner = findOwner(stampCreateDto);
+        Customer customer = findCustomer(stampCreateDto);
         Cafe cafe = findCafe(owner);
-
-        CafePolicy cafePolicy = cafePolicyRepository.findByCafe(cafe)
-                .orElseThrow(IllegalArgumentException::new);
-        CafeCouponDesign cafeCouponDesign = cafeCouponDesignRepository.findByCafe(cafe)
-                .orElseThrow(IllegalArgumentException::new);
-
+        CafePolicy cafePolicy = findCafePolicy(cafe);
+        CafeCouponDesign cafeCouponDesign = findCafeCouponDesign(cafe);
         Coupon coupon = findCoupon(stampCreateDto, customer, cafe);
 
         int earningStampCount = stampCreateDto.getEarningStampCount();
-
         if (coupon.isLessThanMaxStampAfterAccumulateStamp(earningStampCount)) {
             coupon.accumulate(earningStampCount);
             return;
@@ -165,6 +155,30 @@ public class CouponService {
         int restStamp = earningStampCount - restStampCountForReward;
         makeRewardCoupons(customer, cafe, cafePolicy, cafeCouponDesign, coupon, restStamp);
         issueAccumulatingCoupon(customer, cafe, cafePolicy, cafeCouponDesign, restStamp);
+    }
+
+    private CafeCouponDesign findCafeCouponDesign(Cafe cafe) {
+        CafeCouponDesign cafeCouponDesign = cafeCouponDesignRepository.findByCafe(cafe)
+                .orElseThrow(IllegalArgumentException::new);
+        return cafeCouponDesign;
+    }
+
+    private CafePolicy findCafePolicy(Cafe cafe) {
+        CafePolicy cafePolicy = cafePolicyRepository.findByCafe(cafe)
+                .orElseThrow(IllegalArgumentException::new);
+        return cafePolicy;
+    }
+
+    private Customer findCustomer(StampCreateDto stampCreateDto) {
+        Customer customer = customerRepository.findById(stampCreateDto.getCustomerId())
+                .orElseThrow(IllegalArgumentException::new);
+        return customer;
+    }
+
+    private Owner findOwner(StampCreateDto stampCreateDto) {
+        Owner owner = ownerRepository.findById(stampCreateDto.getOwnerId())
+                .orElseThrow(IllegalArgumentException::new);
+        return owner;
     }
 
     private Cafe findCafe(Owner owner) {

--- a/backend/src/main/java/com/stampcrush/backend/application/coupon/CouponService.java
+++ b/backend/src/main/java/com/stampcrush/backend/application/coupon/CouponService.java
@@ -148,7 +148,6 @@ public class CouponService {
             accumulateMaxStampAndMakeReward(customer, cafe, coupon, earningStampCount);
             return;
         }
-
         int restStampCountForReward = coupon.calculateRestStampCountForReward();
         accumulateMaxStampAndMakeReward(customer, cafe, coupon, restStampCountForReward);
 
@@ -158,27 +157,23 @@ public class CouponService {
     }
 
     private CafeCouponDesign findCafeCouponDesign(Cafe cafe) {
-        CafeCouponDesign cafeCouponDesign = cafeCouponDesignRepository.findByCafe(cafe)
+        return cafeCouponDesignRepository.findByCafe(cafe)
                 .orElseThrow(IllegalArgumentException::new);
-        return cafeCouponDesign;
     }
 
     private CafePolicy findCafePolicy(Cafe cafe) {
-        CafePolicy cafePolicy = cafePolicyRepository.findByCafe(cafe)
+        return cafePolicyRepository.findByCafe(cafe)
                 .orElseThrow(IllegalArgumentException::new);
-        return cafePolicy;
     }
 
     private Customer findCustomer(StampCreateDto stampCreateDto) {
-        Customer customer = customerRepository.findById(stampCreateDto.getCustomerId())
+        return customerRepository.findById(stampCreateDto.getCustomerId())
                 .orElseThrow(IllegalArgumentException::new);
-        return customer;
     }
 
     private Owner findOwner(StampCreateDto stampCreateDto) {
-        Owner owner = ownerRepository.findById(stampCreateDto.getOwnerId())
+        return ownerRepository.findById(stampCreateDto.getOwnerId())
                 .orElseThrow(IllegalArgumentException::new);
-        return owner;
     }
 
     private Cafe findCafe(Owner owner) {
@@ -212,8 +207,8 @@ public class CouponService {
         accumulatingCoupon.accumulate(accumulatingStampCount);
     }
 
-    private void makeRewardCoupons(Customer customer, Cafe cafe, CafePolicy cafePolicy, CafeCouponDesign cafeCouponDesign, Coupon coupon, int earningStampCount) {
-        int rewardCouponCount = cafePolicy.calculateRewardCouponCount(earningStampCount);
+    private void makeRewardCoupons(Customer customer, Cafe cafe, CafePolicy cafePolicy, CafeCouponDesign cafeCouponDesign, Coupon coupon, int restStamp) {
+        int rewardCouponCount = cafePolicy.calculateRewardCouponCount(restStamp);
         for (int i = 0; i < rewardCouponCount; i++) {
             Coupon rewardCoupon = issueCoupon(customer, cafe, cafePolicy, cafeCouponDesign);
             rewardCoupon.accumulateMaxStamp();

--- a/backend/src/main/java/com/stampcrush/backend/entity/cafe/CafePolicy.java
+++ b/backend/src/main/java/com/stampcrush/backend/entity/cafe/CafePolicy.java
@@ -54,4 +54,8 @@ public class CafePolicy extends BaseDate {
     public CouponPolicy copy() {
         return new CouponPolicy(maxStampCount, reward, expirePeriod);
     }
+
+    public int calculateRewardCouponCount(int earningStampCount) {
+        return earningStampCount / maxStampCount;
+    }
 }

--- a/backend/src/main/java/com/stampcrush/backend/entity/coupon/Coupon.java
+++ b/backend/src/main/java/com/stampcrush/backend/entity/coupon/Coupon.java
@@ -147,6 +147,10 @@ public class Coupon extends BaseDate {
         return this.stamps.size() + earningStampCount == couponPolicy.getMaxStampCount();
     }
 
+    public int calculateRestStampCountForReward() {
+        return couponPolicy.getMaxStampCount() - this.stamps.size();
+    }
+
     public String getRewardName() {
         return couponPolicy.getRewardName();
     }

--- a/backend/src/main/java/com/stampcrush/backend/entity/coupon/Coupon.java
+++ b/backend/src/main/java/com/stampcrush/backend/entity/coupon/Coupon.java
@@ -136,13 +136,6 @@ public class Coupon extends BaseDate {
         return this.stamps.size() + earningStampCount < couponPolicy.getMaxStampCount();
     }
 
-    public void accumulateEarningStamp(int earningStampCount) {
-        for (int i = 0; i < earningStampCount; i++) {
-            Stamp stamp = new Stamp();
-            stamp.registerCoupon(this);
-        }
-    }
-
     public boolean isSameMaxStampAfterAccumulateStamp(int earningStampCount) {
         return this.stamps.size() + earningStampCount == couponPolicy.getMaxStampCount();
     }

--- a/backend/src/main/java/com/stampcrush/backend/entity/coupon/Coupon.java
+++ b/backend/src/main/java/com/stampcrush/backend/entity/coupon/Coupon.java
@@ -31,7 +31,7 @@ public class Coupon extends BaseDate {
     @Enumerated(EnumType.STRING)
     private CouponStatus status = CouponStatus.ACCUMULATING;
 
-    private Boolean deleted;
+    private Boolean deleted = Boolean.FALSE;
 
     @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "customer_id")
@@ -103,12 +103,22 @@ public class Coupon extends BaseDate {
         return !this.customer.equals(customer) || !this.cafe.equals(cafe);
     }
 
-    public void accumulate() {
-        Stamp stamp = new Stamp();
-        stamp.registerCoupon(this);
+    public void accumulate(int earningStampCount) {
+        for (int i = 0; i < earningStampCount; i++) {
+            Stamp stamp = new Stamp();
+            stamp.registerCoupon(this);
+        }
         if (couponPolicy.isSameMaxStampCount(stamps.size())) {
             status = CouponStatus.REWARDED;
         }
+    }
+
+    public void accumulateMaxStamp() {
+        for (int i = 0; i < couponPolicy.getMaxStampCount(); i++) {
+            Stamp stamp = new Stamp();
+            stamp.registerCoupon(this);
+        }
+        status = CouponStatus.REWARDED;
     }
 
     public int getCouponMaxStampCount() {
@@ -120,6 +130,21 @@ public class Coupon extends BaseDate {
             return couponPolicy.getMaxStampCount();
         }
         return 0;
+    }
+
+    public boolean isLessThanMaxStampAfterAccumulateStamp(int earningStampCount) {
+        return this.stamps.size() + earningStampCount < couponPolicy.getMaxStampCount();
+    }
+
+    public void accumulateEarningStamp(int earningStampCount) {
+        for (int i = 0; i < earningStampCount; i++) {
+            Stamp stamp = new Stamp();
+            stamp.registerCoupon(this);
+        }
+    }
+
+    public boolean isSameMaxStampAfterAccumulateStamp(int earningStampCount) {
+        return this.stamps.size() + earningStampCount == couponPolicy.getMaxStampCount();
     }
 
     public String getRewardName() {

--- a/backend/src/test/java/com/stampcrush/backend/entity/cafe/CafePolicyTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/entity/cafe/CafePolicyTest.java
@@ -1,0 +1,17 @@
+package com.stampcrush.backend.entity.cafe;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class CafePolicyTest {
+
+    @Test
+    void 보상_스탬프_개수를_토대로_스탬프에_대해_몇_개의_보상이_발급되는지_계산한다() {
+        // given, when
+        CafePolicy cafePolicy = new CafePolicy(10, "reward", 6, false, null);
+        int rewardCouponCount = cafePolicy.calculateRewardCouponCount(76);
+
+        // then
+        Assertions.assertThat(rewardCouponCount).isEqualTo(7);
+    }
+}

--- a/backend/src/test/java/com/stampcrush/backend/entity/coupon/CouponTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/entity/coupon/CouponTest.java
@@ -17,7 +17,7 @@ class CouponTest {
     @Test
     void 쿠폰이_현재_USING_상태인지_확인한다() {
         // given, when
-        Coupon coupon = new Coupon(LocalDate.EPOCH, TemporaryCustomer.from( "01012345678"), new Cafe(
+        Coupon coupon = new Coupon(LocalDate.EPOCH, TemporaryCustomer.from("01012345678"), new Cafe(
                 "하디까페",
                 LocalTime.of(12, 30),
                 LocalTime.of(18, 30),
@@ -75,7 +75,7 @@ class CouponTest {
         );
 
         // when
-        coupon.accumulate();
+        coupon.accumulate(1);
 
         // then
         assertThat(coupon.getStatus()).isSameAs(CouponStatus.ACCUMULATING);
@@ -85,7 +85,7 @@ class CouponTest {
     @Test
     void 스탬프를_적립하고_최대_스탬프_개수와_같아지면_쿠폰_상태가_REWARDED가_된다() {
         // given
-        Coupon coupon = new Coupon(LocalDate.EPOCH, TemporaryCustomer.from( "01012345678"), new Cafe(
+        Coupon coupon = new Coupon(LocalDate.EPOCH, TemporaryCustomer.from("01012345678"), new Cafe(
                 "하디까페",
                 LocalTime.of(12, 30),
                 LocalTime.of(18, 30),
@@ -98,8 +98,31 @@ class CouponTest {
         );
 
         // when
-        coupon.accumulate();
-        coupon.accumulate();
+        coupon.accumulate(2);
+
+        // then
+        assertThat(coupon.getStatus()).isSameAs(CouponStatus.REWARDED);
+        assertThat(coupon.getStampCount()).isEqualTo(2);
+    }
+
+    @Test
+    void 스탬프를_적립하고_최대_스탬프_개수와_같아지면_쿠폰_상태가_REWARDED가_된다1() {
+        // given
+        Coupon coupon = new Coupon(LocalDate.EPOCH, TemporaryCustomer.from("01012345678"), new Cafe(
+                "하디까페",
+                LocalTime.of(12, 30),
+                LocalTime.of(18, 30),
+                "0211111111",
+                "http://www.cafeImage.com",
+                "잠실동12길",
+                "14층",
+                "11111111",
+                new Owner("이름", "아이디", "비번", "01012345678")), new CouponDesign(), new CouponPolicy(2, "짱", 10)
+        );
+
+        // when
+        coupon.accumulate(2);
+//        coupon.accumulate();
 
         // then
         assertThat(coupon.getStatus()).isSameAs(CouponStatus.REWARDED);

--- a/backend/src/test/java/com/stampcrush/backend/entity/coupon/CouponTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/entity/coupon/CouponTest.java
@@ -122,10 +122,33 @@ class CouponTest {
 
         // when
         coupon.accumulate(2);
-//        coupon.accumulate();
 
         // then
         assertThat(coupon.getStatus()).isSameAs(CouponStatus.REWARDED);
         assertThat(coupon.getStampCount()).isEqualTo(2);
+    }
+
+    @Test
+    void 보상까지_남은_스탬프_개수를_계산한다() {
+        // given
+        Coupon coupon = new Coupon(LocalDate.EPOCH, TemporaryCustomer.from("01012345678"), new Cafe(
+                "하디까페",
+                LocalTime.of(12, 30),
+                LocalTime.of(18, 30),
+                "0211111111",
+                "http://www.cafeImage.com",
+                "잠실동12길",
+                "14층",
+                "11111111",
+                new Owner("이름", "아이디", "비번", "01012345678")), new CouponDesign(), new CouponPolicy(10, "짱", 10)
+        );
+
+        // when
+        coupon.accumulate(3);
+        int restStampCount = coupon.calculateRestStampCountForReward();
+
+        // then
+        assertThat(restStampCount).isEqualTo(7);
+
     }
 }

--- a/backend/src/test/java/com/stampcrush/backend/entity/coupon/CouponTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/entity/coupon/CouponTest.java
@@ -152,7 +152,7 @@ class CouponTest {
     }
 
     @Test
-    void 추가적으로_스탬프_적립_시_찍힌_스탬프_합이_보상_개수보다_적으면_true다() {
+    void 스탬프_적립_시_찍힌_스탬프_합이_보상_개수보다_적으면_true다() {
         // given
         Coupon coupon = new Coupon(LocalDate.EPOCH, TemporaryCustomer.from("01012345678"), new Cafe(
                 "하디까페",
@@ -171,6 +171,27 @@ class CouponTest {
 
         // then
         assertThat(coupon.isLessThanMaxStampAfterAccumulateStamp(2)).isTrue();
+    }
 
+    @Test
+    void 스탬프_적립_시_찍힌_스탬프_합이_보상_개수와_같으면_true다() {
+        // given
+        Coupon coupon = new Coupon(LocalDate.EPOCH, TemporaryCustomer.from("01012345678"), new Cafe(
+                "하디까페",
+                LocalTime.of(12, 30),
+                LocalTime.of(18, 30),
+                "0211111111",
+                "http://www.cafeImage.com",
+                "잠실동12길",
+                "14층",
+                "11111111",
+                new Owner("이름", "아이디", "비번", "01012345678")), new CouponDesign(), new CouponPolicy(10, "짱", 10)
+        );
+
+        // when
+        coupon.accumulate(7);
+
+        // then
+        assertThat(coupon.isSameMaxStampAfterAccumulateStamp(3)).isTrue();
     }
 }

--- a/backend/src/test/java/com/stampcrush/backend/entity/coupon/CouponTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/entity/coupon/CouponTest.java
@@ -149,6 +149,28 @@ class CouponTest {
 
         // then
         assertThat(restStampCount).isEqualTo(7);
+    }
+
+    @Test
+    void 추가적으로_스탬프_적립_시_찍힌_스탬프_합이_보상_개수보다_적으면_true다() {
+        // given
+        Coupon coupon = new Coupon(LocalDate.EPOCH, TemporaryCustomer.from("01012345678"), new Cafe(
+                "하디까페",
+                LocalTime.of(12, 30),
+                LocalTime.of(18, 30),
+                "0211111111",
+                "http://www.cafeImage.com",
+                "잠실동12길",
+                "14층",
+                "11111111",
+                new Owner("이름", "아이디", "비번", "01012345678")), new CouponDesign(), new CouponPolicy(10, "짱", 10)
+        );
+
+        // when
+        coupon.accumulate(7);
+
+        // then
+        assertThat(coupon.isLessThanMaxStampAfterAccumulateStamp(2)).isTrue();
 
     }
 }

--- a/backend/src/test/java/com/stampcrush/backend/repository/coupon/CouponRepositoryTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/repository/coupon/CouponRepositoryTest.java
@@ -12,7 +12,6 @@ import com.stampcrush.backend.repository.user.TemporaryCustomerRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
 import java.time.LocalDate;
@@ -192,7 +191,6 @@ class CouponRepositoryTest {
         assertThat(expiredDate).isEqualTo(expected);
     }
 
-    // 첫 방문일자 구하기 위한 기능
     @Test
     void 쿠폰들의_createdAt을_비교한다() {
         // given, when


### PR DESCRIPTION
## 주요 변경사항

- CouponService의 createStamp메서드 로직을 while -> if문을 통한 분기로 코드 수정했습니다.
- 기존 쿠폰에 스탬프 찍혀있을 때 스탬프 적립하는 테스트 상황 추가했습니다.

## 리뷰어에게...

- createStamp에서 고려한 상황은 아래와 같습니다.
1. 새롭게 찍은 스탬프 + 기존 스탬프 < 보상 스탬프 개수 
2. 새롭게 찍은 스탬프 + 기존 스탬프 == 보상 스탬프 개수 
3. 새롭게 찍은 스탬프 + 기존 스탬프 > 보상 스탬프 개수
이 순서대로 if문으로 분기 했습니다.

- Coupon, Customer등등을 조회하는 `repo.findById().orElseThrow`가 너무 많아지면서 가독성이 안좋아지더라구요. 그래서 createStamp에서는 orElseThrow만 있는 것도 별도의 private메서드로 분리했습니다!

- 전에 깃짱이 말한 CouponRepositoryTest의 `쿠폰들의_createdAt을_비교한다`를 repository에 작성한 이유가 생각이 났어요. createdAt은 repo를 통해 save될 때 생성이 되기 때문에 어쩔 수 없이 repositoryTest에 넣었던 기억이 있습니다.

## 관련 이슈

closes #259 

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [x] `milestone` 설정
