### PR TITLE
[BE] feat: 카페 즐겨찾기 등록 및 해제 기능을 구현한다.

### DIFF
--- a/backend/src/main/java/com/stampcrush/backend/api/favorites/FavoritesController.java
+++ b/backend/src/main/java/com/stampcrush/backend/api/favorites/FavoritesController.java
@@ -1,0 +1,21 @@
+package com.stampcrush.backend.api.favorites;
+
+import com.stampcrush.backend.api.favorites.request.FavoritesUpdateRequest;
+import com.stampcrush.backend.application.favorites.FavoritesService;
+import com.stampcrush.backend.entity.user.Customer;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api")
+public class FavoritesController {
+
+    public final FavoritesService favoritesService;
+
+    @PostMapping("/cafes/{cafeId}/favorites")
+    public void updateFavorites(Customer customer, @PathVariable Long cafeId, @Valid @RequestBody FavoritesUpdateRequest favoritesUpdateRequest) {
+        favoritesService.changeFavorites(customer, cafeId, favoritesUpdateRequest.getIsFavorites());
+    }
+}

--- a/backend/src/main/java/com/stampcrush/backend/api/favorites/FavoritesController.java
+++ b/backend/src/main/java/com/stampcrush/backend/api/favorites/FavoritesController.java
@@ -5,6 +5,7 @@ import com.stampcrush.backend.application.favorites.FavoritesService;
 import com.stampcrush.backend.entity.user.Customer;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
@@ -15,7 +16,8 @@ public class FavoritesController {
     public final FavoritesService favoritesService;
 
     @PostMapping("/cafes/{cafeId}/favorites")
-    public void updateFavorites(Customer customer, @PathVariable Long cafeId, @Valid @RequestBody FavoritesUpdateRequest favoritesUpdateRequest) {
+    public ResponseEntity<Void> updateFavorites(Customer customer, @PathVariable Long cafeId, @Valid @RequestBody FavoritesUpdateRequest favoritesUpdateRequest) {
         favoritesService.changeFavorites(customer, cafeId, favoritesUpdateRequest.getIsFavorites());
+        return ResponseEntity.ok().build();
     }
 }

--- a/backend/src/main/java/com/stampcrush/backend/api/favorites/request/FavoritesUpdateRequest.java
+++ b/backend/src/main/java/com/stampcrush/backend/api/favorites/request/FavoritesUpdateRequest.java
@@ -1,0 +1,15 @@
+package com.stampcrush.backend.api.favorites.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class FavoritesUpdateRequest {
+
+    @NotNull
+    private Boolean isFavorites;
+}

--- a/backend/src/main/java/com/stampcrush/backend/application/favorites/FavoritesService.java
+++ b/backend/src/main/java/com/stampcrush/backend/application/favorites/FavoritesService.java
@@ -1,0 +1,33 @@
+package com.stampcrush.backend.application.favorites;
+
+import com.stampcrush.backend.entity.cafe.Cafe;
+import com.stampcrush.backend.entity.favorites.Favorites;
+import com.stampcrush.backend.entity.user.Customer;
+import com.stampcrush.backend.exception.CafeNotFoundException;
+import com.stampcrush.backend.repository.cafe.CafeRepository;
+import com.stampcrush.backend.repository.favorites.FavoritesRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class FavoritesService {
+
+    private final FavoritesRepository favoritesRepository;
+    private final CafeRepository cafeRepository;
+
+    public void changeFavorites(Customer customer, Long cafeId, Boolean isFavorites) {
+        Cafe cafe = cafeRepository.findById(cafeId)
+                .orElseThrow(() -> new CafeNotFoundException("카페를 찾을 수 없습니다."));
+        Optional<Favorites> findFavorites = favoritesRepository.findByCafeAndCustomer(cafe, customer);
+        if (findFavorites.isPresent()) {
+            findFavorites.get().changeFavorites(isFavorites);
+            return;
+        }
+        favoritesRepository.save(new Favorites(cafe, customer, isFavorites));
+    }
+}

--- a/backend/src/main/java/com/stampcrush/backend/entity/favorites/Favorites.java
+++ b/backend/src/main/java/com/stampcrush/backend/entity/favorites/Favorites.java
@@ -1,0 +1,47 @@
+package com.stampcrush.backend.entity.favorites;
+
+import com.stampcrush.backend.entity.baseentity.BaseDate;
+import com.stampcrush.backend.entity.cafe.Cafe;
+import com.stampcrush.backend.entity.user.Customer;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static jakarta.persistence.FetchType.LAZY;
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+@Entity
+public class Favorites extends BaseDate {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "cafe_id")
+    private Cafe cafe;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "customer_id")
+    private Customer customer;
+
+    private Boolean isFavorites = false;
+
+    public Favorites(Cafe cafe, Customer customer) {
+        this.cafe = cafe;
+        this.customer = customer;
+    }
+
+    public Favorites(Cafe cafe, Customer customer, Boolean isFavorites) {
+        this.cafe = cafe;
+        this.customer = customer;
+        this.isFavorites = isFavorites;
+    }
+
+    public void changeFavorites(boolean isFavorites) {
+        this.isFavorites = isFavorites;
+    }
+}

--- a/backend/src/main/java/com/stampcrush/backend/repository/favorites/FavoritesRepository.java
+++ b/backend/src/main/java/com/stampcrush/backend/repository/favorites/FavoritesRepository.java
@@ -1,0 +1,13 @@
+package com.stampcrush.backend.repository.favorites;
+
+import com.stampcrush.backend.entity.cafe.Cafe;
+import com.stampcrush.backend.entity.favorites.Favorites;
+import com.stampcrush.backend.entity.user.Customer;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface FavoritesRepository extends JpaRepository<Favorites, Long> {
+
+    Optional<Favorites> findByCafeAndCustomer(Cafe cafe, Customer customer);
+}

--- a/backend/src/test/java/com/stampcrush/backend/application/favorites/FavoritesServiceTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/application/favorites/FavoritesServiceTest.java
@@ -1,0 +1,94 @@
+package com.stampcrush.backend.application.favorites;
+
+import com.stampcrush.backend.entity.cafe.Cafe;
+import com.stampcrush.backend.entity.favorites.Favorites;
+import com.stampcrush.backend.entity.user.Owner;
+import com.stampcrush.backend.entity.user.RegisterCustomer;
+import com.stampcrush.backend.exception.CafeNotFoundException;
+import com.stampcrush.backend.repository.cafe.CafeRepository;
+import com.stampcrush.backend.repository.favorites.FavoritesRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class FavoritesServiceTest {
+
+    @InjectMocks
+    private FavoritesService favoritesService;
+
+    @Mock
+    private CafeRepository cafeRepository;
+
+    @Mock
+    private FavoritesRepository favoritesRepository;
+
+    @Test
+    void 존재하지_않는_카페를_즐겨찾기에_등록_또는_해제_하려하면_예외를_던진다() {
+        // given
+        RegisterCustomer customer = new RegisterCustomer("hardy", "01000000000", "ehdgur4814", "1234");
+        Long cafeId = 1L;
+        Boolean isFavorites = Boolean.TRUE;
+
+        when(cafeRepository.findById(anyLong()))
+                .thenReturn(Optional.empty());
+
+        // when, then
+        assertThatThrownBy(() -> favoritesService.changeFavorites(customer, cafeId, isFavorites))
+                .isInstanceOf(CafeNotFoundException.class);
+    }
+
+    @Test
+    void 카페를_즐겨찾기_목록에_이미_존재하지_않을_경우_새로_만들어_저장한다() {
+        // given
+        RegisterCustomer customer = new RegisterCustomer("hardy", "01000000000", "ehdgur4814", "1234");
+        Long cafeId = 1L;
+        Boolean isFavorites = Boolean.TRUE;
+        Cafe cafe = new Cafe("하디카페", "동작구", "이수동", "1111", new Owner("하디", "hardy@", "1234", "010111111111"));
+
+        when(cafeRepository.findById(anyLong()))
+                .thenReturn(Optional.of(cafe));
+        when(favoritesRepository.findByCafeAndCustomer(cafe, customer))
+                .thenReturn(Optional.empty());
+
+        // when
+        favoritesService.changeFavorites(customer, cafeId, isFavorites);
+
+        // then
+        verify(cafeRepository, times(1)).findById(anyLong());
+        verify(favoritesRepository, times(1)).findByCafeAndCustomer(cafe, customer);
+        verify(favoritesRepository, times(1)).save(any(Favorites.class));
+    }
+
+    @Test
+    void 카페를_즐겨찾기_목록에_이미_존재할_경우_새로_저장하지_않고_변경한다() {
+        // given
+        RegisterCustomer customer = new RegisterCustomer("hardy", "01000000000", "ehdgur4814", "1234");
+        Long cafeId = 1L;
+        Boolean isFavorites = Boolean.TRUE;
+        Cafe cafe = new Cafe("하디카페", "동작구", "이수동", "1111", new Owner("하디", "hardy@", "1234", "010111111111"));
+        Favorites favorites = new Favorites(cafe, customer, isFavorites);
+
+        when(cafeRepository.findById(anyLong()))
+                .thenReturn(Optional.of(cafe));
+        when(favoritesRepository.findByCafeAndCustomer(cafe, customer))
+                .thenReturn(Optional.of(favorites));
+
+        // when
+        favoritesService.changeFavorites(customer, cafeId, isFavorites);
+
+        // then
+        verify(cafeRepository, times(1)).findById(anyLong());
+        verify(favoritesRepository, times(1)).findByCafeAndCustomer(cafe, customer);
+        verify(favoritesRepository, times(0)).save(any(Favorites.class));
+    }
+}


### PR DESCRIPTION
## 주요 변경사항
카페 즐겨찾기 등록 및 해제 기능을 구현

## 리뷰어에게...
현재, 카페 즐겨찾기를 등록할 때, `Favorites` 테이블에 이미 데이터가 존재한다면, `isFavorites` 필드만 수정해주고, 
처음 들어오는 데이터라면 새로 저장을 하는 로직을 짰습니다.
그래서 이 요청이 `Post`인지 `Patch`인지 헷갈리네요.

데이터베이스에 없다면 삽입을 하고 있다면 업데이트인데.. 여러분의 생각은 어떠신가요 ...??????

인수테스트와, 컨트롤러 단위테스트는 `base64`인증 과정이 들어오고 나서 한번에 짜겠습니다 !

### 쿠폰 즐겨찾기 등록, 해제(고객 모드)

### Request

**Header** 

- 데이터베이스 설계에 따라 변경될 수 있음.

```http
POST /api/cafes/{cafeId}/favorites

Authorization: username@password Base64 (customer)
```

**Body**

```json
{
	"isFavorites": true || false
}
```

### Response

**Header**

- 데이터베이스에서 어떻게 사용할지에 따라서 변경될 수 있음.

```json
HTTP/1.1 200 OK
```
## 관련 이슈

closes #258 

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [x] `milestone` 설정
