### PR TITLE
[FE] feat: 쿠폰 상세 모달 컴포넌트를 구현한다. 

### DIFF
--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -218,15 +218,18 @@ export const handlers = [
   // 카페 정보 조회
   rest.get('/cafes/:cafeId', (req, res, ctx) => {
     const cafe = {
-      id: 1,
-      name: '우아한 카페',
-      introduction: '안녕하세요 우아한 카페입니다',
-      openTime: '10:00',
-      closeTime: '18:00',
-      telephoneNumber: '01012345678',
-      cafeImageUrl: 'http://sdfjs.sfm/dfjnvd',
-      roadAddress: '서울시 송파구',
-      detailAddress: '루터회관',
+      cafe: {
+        id: 1,
+        name: '우아한 카페',
+        introduction:
+          '이 편지는 영국에서 최초로 시작되어 일년에 한바퀴를 돌면서 받는 사람에게 행운을 주었고 지금은 당신에게로 옮겨진 이 편지는 4일 안에 당신 곁을 ...',
+        openTime: '10:00',
+        closeTime: '18:00',
+        telephoneNumber: '01012345678',
+        cafeImageUrl: 'https://picsum.photos/540/900',
+        roadAddress: '서울시 송파구',
+        detailAddress: '루터회관',
+      },
     };
 
     return res(ctx.status(200), ctx.json(cafe));

--- a/frontend/src/mocks/mockData.ts
+++ b/frontend/src/mocks/mockData.ts
@@ -164,21 +164,21 @@ export const customerCoupons = {
           stampCount: 1,
           maxStampCount: 8,
           rewardName: '아메리카노',
-          frontImageUrl:
-            'https://www.womansense.co.kr/upload/woman/article/201912/thumb/43651-396205-sampleM.jpg',
+          frontImageUrl: 'https://woowahan-cdn.woowahan.com/static/image/share_kor.jpg',
           backImageUrl:
             'https://wemix-dev-s3.s3.amazonaws.com/media/sample/%EC%BF%A0%ED%8F%B0(%EB%AA%85%ED%95%A8)/2019/NC236B.jpg',
-          stampImageUrl: 'https://source.unsplash.com/random',
+          stampImageUrl:
+            'https://blog.kakaocdn.net/dn/Idhl1/btqDj3EXl1n/Q8AkpYkKmc3wkAyXJZX3g0/img.png',
           coordinates: [
             {
               order: 1,
-              xCoordinate: 2,
-              yCoordinate: 5,
+              xCoordinate: 20,
+              yCoordinate: 35,
             },
             {
               order: 2,
-              xCoordinate: 5,
-              yCoordinate: 5,
+              xCoordinate: 70,
+              yCoordinate: 35,
             },
           ],
         },
@@ -263,7 +263,7 @@ export const customerCoupons = {
           maxStampCount: 10,
           rewardName: '아메리카노',
           frontImageUrl:
-            'https://www.womansense.co.kr/upload/woman/article/201912/thumb/43651-396205-sampleM.jpg',
+            'https://p.turbosquid.com/ts-thumb/0y/GUpc1A/YYRcOWWr/lego_woman_generic_person_thumbnail_0000/jpg/1541672521/600x600/fit_q87/293a4ab10b3b21b10fba9335608cc2eaa0fe4f6c/lego_woman_generic_person_thumbnail_0000.jpg',
           backImageUrl: 'https://source.unsplash.com/random',
           stampImageUrl: 'https://source.unsplash.com/random',
           coordinates: [
@@ -296,18 +296,20 @@ export const customerCoupons = {
           rewardName: '아메리카노',
           frontImageUrl:
             'https://www.womansense.co.kr/upload/woman/article/201912/thumb/43651-396205-sampleM.jpg',
-          backImageUrl: 'https://source.unsplash.com/random',
-          stampImageUrl: 'https://source.unsplash.com/random',
+          backImageUrl:
+            'https://wemix-dev-s3.s3.amazonaws.com/media/sample/%EC%BF%A0%ED%8F%B0(%EB%AA%85%ED%95%A8)/2019/NC236B.jpg',
+          stampImageUrl:
+            'https://blog.kakaocdn.net/dn/Idhl1/btqDj3EXl1n/Q8AkpYkKmc3wkAyXJZX3g0/img.png',
           coordinates: [
             {
               order: 1,
-              xCoordinate: 2,
-              yCoordinate: 5,
+              xCoordinate: 50,
+              yCoordinate: 20,
             },
             {
               order: 2,
-              xCoordinate: 5,
-              yCoordinate: 5,
+              xCoordinate: 80,
+              yCoordinate: 20,
             },
           ],
         },

--- a/frontend/src/mocks/mockData.ts
+++ b/frontend/src/mocks/mockData.ts
@@ -200,7 +200,8 @@ export const customerCoupons = {
           frontImageUrl: 'https://the2.sfo2.cdn.digitaloceanspaces.com/m_photo/268167.webp',
           backImageUrl:
             'https://wemix-dev-s3.s3.amazonaws.com/media/sample/%EC%BF%A0%ED%8F%B0(%EB%AA%85%ED%95%A8)/2019/NC241B.jpg',
-          stampImageUrl: 'https://source.unsplash.com/random',
+          stampImageUrl:
+            'https://w7.pngwing.com/pngs/608/604/png-transparent-rubber-stamp-free-miscellaneous-freight-transport-text.png',
           coordinates: [
             {
               order: 1,
@@ -233,7 +234,8 @@ export const customerCoupons = {
             'https://img.freepik.com/premium-vector/golden-bright-star-light-effect-bright-star-beautiful-light-to-illustrate-star-white-sparks-sparkle-with-a-special-light-sparkles-on-transparent-background_220217-2514.jpg',
           backImageUrl:
             'https://wemix-dev-s3.s3.amazonaws.com/media/sample/%EC%BF%A0%ED%8F%B0(%EB%AA%85%ED%95%A8)/2019/NC240B.jpg',
-          stampImageUrl: 'https://source.unsplash.com/random',
+          stampImageUrl:
+            'https://w7.pngwing.com/pngs/608/604/png-transparent-rubber-stamp-free-miscellaneous-freight-transport-text.png',
           coordinates: [
             {
               order: 1,
@@ -261,21 +263,23 @@ export const customerCoupons = {
           status: 'ACCUMULATING',
           stampCount: 2,
           maxStampCount: 10,
-          rewardName: '아메리카노',
+          rewardName: '자바칩 프라푸치노 한 잔',
           frontImageUrl:
             'https://p.turbosquid.com/ts-thumb/0y/GUpc1A/YYRcOWWr/lego_woman_generic_person_thumbnail_0000/jpg/1541672521/600x600/fit_q87/293a4ab10b3b21b10fba9335608cc2eaa0fe4f6c/lego_woman_generic_person_thumbnail_0000.jpg',
-          backImageUrl: 'https://source.unsplash.com/random',
-          stampImageUrl: 'https://source.unsplash.com/random',
+          backImageUrl:
+            'https://wemix-dev-s3.s3.amazonaws.com/media/sample/%EC%BF%A0%ED%8F%B0(%EB%AA%85%ED%95%A8)/2023/NC209B.jpg',
+          stampImageUrl:
+            'https://w7.pngwing.com/pngs/608/604/png-transparent-rubber-stamp-free-miscellaneous-freight-transport-text.png',
           coordinates: [
             {
               order: 1,
-              xCoordinate: 2,
-              yCoordinate: 5,
+              xCoordinate: 30,
+              yCoordinate: 48,
             },
             {
               order: 2,
-              xCoordinate: 5,
-              yCoordinate: 5,
+              xCoordinate: 75,
+              yCoordinate: 53,
             },
           ],
         },
@@ -303,13 +307,18 @@ export const customerCoupons = {
           coordinates: [
             {
               order: 1,
-              xCoordinate: 50,
-              yCoordinate: 20,
+              xCoordinate: 35,
+              yCoordinate: 45,
             },
             {
               order: 2,
               xCoordinate: 80,
-              yCoordinate: 20,
+              yCoordinate: 40,
+            },
+            {
+              order: 3,
+              xCoordinate: 130,
+              yCoordinate: 45,
             },
           ],
         },

--- a/frontend/src/mocks/mockData.ts
+++ b/frontend/src/mocks/mockData.ts
@@ -164,8 +164,10 @@ export const customerCoupons = {
           stampCount: 1,
           maxStampCount: 8,
           rewardName: '아메리카노',
-          frontImageUrl: 'https://source.unsplash.com/random',
-          backImageUrl: 'https://source.unsplash.com/random',
+          frontImageUrl:
+            'https://www.womansense.co.kr/upload/woman/article/201912/thumb/43651-396205-sampleM.jpg',
+          backImageUrl:
+            'https://wemix-dev-s3.s3.amazonaws.com/media/sample/%EC%BF%A0%ED%8F%B0(%EB%AA%85%ED%95%A8)/2019/NC236B.jpg',
           stampImageUrl: 'https://source.unsplash.com/random',
           coordinates: [
             {
@@ -195,8 +197,9 @@ export const customerCoupons = {
           stampCount: 3,
           maxStampCount: 8,
           rewardName: '아메리카노',
-          frontImageUrl: 'https://source.unsplash.com/random',
-          backImageUrl: 'https://source.unsplash.com/random',
+          frontImageUrl: 'https://the2.sfo2.cdn.digitaloceanspaces.com/m_photo/268167.webp',
+          backImageUrl:
+            'https://wemix-dev-s3.s3.amazonaws.com/media/sample/%EC%BF%A0%ED%8F%B0(%EB%AA%85%ED%95%A8)/2019/NC241B.jpg',
           stampImageUrl: 'https://source.unsplash.com/random',
           coordinates: [
             {
@@ -226,8 +229,10 @@ export const customerCoupons = {
           stampCount: 7,
           maxStampCount: 8,
           rewardName: '아메리카노',
-          frontImageUrl: 'https://source.unsplash.com/random',
-          backImageUrl: 'https://source.unsplash.com/random',
+          frontImageUrl:
+            'https://img.freepik.com/premium-vector/golden-bright-star-light-effect-bright-star-beautiful-light-to-illustrate-star-white-sparks-sparkle-with-a-special-light-sparkles-on-transparent-background_220217-2514.jpg',
+          backImageUrl:
+            'https://wemix-dev-s3.s3.amazonaws.com/media/sample/%EC%BF%A0%ED%8F%B0(%EB%AA%85%ED%95%A8)/2019/NC240B.jpg',
           stampImageUrl: 'https://source.unsplash.com/random',
           coordinates: [
             {
@@ -257,7 +262,8 @@ export const customerCoupons = {
           stampCount: 2,
           maxStampCount: 10,
           rewardName: '아메리카노',
-          frontImageUrl: 'https://source.unsplash.com/random',
+          frontImageUrl:
+            'https://www.womansense.co.kr/upload/woman/article/201912/thumb/43651-396205-sampleM.jpg',
           backImageUrl: 'https://source.unsplash.com/random',
           stampImageUrl: 'https://source.unsplash.com/random',
           coordinates: [
@@ -288,7 +294,8 @@ export const customerCoupons = {
           stampCount: 3,
           maxStampCount: 8,
           rewardName: '아메리카노',
-          frontImageUrl: 'https://source.unsplash.com/random',
+          frontImageUrl:
+            'https://www.womansense.co.kr/upload/woman/article/201912/thumb/43651-396205-sampleM.jpg',
           backImageUrl: 'https://source.unsplash.com/random',
           stampImageUrl: 'https://source.unsplash.com/random',
           coordinates: [

--- a/frontend/src/pages/CouponList/Coupon/index.tsx
+++ b/frontend/src/pages/CouponList/Coupon/index.tsx
@@ -1,12 +1,13 @@
+import { CouponType } from '..';
 import { CouponWrapper } from './style';
 
 interface CouponProps {
-  frontImageUrl: string;
+  coupon: CouponType;
   onClick: () => void;
 }
 
-const Coupon = ({ frontImageUrl, onClick }: CouponProps) => {
-  return <CouponWrapper src={frontImageUrl} onClick={onClick} />;
+const Coupon = ({ coupon, onClick }: CouponProps) => {
+  return <CouponWrapper src={coupon.couponInfos[0].frontImageUrl} onClick={onClick} />;
 };
 
 export default Coupon;

--- a/frontend/src/pages/CouponList/Coupon/index.tsx
+++ b/frontend/src/pages/CouponList/Coupon/index.tsx
@@ -1,4 +1,4 @@
-import { CouponType } from '..';
+import { CouponType } from '../../../types';
 import { CouponWrapper } from './style';
 
 interface CouponProps {
@@ -7,7 +7,13 @@ interface CouponProps {
 }
 
 const Coupon = ({ coupon, onClick }: CouponProps) => {
-  return <CouponWrapper src={coupon.couponInfos[0].frontImageUrl} onClick={onClick} />;
+  return (
+    <CouponWrapper
+      src={coupon.couponInfos[0].frontImageUrl}
+      onClick={onClick}
+      aria-label={coupon.cafeInfo.name}
+    />
+  );
 };
 
 export default Coupon;

--- a/frontend/src/pages/CouponList/Coupon/style.tsx
+++ b/frontend/src/pages/CouponList/Coupon/style.tsx
@@ -10,4 +10,5 @@ export const CouponWrapper = styled.img`
   transition: transform 0.1s;
   object-fit: cover;
   box-shadow: 0px -2px 15px -2px #888;
+  z-index: 2;
 `;

--- a/frontend/src/pages/CouponList/CouponDetail/index.tsx
+++ b/frontend/src/pages/CouponList/CouponDetail/index.tsx
@@ -30,6 +30,7 @@ const CouponDetail = ({ isDetail, isShown, coupon, cafe, closeDetail }: CouponDe
         frontImageUrl={coupon.couponInfos[0].frontImageUrl}
         backImageUrl={coupon.couponInfos[0].backImageUrl}
         isShown={isShown}
+        coordinates={coupon.couponInfos[0].coordinates}
       />
       <CloseButton onClick={closeDetail}>
         <BiArrowBack size={24} />

--- a/frontend/src/pages/CouponList/CouponDetail/index.tsx
+++ b/frontend/src/pages/CouponList/CouponDetail/index.tsx
@@ -1,4 +1,4 @@
-import { MouseEvent } from 'react';
+import { MouseEvent, useState } from 'react';
 import { CafeType, CouponType } from '..';
 import Text from '../../../components/Text';
 import {
@@ -11,19 +11,26 @@ import {
 import { BiArrowBack } from 'react-icons/bi';
 import { FaRegClock, FaPhoneAlt } from 'react-icons/fa';
 import { FaLocationDot } from 'react-icons/fa6';
+import FlippedCoupon from '../FlippedCoupon';
 
 interface CouponDetailProps {
   isDetail: boolean;
+  isShown: boolean;
   coupon: CouponType;
   cafe: CafeType;
   closeDetail: (e: MouseEvent<HTMLButtonElement>) => void;
 }
 
 // TODO:이후 카페 관리 병합 후 parseUtil 사용
-const CouponDetail = ({ isDetail, coupon, cafe, closeDetail }: CouponDetailProps) => {
+const CouponDetail = ({ isDetail, isShown, coupon, cafe, closeDetail }: CouponDetailProps) => {
   return (
     <CouponDetailContainer $isDetail={isDetail}>
       <CafeImage src={cafe.cafe.cafeImageUrl} />
+      <FlippedCoupon
+        frontImageUrl={coupon.couponInfos[0].frontImageUrl}
+        backImageUrl={coupon.couponInfos[0].backImageUrl}
+        isShown={isShown}
+      />
       <CloseButton onClick={closeDetail}>
         <BiArrowBack size={24} />
       </CloseButton>

--- a/frontend/src/pages/CouponList/CouponDetail/index.tsx
+++ b/frontend/src/pages/CouponList/CouponDetail/index.tsx
@@ -1,0 +1,52 @@
+import { MouseEvent } from 'react';
+import { CafeType, CouponType } from '..';
+import Text from '../../../components/Text';
+import {
+  CafeImage,
+  CloseButton,
+  ContentContainer,
+  CouponDetailContainer,
+  OverviewContainer,
+} from './style';
+import { BiArrowBack } from 'react-icons/bi';
+import { FaRegClock, FaPhoneAlt } from 'react-icons/fa';
+import { FaLocationDot } from 'react-icons/fa6';
+
+interface CouponDetailProps {
+  isDetail: boolean;
+  coupon: CouponType;
+  cafe: CafeType;
+  closeDetail: (e: MouseEvent<HTMLButtonElement>) => void;
+}
+
+// TODO:이후 카페 관리 병합 후 parseUtil 사용
+const CouponDetail = ({ isDetail, coupon, cafe, closeDetail }: CouponDetailProps) => {
+  return (
+    <CouponDetailContainer $isDetail={isDetail}>
+      <CafeImage src={cafe.cafe.cafeImageUrl} />
+      <CloseButton onClick={closeDetail}>
+        <BiArrowBack size={24} />
+      </CloseButton>
+      <OverviewContainer>
+        <Text variant="subTitle">{coupon.cafeInfo.name}</Text>
+        <Text>{cafe.cafe.introduction}</Text>
+      </OverviewContainer>
+      <ContentContainer>
+        <Text>
+          <FaRegClock size={24} />
+          {`여는 시간 ${cafe.cafe.openTime}\n닫는 시간 ${cafe.cafe.closeTime}`}
+        </Text>
+        <Text>
+          <FaPhoneAlt size={24} />
+          {cafe.cafe.telephoneNumber}
+        </Text>
+        <Text>
+          <FaLocationDot size={24} />
+          {cafe.cafe.roadAddress + ' ' + cafe.cafe.detailAddress}
+        </Text>
+      </ContentContainer>
+    </CouponDetailContainer>
+  );
+};
+
+export default CouponDetail;

--- a/frontend/src/pages/CouponList/CouponDetail/index.tsx
+++ b/frontend/src/pages/CouponList/CouponDetail/index.tsx
@@ -24,13 +24,13 @@ interface CouponDetailProps {
 const CouponDetail = ({ isDetail, isShown, coupon, cafe, closeDetail }: CouponDetailProps) => {
   // FIXME: cafeName 등 넘겨받은 데이터 이후에 알맞게 변경
   const couponInfos = coupon.couponInfos[0];
-  const cafeInfo = cafe.cafe;
+
   const cafeName = coupon.cafeInfo.name;
 
   // FIXME: 이후 카페 관리 병합 후 parseUtil 사용
   return (
     <CouponDetailContainer $isDetail={isDetail}>
-      <CafeImage src={cafeInfo.cafeImageUrl} />
+      <CafeImage src={cafe.cafeImageUrl} />
       <FlippedCoupon
         frontImageUrl={couponInfos.frontImageUrl}
         backImageUrl={couponInfos.backImageUrl}
@@ -43,7 +43,7 @@ const CouponDetail = ({ isDetail, isShown, coupon, cafe, closeDetail }: CouponDe
       </CloseButton>
       <OverviewContainer>
         <Text variant="subTitle">{cafeName}</Text>
-        <Text>{cafe.cafe.introduction}</Text>
+        <Text>{cafe.introduction}</Text>
       </OverviewContainer>
       <ContentContainer>
         <Text>
@@ -52,15 +52,15 @@ const CouponDetail = ({ isDetail, isShown, coupon, cafe, closeDetail }: CouponDe
         </Text>
         <Text>
           <FaRegClock size={24} />
-          {`여는 시간 ${cafeInfo.openTime}\n닫는 시간 ${cafeInfo.closeTime}`}
+          {`여는 시간 ${cafe.openTime}\n닫는 시간 ${cafe.closeTime}`}
         </Text>
         <Text>
           <FaPhoneAlt size={24} />
-          {cafeInfo.telephoneNumber}
+          {cafe.telephoneNumber}
         </Text>
         <Text>
           <FaLocationDot size={24} />
-          {cafeInfo.roadAddress + ' ' + cafeInfo.detailAddress}
+          {cafe.roadAddress + ' ' + cafe.detailAddress}
         </Text>
       </ContentContainer>
     </CouponDetailContainer>

--- a/frontend/src/pages/CouponList/CouponDetail/index.tsx
+++ b/frontend/src/pages/CouponList/CouponDetail/index.tsx
@@ -1,5 +1,5 @@
-import { MouseEvent, useState } from 'react';
-import { CafeType, CouponType } from '..';
+import { MouseEvent } from 'react';
+import FlippedCoupon from '../FlippedCoupon';
 import Text from '../../../components/Text';
 import {
   CafeImage,
@@ -9,9 +9,9 @@ import {
   OverviewContainer,
 } from './style';
 import { BiArrowBack } from 'react-icons/bi';
-import { FaRegClock, FaPhoneAlt } from 'react-icons/fa';
+import { FaRegClock, FaPhoneAlt, FaRegBell } from 'react-icons/fa';
 import { FaLocationDot } from 'react-icons/fa6';
-import FlippedCoupon from '../FlippedCoupon';
+import { CafeType, CouponType } from '../../../types';
 
 interface CouponDetailProps {
   isDetail: boolean;
@@ -21,36 +21,46 @@ interface CouponDetailProps {
   closeDetail: (e: MouseEvent<HTMLButtonElement>) => void;
 }
 
-// TODO:이후 카페 관리 병합 후 parseUtil 사용
 const CouponDetail = ({ isDetail, isShown, coupon, cafe, closeDetail }: CouponDetailProps) => {
+  // FIXME: cafeName 등 넘겨받은 데이터 이후에 알맞게 변경
+  const couponInfos = coupon.couponInfos[0];
+  const cafeInfo = cafe.cafe;
+  const cafeName = coupon.cafeInfo.name;
+
+  // FIXME: 이후 카페 관리 병합 후 parseUtil 사용
   return (
     <CouponDetailContainer $isDetail={isDetail}>
-      <CafeImage src={cafe.cafe.cafeImageUrl} />
+      <CafeImage src={cafeInfo.cafeImageUrl} />
       <FlippedCoupon
-        frontImageUrl={coupon.couponInfos[0].frontImageUrl}
-        backImageUrl={coupon.couponInfos[0].backImageUrl}
+        frontImageUrl={couponInfos.frontImageUrl}
+        backImageUrl={couponInfos.backImageUrl}
+        stampImageUrl={couponInfos.stampImageUrl}
         isShown={isShown}
-        coordinates={coupon.couponInfos[0].coordinates}
+        coordinates={couponInfos.coordinates}
       />
       <CloseButton onClick={closeDetail}>
         <BiArrowBack size={24} />
       </CloseButton>
       <OverviewContainer>
-        <Text variant="subTitle">{coupon.cafeInfo.name}</Text>
+        <Text variant="subTitle">{cafeName}</Text>
         <Text>{cafe.cafe.introduction}</Text>
       </OverviewContainer>
       <ContentContainer>
         <Text>
+          <FaRegBell size={24} />
+          {`스탬프 ${couponInfos.maxStampCount}개를 채우면 ${couponInfos.rewardName} 무료!`}
+        </Text>
+        <Text>
           <FaRegClock size={24} />
-          {`여는 시간 ${cafe.cafe.openTime}\n닫는 시간 ${cafe.cafe.closeTime}`}
+          {`여는 시간 ${cafeInfo.openTime}\n닫는 시간 ${cafeInfo.closeTime}`}
         </Text>
         <Text>
           <FaPhoneAlt size={24} />
-          {cafe.cafe.telephoneNumber}
+          {cafeInfo.telephoneNumber}
         </Text>
         <Text>
           <FaLocationDot size={24} />
-          {cafe.cafe.roadAddress + ' ' + cafe.cafe.detailAddress}
+          {cafeInfo.roadAddress + ' ' + cafeInfo.detailAddress}
         </Text>
       </ContentContainer>
     </CouponDetailContainer>

--- a/frontend/src/pages/CouponList/CouponDetail/style.tsx
+++ b/frontend/src/pages/CouponList/CouponDetail/style.tsx
@@ -19,14 +19,12 @@ export const CouponDetailContainer = styled.section<{ $isDetail: boolean }>`
 
   > :nth-child(2) {
     position: absolute;
-    top: 67px;
+    top: 68px;
     left: 50%;
     transform: translateX(-50%);
     z-index: 999;
   }
 `;
-
-// 쿠폰은 올라가면 사라진다. -> 돌아가는 쿠폰으로 대체
 // 텍스트 애니메이션 삽입 ㄱ
 
 export const OverviewContainer = styled.div`
@@ -54,9 +52,9 @@ export const ContentContainer = styled.div`
   display: flex;
   flex-direction: column;
   position: absolute;
-  bottom: 300px;
+  bottom: 30%;
   left: 50px;
-  width: 200px;
+  width: 300px;
   height: 100px;
   gap: 20px;
 
@@ -75,5 +73,6 @@ export const CloseButton = styled.button`
   left: 15px;
   width: 24px;
   height: 24px;
+  color: black;
   background: transparent;
 `;

--- a/frontend/src/pages/CouponList/CouponDetail/style.tsx
+++ b/frontend/src/pages/CouponList/CouponDetail/style.tsx
@@ -1,0 +1,65 @@
+import styled from 'styled-components';
+
+export const CouponDetailContainer = styled.section<{ $isDetail: boolean }>`
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 100vw;
+  height: 100vh;
+  transform: translateX(${(props) => (props.$isDetail ? '0' : '500px')});
+  transition: transform 0.4s;
+
+  background: white;
+`;
+
+// 쿠폰은 올라가면 사라진다. -> 돌아가는 쿠폰으로 대체
+// 텍스트 애니메이션 삽입 ㄱ
+
+export const OverviewContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  position: absolute;
+  align-items: center;
+  width: 100%;
+  height: 130px;
+  top: 250px;
+  padding: 0 10px;
+  gap: 10px;
+  word-break: break-all;
+  overflow: hidden;
+`;
+
+export const CafeImage = styled.img`
+  width: 100%;
+  height: 100%;
+  opacity: 0.45;
+  object-fit: cover;
+`;
+
+export const ContentContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  position: absolute;
+  bottom: 300px;
+  left: 50px;
+  width: 200px;
+  height: 100px;
+  gap: 20px;
+
+  :nth-child(n) {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: flex-start;
+    gap: 10px;
+  }
+`;
+
+export const CloseButton = styled.button`
+  position: absolute;
+  top: 15px;
+  left: 15px;
+  width: 24px;
+  height: 24px;
+  background: transparent;
+`;

--- a/frontend/src/pages/CouponList/CouponDetail/style.tsx
+++ b/frontend/src/pages/CouponList/CouponDetail/style.tsx
@@ -1,13 +1,15 @@
 import styled from 'styled-components';
 
 export const CouponDetailContainer = styled.section<{ $isDetail: boolean }>`
+  opacity: ${({ $isDetail }) => ($isDetail ? '1' : '0')};
+
   position: absolute;
   top: 0;
   right: 0;
   width: 100vw;
   height: 100vh;
-  transform: translateX(${(props) => (props.$isDetail ? '0' : '500px')});
-  transition: transform 0.4s;
+  transform: translateX(${({ $isDetail }) => ($isDetail ? '0' : '500px')});
+  transition: all 0.4s;
 
   background: white;
 `;

--- a/frontend/src/pages/CouponList/CouponDetail/style.tsx
+++ b/frontend/src/pages/CouponList/CouponDetail/style.tsx
@@ -16,6 +16,14 @@ export const CouponDetailContainer = styled.section<{ $isDetail: boolean }>`
   h1 {
     white-space: pre-line;
   }
+
+  > :nth-child(2) {
+    position: absolute;
+    top: 67px;
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 999;
+  }
 `;
 
 // 쿠폰은 올라가면 사라진다. -> 돌아가는 쿠폰으로 대체

--- a/frontend/src/pages/CouponList/CouponDetail/style.tsx
+++ b/frontend/src/pages/CouponList/CouponDetail/style.tsx
@@ -25,7 +25,13 @@ export const CouponDetailContainer = styled.section<{ $isDetail: boolean }>`
     z-index: 999;
   }
 `;
-// 텍스트 애니메이션 삽입 ㄱ
+
+// 텍스트 애니메이션 삽입?
+export const CouponNotification = styled.p`
+  position: absolute;
+  top: 100px;
+  left: 0px;
+`;
 
 export const OverviewContainer = styled.div`
   display: flex;
@@ -34,11 +40,16 @@ export const OverviewContainer = styled.div`
   align-items: center;
   width: 100%;
   height: 130px;
-  top: 250px;
+  top: 260px;
   padding: 0 10px;
   gap: 10px;
   word-break: break-all;
   overflow: hidden;
+
+  :nth-child(1) {
+    padding: 5px 20px;
+    border-bottom: 2px solid black;
+  }
 `;
 
 export const CafeImage = styled.img`
@@ -52,7 +63,7 @@ export const ContentContainer = styled.div`
   display: flex;
   flex-direction: column;
   position: absolute;
-  bottom: 30%;
+  bottom: 25%;
   left: 50px;
   width: 300px;
   height: 100px;

--- a/frontend/src/pages/CouponList/CouponDetail/style.tsx
+++ b/frontend/src/pages/CouponList/CouponDetail/style.tsx
@@ -9,9 +9,13 @@ export const CouponDetailContainer = styled.section<{ $isDetail: boolean }>`
   width: 100vw;
   height: 100vh;
   transform: translateX(${({ $isDetail }) => ($isDetail ? '0' : '500px')});
-  transition: all 0.4s;
+  transition: all 0.4s ease-in-out;
 
   background: white;
+
+  h1 {
+    white-space: pre-line;
+  }
 `;
 
 // 쿠폰은 올라가면 사라진다. -> 돌아가는 쿠폰으로 대체

--- a/frontend/src/pages/CouponList/FlippedCoupon/index.tsx
+++ b/frontend/src/pages/CouponList/FlippedCoupon/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { BackImage, CouponContainer, CouponWrapper, FrontImage, StampImage } from './style';
 
 interface StampCoordinate {
@@ -10,6 +10,7 @@ interface StampCoordinate {
 interface FlippedCouponProps {
   frontImageUrl: string;
   backImageUrl: string;
+  stampImageUrl: string;
   isShown: boolean;
   coordinates: StampCoordinate[];
 }
@@ -17,10 +18,15 @@ interface FlippedCouponProps {
 const FlippedCoupon = ({
   frontImageUrl,
   backImageUrl,
+  stampImageUrl,
   isShown,
   coordinates,
 }: FlippedCouponProps) => {
   const [isFlipped, setIsFlipped] = useState(false);
+
+  useEffect(() => {
+    if (!isShown) setIsFlipped(false);
+  }, [isShown]);
 
   const flipCoupon = () => {
     setIsFlipped(!isFlipped);
@@ -31,16 +37,16 @@ const FlippedCoupon = ({
       <CouponWrapper $isFlipped={isFlipped}>
         <FrontImage src={frontImageUrl} />
         <BackImage src={backImageUrl} />
+        {coordinates &&
+          coordinates.map(({ order, xCoordinate, yCoordinate }, idx) => (
+            <StampImage
+              key={order + idx}
+              src={stampImageUrl}
+              $xCoordinate={xCoordinate}
+              $yCoordinate={yCoordinate}
+            />
+          ))}
       </CouponWrapper>
-      {coordinates &&
-        coordinates.map(({ order, xCoordinate, yCoordinate }, idx) => (
-          <StampImage
-            key={order + idx}
-            $isFlipped={isFlipped}
-            $xCoordinate={xCoordinate}
-            $yCoordinate={yCoordinate}
-          />
-        ))}
     </CouponContainer>
   );
 };

--- a/frontend/src/pages/CouponList/FlippedCoupon/index.tsx
+++ b/frontend/src/pages/CouponList/FlippedCoupon/index.tsx
@@ -1,12 +1,5 @@
 import { useEffect, useState } from 'react';
-import {
-  BackImage,
-  CouponContainer,
-  CouponNotification,
-  CouponWrapper,
-  FrontImage,
-  StampImage,
-} from './style';
+import { BackImage, CouponContainer, CouponWrapper, FrontImage, StampImage } from './style';
 import { StampCoordinate } from '../../../types';
 
 interface FlippedCouponProps {
@@ -27,36 +20,33 @@ const FlippedCoupon = ({
   const [isFlipped, setIsFlipped] = useState(false);
 
   useEffect(() => {
-    if (!isShown) setIsFlipped(false);
+    if (isShown) {
+      setTimeout(() => {
+        setIsFlipped(true);
+      }, 100);
+    }
+
+    if (!isShown) {
+      setIsFlipped(false);
+    }
   }, [isShown]);
 
-  const flipCoupon = () => {
-    setIsFlipped(!isFlipped);
-  };
-
   return (
-    <>
-      <CouponContainer $isShown={isShown} onClick={flipCoupon}>
-        <CouponWrapper $isFlipped={isFlipped}>
-          <FrontImage src={frontImageUrl} />
-          <BackImage src={backImageUrl} />
-          {coordinates &&
-            coordinates.map(({ order, xCoordinate, yCoordinate }, idx) => (
-              <StampImage
-                key={order + idx}
-                src={stampImageUrl}
-                $xCoordinate={xCoordinate}
-                $yCoordinate={yCoordinate}
-              />
-            ))}
-        </CouponWrapper>
-      </CouponContainer>
-      <CouponNotification>
-        {isFlipped
-          ? '쿠폰을 터치하여 쿠폰 앞면으로 돌아갑니다.'
-          : '쿠폰을 터치하여 스탬프를 확인할 수 있습니다.'}
-      </CouponNotification>
-    </>
+    <CouponContainer $isShown={isShown}>
+      <CouponWrapper $isFlipped={isFlipped}>
+        <FrontImage src={frontImageUrl} />
+        <BackImage src={backImageUrl} />
+        {coordinates &&
+          coordinates.map(({ order, xCoordinate, yCoordinate }, idx) => (
+            <StampImage
+              key={order + idx}
+              src={stampImageUrl}
+              $xCoordinate={xCoordinate}
+              $yCoordinate={yCoordinate}
+            />
+          ))}
+      </CouponWrapper>
+    </CouponContainer>
   );
 };
 

--- a/frontend/src/pages/CouponList/FlippedCoupon/index.tsx
+++ b/frontend/src/pages/CouponList/FlippedCoupon/index.tsx
@@ -1,13 +1,25 @@
 import { useState } from 'react';
 import { BackImage, CouponContainer, CouponWrapper, FrontImage, StampImage } from './style';
 
+interface StampCoordinate {
+  order: number;
+  xCoordinate: number;
+  yCoordinate: number;
+}
+
 interface FlippedCouponProps {
   frontImageUrl: string;
   backImageUrl: string;
   isShown: boolean;
+  coordinates: StampCoordinate[];
 }
 
-const FlippedCoupon = ({ frontImageUrl, backImageUrl, isShown }: FlippedCouponProps) => {
+const FlippedCoupon = ({
+  frontImageUrl,
+  backImageUrl,
+  isShown,
+  coordinates,
+}: FlippedCouponProps) => {
   const [isFlipped, setIsFlipped] = useState(false);
 
   const flipCoupon = () => {
@@ -20,7 +32,15 @@ const FlippedCoupon = ({ frontImageUrl, backImageUrl, isShown }: FlippedCouponPr
         <FrontImage src={frontImageUrl} />
         <BackImage src={backImageUrl} />
       </CouponWrapper>
-      <StampImage $isFlipped={isFlipped} />
+      {coordinates &&
+        coordinates.map(({ order, xCoordinate, yCoordinate }, idx) => (
+          <StampImage
+            key={order + idx}
+            $isFlipped={isFlipped}
+            $xCoordinate={xCoordinate}
+            $yCoordinate={yCoordinate}
+          />
+        ))}
     </CouponContainer>
   );
 };

--- a/frontend/src/pages/CouponList/FlippedCoupon/index.tsx
+++ b/frontend/src/pages/CouponList/FlippedCoupon/index.tsx
@@ -1,0 +1,28 @@
+import { useState } from 'react';
+import { BackImage, CouponContainer, CouponWrapper, FrontImage, StampImage } from './style';
+
+interface FlippedCouponProps {
+  frontImageUrl: string;
+  backImageUrl: string;
+  isShown: boolean;
+}
+
+const FlippedCoupon = ({ frontImageUrl, backImageUrl, isShown }: FlippedCouponProps) => {
+  const [isFlipped, setIsFlipped] = useState(false);
+
+  const flipCoupon = () => {
+    setIsFlipped(!isFlipped);
+  };
+
+  return (
+    <CouponContainer $isShown={isShown} onClick={flipCoupon}>
+      <CouponWrapper $isFlipped={isFlipped}>
+        <FrontImage src={frontImageUrl} />
+        <BackImage src={backImageUrl} />
+      </CouponWrapper>
+      <StampImage $isFlipped={isFlipped} />
+    </CouponContainer>
+  );
+};
+
+export default FlippedCoupon;

--- a/frontend/src/pages/CouponList/FlippedCoupon/index.tsx
+++ b/frontend/src/pages/CouponList/FlippedCoupon/index.tsx
@@ -1,11 +1,13 @@
 import { useEffect, useState } from 'react';
-import { BackImage, CouponContainer, CouponWrapper, FrontImage, StampImage } from './style';
-
-interface StampCoordinate {
-  order: number;
-  xCoordinate: number;
-  yCoordinate: number;
-}
+import {
+  BackImage,
+  CouponContainer,
+  CouponNotification,
+  CouponWrapper,
+  FrontImage,
+  StampImage,
+} from './style';
+import { StampCoordinate } from '../../../types';
 
 interface FlippedCouponProps {
   frontImageUrl: string;
@@ -33,21 +35,28 @@ const FlippedCoupon = ({
   };
 
   return (
-    <CouponContainer $isShown={isShown} onClick={flipCoupon}>
-      <CouponWrapper $isFlipped={isFlipped}>
-        <FrontImage src={frontImageUrl} />
-        <BackImage src={backImageUrl} />
-        {coordinates &&
-          coordinates.map(({ order, xCoordinate, yCoordinate }, idx) => (
-            <StampImage
-              key={order + idx}
-              src={stampImageUrl}
-              $xCoordinate={xCoordinate}
-              $yCoordinate={yCoordinate}
-            />
-          ))}
-      </CouponWrapper>
-    </CouponContainer>
+    <>
+      <CouponContainer $isShown={isShown} onClick={flipCoupon}>
+        <CouponWrapper $isFlipped={isFlipped}>
+          <FrontImage src={frontImageUrl} />
+          <BackImage src={backImageUrl} />
+          {coordinates &&
+            coordinates.map(({ order, xCoordinate, yCoordinate }, idx) => (
+              <StampImage
+                key={order + idx}
+                src={stampImageUrl}
+                $xCoordinate={xCoordinate}
+                $yCoordinate={yCoordinate}
+              />
+            ))}
+        </CouponWrapper>
+      </CouponContainer>
+      <CouponNotification>
+        {isFlipped
+          ? '쿠폰을 터치하여 쿠폰 앞면으로 돌아갑니다.'
+          : '쿠폰을 터치하여 스탬프를 확인할 수 있습니다.'}
+      </CouponNotification>
+    </>
   );
 };
 

--- a/frontend/src/pages/CouponList/FlippedCoupon/style.tsx
+++ b/frontend/src/pages/CouponList/FlippedCoupon/style.tsx
@@ -1,5 +1,15 @@
 import { css, styled } from 'styled-components';
 
+export const CouponNotification = styled.p`
+  position: absolute;
+  width: 100%;
+  top: 225px;
+  left: 50%;
+  font-size: 12px;
+  text-align: center;
+  transform: translateX(-50%);
+`;
+
 export const CouponContainer = styled.div<{ $isShown: boolean }>`
   display: ${({ $isShown }) => ($isShown ? 'flex' : 'none')};
   position: relative;

--- a/frontend/src/pages/CouponList/FlippedCoupon/style.tsx
+++ b/frontend/src/pages/CouponList/FlippedCoupon/style.tsx
@@ -1,0 +1,62 @@
+import { css, styled } from 'styled-components';
+
+export const CouponContainer = styled.div<{ $isShown: boolean }>`
+  display: ${({ $isShown }) => ($isShown ? 'flex' : 'none')};
+  position: relative;
+  width: 270px;
+  height: 150px;
+  perspective: 1100px;
+  transition: all 0.4s;
+`;
+
+export const CouponWrapper = styled.div<{ $isFlipped: boolean }>`
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  transform-style: preserve-3d;
+  backface-visibility: hidden;
+  transition: all 0.4s;
+
+  ${({ $isFlipped }) =>
+    $isFlipped &&
+    css`
+      transform: rotateY(180deg);
+    `}
+`;
+
+export const CouponImage = styled.img`
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  transform-style: preserve-3d;
+  backface-visibility: hidden;
+  z-index: 2;
+`;
+
+export const FrontImage = styled(CouponImage)`
+  z-index: 10;
+`;
+
+export const BackImage = styled(CouponImage)`
+  transform: rotateY(180deg);
+  z-index: 0;
+`;
+
+export const StampImage = styled.img<{ $isFlipped: boolean }>`
+  ${({ $isFlipped }) =>
+    $isFlipped &&
+    css`
+      ${CouponWrapper} + & {
+        visibility: visible;
+      }
+    `}
+
+  visibility: hidden;
+  width: 30px;
+  height: 30px;
+  position: absolute;
+  top: 20px;
+  left: 20px;
+  background: yellow;
+  z-index: 1;
+`;

--- a/frontend/src/pages/CouponList/FlippedCoupon/style.tsx
+++ b/frontend/src/pages/CouponList/FlippedCoupon/style.tsx
@@ -45,11 +45,16 @@ export const BackImage = styled(CouponImage)`
   z-index: 0;
 `;
 
-export const StampImage = styled.img<{ $isFlipped: boolean }>`
+interface StyledStampPosProps {
+  $isFlipped: boolean;
+  $xCoordinate: number;
+  $yCoordinate: number;
+}
+export const StampImage = styled.img<StyledStampPosProps>`
   ${({ $isFlipped }) =>
     $isFlipped &&
     css`
-      ${CouponWrapper} + & {
+      ${CouponWrapper} ~ & {
         visibility: visible;
       }
     `}
@@ -58,8 +63,9 @@ export const StampImage = styled.img<{ $isFlipped: boolean }>`
   width: 30px;
   height: 30px;
   position: absolute;
-  top: 20px;
-  left: 20px;
+  object-fit: contain;
+  top: ${({ $yCoordinate }) => `${$yCoordinate}px`};
+  left: ${({ $xCoordinate }) => `${$xCoordinate}px`};
   background: yellow;
   z-index: 1;
 `;

--- a/frontend/src/pages/CouponList/FlippedCoupon/style.tsx
+++ b/frontend/src/pages/CouponList/FlippedCoupon/style.tsx
@@ -46,26 +46,19 @@ export const BackImage = styled(CouponImage)`
 `;
 
 interface StyledStampPosProps {
-  $isFlipped: boolean;
   $xCoordinate: number;
   $yCoordinate: number;
 }
 export const StampImage = styled.img<StyledStampPosProps>`
-  ${({ $isFlipped }) =>
-    $isFlipped &&
-    css`
-      ${CouponWrapper} ~ & {
-        visibility: visible;
-      }
-    `}
-
-  visibility: hidden;
   width: 30px;
   height: 30px;
   position: absolute;
   object-fit: contain;
   top: ${({ $yCoordinate }) => `${$yCoordinate}px`};
-  left: ${({ $xCoordinate }) => `${$xCoordinate}px`};
-  background: yellow;
+  right: ${({ $xCoordinate }) => `${$xCoordinate}px`};
+
+  backface-visibility: hidden;
+  transform-style: preserve-3d;
+  transform: rotateY(180deg);
   z-index: 1;
 `;

--- a/frontend/src/pages/CouponList/FlippedCoupon/style.tsx
+++ b/frontend/src/pages/CouponList/FlippedCoupon/style.tsx
@@ -1,15 +1,5 @@
 import { css, styled } from 'styled-components';
 
-export const CouponNotification = styled.p`
-  position: absolute;
-  width: 100%;
-  top: 225px;
-  left: 50%;
-  font-size: 12px;
-  text-align: center;
-  transform: translateX(-50%);
-`;
-
 export const CouponContainer = styled.div<{ $isShown: boolean }>`
   display: ${({ $isShown }) => ($isShown ? 'flex' : 'none')};
   position: relative;

--- a/frontend/src/pages/CouponList/FlippedCoupon/style.tsx
+++ b/frontend/src/pages/CouponList/FlippedCoupon/style.tsx
@@ -29,7 +29,10 @@ export const CouponImage = styled.img`
   width: 100%;
   height: 100%;
   transform-style: preserve-3d;
+  object-fit: cover;
   backface-visibility: hidden;
+  box-shadow: 0px -2px 15px -2px #888;
+
   z-index: 2;
 `;
 

--- a/frontend/src/pages/CouponList/index.tsx
+++ b/frontend/src/pages/CouponList/index.tsx
@@ -24,7 +24,7 @@ import Color from 'color-thief-react';
 import { useNavigate } from 'react-router-dom';
 import { TbZoomCheck } from 'react-icons/tb';
 import CouponDetail from './CouponDetail';
-import { CouponType } from '../../types';
+import { CafeRes, CouponType } from '../../types';
 
 const CouponList = () => {
   const navigate = useNavigate();
@@ -40,7 +40,9 @@ const CouponList = () => {
     getCoupons,
   );
 
-  const { data: cafeData, status: cafeStatus } = useQuery(['cafeInfos'], () => getCafeInfo(cafeId));
+  const { data: cafeData, status: cafeStatus } = useQuery<CafeRes>(['cafeInfos'], () =>
+    getCafeInfo(cafeId),
+  );
 
   useEffect(() => {
     if (couponsInfosData) setCurrentIndex(couponsInfosData?.coupons.length - 1);
@@ -152,7 +154,7 @@ const CouponList = () => {
       {cafeStatus !== 'loading' && cafeStatus !== 'error' && (
         <CouponDetail
           coupon={getCurrentCoupon()}
-          cafe={cafeData}
+          cafe={cafeData.cafe}
           closeDetail={closeCouponDetail}
           isDetail={isDetail}
           isShown={isDetailShown}

--- a/frontend/src/pages/CouponList/index.tsx
+++ b/frontend/src/pages/CouponList/index.tsx
@@ -158,7 +158,7 @@ const CouponList = () => {
           isShown={isDetailShown}
         />
       )}
-      <DetailButton onClick={openCouponDetail} aria-label="쿠폰 상세 보기">
+      <DetailButton onClick={openCouponDetail} $isDetail={isDetail} aria-label="쿠폰 상세 보기">
         <TbZoomCheck size={32} color={'#424242'} />
       </DetailButton>
     </>

--- a/frontend/src/pages/CouponList/index.tsx
+++ b/frontend/src/pages/CouponList/index.tsx
@@ -12,7 +12,7 @@ import {
   ProgressBarContainer,
   StampCount,
 } from './style';
-import { useRef, useState } from 'react';
+import { MouseEvent, useRef, useState } from 'react';
 import { getCoupons } from '../../api/get';
 import { useQuery } from '@tanstack/react-query';
 import AdminHeaderLogo from '../../assets/admin_header_logo.png';
@@ -49,12 +49,13 @@ const CouponList = () => {
   const [currentIndex, setCurrentIndex] = useState(0);
   const couponListContainerRef = useRef<HTMLDivElement>(null);
   const [isLast, setIsLast] = useState(false);
+  const [isDetail, setIsDetail] = useState(false);
   const { data, status } = useQuery<{ coupons: CouponType[] }>(['coupons'], getCoupons, {});
 
   if (status === 'error') return <>에러가 발생했습니다.</>;
   if (status === 'loading') return <>로딩 중입니다.</>;
 
-  const swapCoupon = (e: React.MouseEvent<HTMLDivElement>) => {
+  const swapCoupon = (e: MouseEvent<HTMLDivElement>) => {
     if (!couponListContainerRef.current) return;
 
     const coupon = couponListContainerRef.current.lastElementChild;
@@ -75,6 +76,10 @@ const CouponList = () => {
 
   const navigateMyPage = () => {
     navigate(ROUTER_PATH.myPage);
+  };
+
+  const showCouponDetail = (e: MouseEvent<HTMLButtonElement>) => {
+    setIsDetail(true);
   };
 
   return (
@@ -113,7 +118,12 @@ const CouponList = () => {
           <MaxStampCount>{getCurrentCoupon().couponInfos[0].maxStampCount}</MaxStampCount>
         </ProgressBarContainer>
       </InfoContainer>
-      <CouponListContainer ref={couponListContainerRef} onClick={swapCoupon} $isLast={isLast}>
+      <CouponListContainer
+        ref={couponListContainerRef}
+        onClick={swapCoupon}
+        $isLast={isLast}
+        $isDetail={isDetail}
+      >
         {data.coupons.map(({ cafeInfo, couponInfos }, index) => (
           <Coupon
             key={cafeInfo.id}
@@ -123,7 +133,7 @@ const CouponList = () => {
           />
         ))}
       </CouponListContainer>
-      <DetailButton>
+      <DetailButton onClick={showCouponDetail}>
         <TbZoomCheck size={32} color={'#424242'} />
       </DetailButton>
     </>

--- a/frontend/src/pages/CouponList/index.tsx
+++ b/frontend/src/pages/CouponList/index.tsx
@@ -32,7 +32,7 @@ const CouponList = () => {
   const couponListContainerRef = useRef<HTMLDivElement>(null);
   const [isLast, setIsLast] = useState(false);
   const [isDetail, setIsDetail] = useState(false);
-  const [isDetailShown, setIsDetailShown] = useState(false);
+  const [isFlippedCouponShown, setIsFlippedCouponShown] = useState(false);
   const [cafeId, setCafeId] = useState(0);
 
   const { data: couponsInfosData, status } = useQuery<{ coupons: CouponType[] }>(
@@ -92,13 +92,13 @@ const CouponList = () => {
 
     setIsDetail(true);
     setTimeout(() => {
-      setIsDetailShown(true);
+      setIsFlippedCouponShown(true);
     }, 700);
   };
 
   const closeCouponDetail = () => {
     setIsDetail(false);
-    setIsDetailShown(false);
+    setIsFlippedCouponShown(false);
   };
 
   return (
@@ -138,7 +138,7 @@ const CouponList = () => {
         onClick={swapCoupon}
         $isLast={isLast}
         $isDetail={isDetail}
-        $isShown={isDetailShown}
+        $isShown={isFlippedCouponShown}
       >
         {couponsInfosData.coupons.map(({ cafeInfo, couponInfos }, index) => (
           <>
@@ -157,7 +157,7 @@ const CouponList = () => {
           cafe={cafeData.cafe}
           closeDetail={closeCouponDetail}
           isDetail={isDetail}
-          isShown={isDetailShown}
+          isShown={isFlippedCouponShown}
         />
       )}
       <DetailButton onClick={openCouponDetail} $isDetail={isDetail} aria-label="쿠폰 상세 보기">

--- a/frontend/src/pages/CouponList/index.tsx
+++ b/frontend/src/pages/CouponList/index.tsx
@@ -24,7 +24,7 @@ import Color from 'color-thief-react';
 import { useNavigate } from 'react-router-dom';
 import { TbZoomCheck } from 'react-icons/tb';
 
-interface CouponType {
+export interface CouponType {
   cafeInfo: {
     id: number;
     name: string;
@@ -79,7 +79,7 @@ const CouponList = () => {
   };
 
   const showCouponDetail = (e: MouseEvent<HTMLButtonElement>) => {
-    setIsDetail(true);
+    setIsDetail(!isDetail);
   };
 
   return (
@@ -127,7 +127,7 @@ const CouponList = () => {
         {data.coupons.map(({ cafeInfo, couponInfos }, index) => (
           <Coupon
             key={cafeInfo.id}
-            frontImageUrl={couponInfos[0].frontImageUrl}
+            coupon={{ cafeInfo, couponInfos }}
             data-index={index}
             onClick={changeCurrentIndex(index)}
           />

--- a/frontend/src/pages/CouponList/index.tsx
+++ b/frontend/src/pages/CouponList/index.tsx
@@ -13,7 +13,7 @@ import {
   StampCount,
 } from './style';
 import { MouseEvent, useRef, useState } from 'react';
-import { getCafeInfo, getCoupon, getCoupons } from '../../api/get';
+import { getCafeInfo, getCoupons } from '../../api/get';
 import { useQuery } from '@tanstack/react-query';
 import AdminHeaderLogo from '../../assets/admin_header_logo.png';
 import { ROUTER_PATH } from '../../constants';
@@ -65,6 +65,7 @@ const CouponList = () => {
   const couponListContainerRef = useRef<HTMLDivElement>(null);
   const [isLast, setIsLast] = useState(false);
   const [isDetail, setIsDetail] = useState(false);
+  const [isDetailShown, setIsDetailShown] = useState(false);
   const [cafeId, setCafeId] = useState(0);
 
   const { data: couponsInfosData, status } = useQuery<{ coupons: CouponType[] }>(
@@ -109,10 +110,14 @@ const CouponList = () => {
     setCafeId(getCurrentCoupon().cafeInfo.id);
 
     setIsDetail(true);
+    setTimeout(() => {
+      setIsDetailShown(true);
+    }, 700);
   };
 
   const closeCouponDetail = () => {
     setIsDetail(false);
+    setIsDetailShown(false);
   };
 
   return (
@@ -156,6 +161,7 @@ const CouponList = () => {
         onClick={swapCoupon}
         $isLast={isLast}
         $isDetail={isDetail}
+        $isShown={isDetailShown}
       >
         {couponsInfosData.coupons.map(({ cafeInfo, couponInfos }, index) => (
           <>
@@ -174,6 +180,7 @@ const CouponList = () => {
           cafe={cafeData}
           closeDetail={closeCouponDetail}
           isDetail={isDetail}
+          isShown={isDetailShown}
         />
       )}
       <DetailButton onClick={openCouponDetail}>

--- a/frontend/src/pages/CouponList/index.tsx
+++ b/frontend/src/pages/CouponList/index.tsx
@@ -25,6 +25,12 @@ import { useNavigate } from 'react-router-dom';
 import { TbZoomCheck } from 'react-icons/tb';
 import CouponDetail from './CouponDetail';
 
+interface StampCoordinate {
+  order: number;
+  xCoordinate: number;
+  yCoordinate: number;
+}
+
 export interface CouponType {
   cafeInfo: {
     id: number;
@@ -40,7 +46,7 @@ export interface CouponType {
       frontImageUrl: string;
       backImageUrl: string;
       stampImageUrl: string;
-      // TODO: coordinate
+      coordinates: StampCoordinate[];
     },
   ];
 }

--- a/frontend/src/pages/CouponList/index.tsx
+++ b/frontend/src/pages/CouponList/index.tsx
@@ -71,6 +71,10 @@ const CouponList = () => {
     });
   };
 
+  const currentCoupon = couponsInfosData.coupons[currentIndex];
+  const currentCafeInfo = currentCoupon.cafeInfo;
+  const currentCouponInfo = currentCoupon.couponInfos[0];
+
   const getCurrentCoupon = () => {
     return couponsInfosData.coupons[currentIndex];
   };
@@ -109,7 +113,7 @@ const CouponList = () => {
       </HeaderContainer>
       <InfoContainer>
         <NameContainer>
-          <CafeName aria-label="카페 이름">{getCurrentCafeInfo().name}</CafeName>
+          <CafeName aria-label="카페 이름">{currentCafeInfo.name}</CafeName>
           {getCurrentCouponInfo().isFavorites ? (
             <AiFillStar size={40} color={'#FFD600'} />
           ) : (
@@ -117,7 +121,7 @@ const CouponList = () => {
           )}
         </NameContainer>
         <ProgressBarContainer aria-label="스탬프 개수">
-          <Color src={getCurrentCouponInfo().frontImageUrl} format="hex" crossOrigin="anonymous">
+          <Color src={currentCouponInfo.frontImageUrl} format="hex" crossOrigin="anonymous">
             {({ data: color }) => (
               <>
                 <BackDrop $couponMainColor={color ? color : 'gray'} />

--- a/frontend/src/pages/CouponList/style.tsx
+++ b/frontend/src/pages/CouponList/style.tsx
@@ -71,7 +71,7 @@ export const BackDrop = styled.div<{ $couponMainColor: string }>`
   opacity: 0.7;
 `;
 
-export const CouponListContainer = styled.div<{ $isLast: boolean }>`
+export const CouponListContainer = styled.div<{ $isLast: boolean; $isDetail: boolean }>`
   display: flex;
   justify-content: center;
   position: relative;
@@ -86,10 +86,14 @@ export const CouponListContainer = styled.div<{ $isLast: boolean }>`
           `
         : 'none'};
     cursor: pointer;
-    &:hover {
-      transform: scale(1.1);
-    }
   }
+
+  ${({ $isDetail }) =>
+    $isDetail
+      ? css`:nth-last-child(1) {
+    transform: translateY(-200%)`
+      : ''};
+
   :nth-last-child(2) {
     transform: translateY(0px) scale(1);
     pointer-events: none;

--- a/frontend/src/pages/CouponList/style.tsx
+++ b/frontend/src/pages/CouponList/style.tsx
@@ -131,5 +131,5 @@ export const DetailButton = styled.button`
   outline: none;
   background: white;
   box-shadow: 2px 2px 4px 4px rgba(0, 0, 0, 0.1);
-  z-index: 999;
+  z-index: -1;
 `;

--- a/frontend/src/pages/CouponList/style.tsx
+++ b/frontend/src/pages/CouponList/style.tsx
@@ -1,5 +1,5 @@
 import { css, styled } from 'styled-components';
-import { swap } from '../../style/keyframes';
+import { detail, swap } from '../../style/keyframes';
 
 export const HeaderContainer = styled.header`
   display: flex;
@@ -71,7 +71,11 @@ export const BackDrop = styled.div<{ $couponMainColor: string }>`
   opacity: 0.7;
 `;
 
-export const CouponListContainer = styled.div<{ $isLast: boolean; $isDetail: boolean }>`
+export const CouponListContainer = styled.div<{
+  $isLast: boolean;
+  $isDetail: boolean;
+  $isShown: boolean;
+}>`
   display: flex;
   justify-content: center;
   position: relative;
@@ -79,6 +83,7 @@ export const CouponListContainer = styled.div<{ $isLast: boolean; $isDetail: boo
   transition: all 0.1s;
 
   :nth-last-child(1) {
+    z-index: ${({ $isShown }) => ($isShown ? '-1' : '3')};
     transform: translateY(15px) scale(1.05);
     animation: ${({ $isLast }) =>
       $isLast
@@ -94,9 +99,8 @@ export const CouponListContainer = styled.div<{ $isLast: boolean; $isDetail: boo
     $isDetail &&
     css`
       :nth-last-child(1) {
-        transform: translateY(-250%);
-        transition: transform 0.6s ease-in-out;
-        backface-visibility: hidden;
+        transform: translateY(-250%) scale(0.86);
+        animation: ${detail} 0.4s;
       }
       :nth-last-child(n + 2) {
         display: none;

--- a/frontend/src/pages/CouponList/style.tsx
+++ b/frontend/src/pages/CouponList/style.tsx
@@ -59,7 +59,7 @@ export const BackDrop = styled.div<{ $couponMainColor: string }>`
   width: 100vw;
   overflow: hidden;
   height: 100%;
-  position: fixed;
+  position: absolute;
   top: 0;
   right: 0;
   background: linear-gradient(
@@ -76,6 +76,7 @@ export const CouponListContainer = styled.div<{ $isLast: boolean; $isDetail: boo
   justify-content: center;
   position: relative;
   height: 270px;
+  transition: all 0.4s;
 
   :nth-last-child(1) {
     transform: translateY(15px) scale(1.05);
@@ -89,15 +90,17 @@ export const CouponListContainer = styled.div<{ $isLast: boolean; $isDetail: boo
   }
 
   ${({ $isDetail }) =>
-    $isDetail
-      ? css`
-          :nth-last-child(1) {
-            transform: translateY(-200%) rotateY(180deg);
-            transition: transform 0.5s;
-            backface-visibility: hidden;
-          }
-        `
-      : ''}
+    $isDetail &&
+    css`
+      :nth-last-child(1) {
+        transform: translateY(-250%);
+        transition: transform 0.5s;
+        backface-visibility: hidden;
+      }
+      :nth-last-child(n + 2) {
+        display: none;
+      }
+    `}
 
   :nth-last-child(2) {
     transform: translateY(0px) scale(1);

--- a/frontend/src/pages/CouponList/style.tsx
+++ b/frontend/src/pages/CouponList/style.tsx
@@ -90,9 +90,14 @@ export const CouponListContainer = styled.div<{ $isLast: boolean; $isDetail: boo
 
   ${({ $isDetail }) =>
     $isDetail
-      ? css`:nth-last-child(1) {
-    transform: translateY(-200%)`
-      : ''};
+      ? css`
+          :nth-last-child(1) {
+            transform: translateY(-200%) rotateY(180deg);
+            transition: transform 0.5s;
+            backface-visibility: hidden;
+          }
+        `
+      : ''}
 
   :nth-last-child(2) {
     transform: translateY(0px) scale(1);
@@ -118,4 +123,5 @@ export const DetailButton = styled.button`
   outline: none;
   background: white;
   box-shadow: 2px 2px 4px 4px rgba(0, 0, 0, 0.1);
+  z-index: 999;
 `;

--- a/frontend/src/pages/CouponList/style.tsx
+++ b/frontend/src/pages/CouponList/style.tsx
@@ -121,7 +121,7 @@ export const CouponListContainer = styled.div<{
   }
 `;
 
-export const DetailButton = styled.button`
+export const DetailButton = styled.button<{ $isDetail: boolean }>`
   position: absolute;
   bottom: 50px;
   right: 40px;
@@ -131,5 +131,5 @@ export const DetailButton = styled.button`
   outline: none;
   background: white;
   box-shadow: 2px 2px 4px 4px rgba(0, 0, 0, 0.1);
-  z-index: -1;
+  z-index: ${({ $isDetail }) => ($isDetail ? -1 : 4)};
 `;

--- a/frontend/src/pages/CouponList/style.tsx
+++ b/frontend/src/pages/CouponList/style.tsx
@@ -76,16 +76,17 @@ export const CouponListContainer = styled.div<{ $isLast: boolean; $isDetail: boo
   justify-content: center;
   position: relative;
   height: 270px;
-  transition: all 0.4s;
+  transition: all 0.1s;
 
   :nth-last-child(1) {
     transform: translateY(15px) scale(1.05);
     animation: ${({ $isLast }) =>
       $isLast
         ? css`
-            ${swap} 0.7s forwards
+            ${swap} 0.5s forwards
           `
         : 'none'};
+    transition: transform 0.4s;
     cursor: pointer;
   }
 
@@ -94,7 +95,7 @@ export const CouponListContainer = styled.div<{ $isLast: boolean; $isDetail: boo
     css`
       :nth-last-child(1) {
         transform: translateY(-250%);
-        transition: transform 0.5s;
+        transition: transform 0.6s ease-in-out;
         backface-visibility: hidden;
       }
       :nth-last-child(n + 2) {

--- a/frontend/src/pages/CouponList/style.tsx
+++ b/frontend/src/pages/CouponList/style.tsx
@@ -100,7 +100,7 @@ export const CouponListContainer = styled.div<{
     css`
       :nth-last-child(1) {
         transform: translateY(-250%) scale(0.86);
-        animation: ${detail} 0.4s;
+        animation: ${detail} 0.3s;
       }
       :nth-last-child(n + 2) {
         display: none;

--- a/frontend/src/style/keyframes.ts
+++ b/frontend/src/style/keyframes.ts
@@ -10,3 +10,15 @@ export const swap = keyframes`
     z-index: -1;
   }
 `;
+
+export const detail = keyframes`
+  0% {
+    transform: translateY(15px) scale(1.05);
+    display: flex;
+  }
+  
+  100%{
+    transform: translateY(-250%) scale(0.86);
+display: none;
+  }
+`;

--- a/frontend/src/style/keyframes.ts
+++ b/frontend/src/style/keyframes.ts
@@ -19,6 +19,5 @@ export const detail = keyframes`
   
   100%{
     transform: translateY(-250%) scale(0.86);
-display: none;
   }
 `;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,0 +1,39 @@
+export interface StampCoordinate {
+  order: number;
+  xCoordinate: number;
+  yCoordinate: number;
+}
+
+export interface CafeType {
+  cafe: {
+    id: number;
+    name: string;
+    introduction: string;
+    openTime: string;
+    closeTime: string;
+    telephoneNumber: string;
+    cafeImageUrl: string;
+    roadAddress: string;
+    detailAddress: string;
+  };
+}
+
+export interface CouponType {
+  cafeInfo: {
+    id: number;
+    name: string;
+  };
+  couponInfos: [
+    {
+      id: number;
+      isFavorites: boolean;
+      stampCount: number;
+      maxStampCount: number;
+      rewardName: string;
+      frontImageUrl: string;
+      backImageUrl: string;
+      stampImageUrl: string;
+      coordinates: StampCoordinate[];
+    },
+  ];
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -4,18 +4,20 @@ export interface StampCoordinate {
   yCoordinate: number;
 }
 
+export interface CafeRes {
+  cafe: CafeType;
+}
+
 export interface CafeType {
-  cafe: {
-    id: number;
-    name: string;
-    introduction: string;
-    openTime: string;
-    closeTime: string;
-    telephoneNumber: string;
-    cafeImageUrl: string;
-    roadAddress: string;
-    detailAddress: string;
-  };
+  id: number;
+  name: string;
+  introduction: string;
+  openTime: string;
+  closeTime: string;
+  telephoneNumber: string;
+  cafeImageUrl: string;
+  roadAddress: string;
+  detailAddress: string;
 }
 
 export interface CouponType {


### PR DESCRIPTION
## 주요 변경사항

- 쿠폰 상세 페이지를 구현했습니다.
- 화면에 표시되는 쿠폰의 index와 `currentIndex`가 일치하지 않는 오류가 있어 수정하였습니다. 
- 월요일에 만나서 설명드릴테지만, 상세페이지가 열릴 때 실제 Y축 - 방향으로 이동하는 `Coupon` 컴포넌트와 상세 페이지에서 뒤집으며 확인하는 쿠폰은 다른 컴포넌트입니다.

++ 동작 화면에서는 확인할 수 없지만 쿠폰을 뒤집어 스탬프를 확인할 수 있음을 명시했습니다.

## 리뷰어에게...

동작 화면
![쿠폰_상세](https://github.com/woowacourse-teams/2023-stamp-crush/assets/90092440/702eed4b-6b4d-46da-8ade-91137bf42306)


## 관련 이슈

closes #207 

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [x] `milestone` 설정
