### PR TITLE
[FE] refactor: webpack.common.js의 중복되는 코드를 dev로 이동

### DIFF
--- a/frontend/webpack.common.js
+++ b/frontend/webpack.common.js
@@ -43,11 +43,4 @@ module.exports = {
     }),
   ],
   devtool: 'inline-source-map',
-  devServer: {
-    static: {
-      directory: path.join(__dirname, 'public'),
-    },
-    hot: true,
-    open: true,
-  },
 };

--- a/frontend/webpack.dev.js
+++ b/frontend/webpack.dev.js
@@ -1,10 +1,14 @@
-const { merge } = require("webpack-merge");
-const common = require("./webpack.common.js");
+const path = require('path');
+const { merge } = require('webpack-merge');
+const common = require('./webpack.common.js');
 
 module.exports = merge(common, {
-  mode: "development",
-  devtool: "eval",
+  mode: 'development',
+  devtool: 'eval',
   devServer: {
+    static: {
+      directory: path.join(__dirname, 'public'),
+    },
     historyApiFallback: true,
     port: 3000,
     hot: true,


### PR DESCRIPTION
## 주요 변경사항

- webpack.common.js와 webpack.dev.js 두 파일의 중복되는 코드를 제거하고 dev로 이동시켰습니다. 해당부분이 현재 admin에서 오류가 나는데, api 추상화 코드에 admin prefix가 부재해서 그렇습니다. 즉시 이슈 발행하도록 하겠습니다.

## 리뷰어에게...

## 관련 이슈

closes #266 

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [x] `milestone` 설정
