### PR TITLE
[FE] refactor: 고객 모드의 화면을 PC환경에서도 모바일뷰로 렌더링한다. 

### DIFF
--- a/frontend/src/Router.tsx
+++ b/frontend/src/Router.tsx
@@ -17,6 +17,7 @@ import SelectCoupon from './pages/Admin/SelectCoupon';
 import RewardPage from './pages/Admin/RewardPage';
 import { ROUTER_PATH } from './constants';
 import EarnStamp from './pages/Admin/EarnStamp';
+import CustomerTemplate from './components/Template/CustomerTemplate';
 
 const AdminRoot = () => {
   return (
@@ -31,9 +32,9 @@ const AdminRoot = () => {
 
 const CustomerRoot = () => {
   return (
-    <>
+    <CustomerTemplate>
       <Outlet />
-    </>
+    </CustomerTemplate>
   );
 };
 

--- a/frontend/src/components/Template/CustomerTemplate/index.tsx
+++ b/frontend/src/components/Template/CustomerTemplate/index.tsx
@@ -1,0 +1,12 @@
+import { PropsWithChildren } from 'react';
+import { BaseCustomerTemplate, ContentContainer } from './style';
+
+const CustomerTemplate = ({ children }: PropsWithChildren) => {
+  return (
+    <BaseCustomerTemplate>
+      <ContentContainer>{children}</ContentContainer>
+    </BaseCustomerTemplate>
+  );
+};
+
+export default CustomerTemplate;

--- a/frontend/src/components/Template/CustomerTemplate/style.tsx
+++ b/frontend/src/components/Template/CustomerTemplate/style.tsx
@@ -4,28 +4,20 @@ export const BaseCustomerTemplate = styled.div`
   display: flex;
   width: 100vw;
   height: 100vh;
-
-  @media screen and (min-width: 768px) {
-    align-items: center;
-  }
 `;
 
 export const ContentContainer = styled.main`
   display: flex;
   flex-direction: column;
-  height: 90vh;
+  width: 100%;
+  height: 100vh;
   max-width: 450px;
   margin: 0 auto;
   border-radius: 8px;
 
-  @media screen and (min-width: 768px) {
+  @media screen and (min-width: 450px) {
     position: relative;
-    width: 80%;
-    margin: 0 auto;
-  }
 
-  @media screen and (max-width: 768px) {
-    width: 100%;
-    position: static;
+    margin: 0 auto;
   }
 `;

--- a/frontend/src/components/Template/CustomerTemplate/style.tsx
+++ b/frontend/src/components/Template/CustomerTemplate/style.tsx
@@ -1,0 +1,23 @@
+import styled from 'styled-components';
+
+export const BaseCustomerTemplate = styled.div`
+  display: flex;
+  width: 100vw;
+  height: 100vh;
+  align-items: center;
+`;
+
+export const ContentContainer = styled.main`
+  display: flex;
+  position: relative;
+  flex-direction: column;
+  height: 90vh;
+  max-width: 450px;
+  margin: 0 auto;
+  border-radius: 8px;
+
+  @media screen and (min-width: 768px) {
+    width: 80%;
+    margin: 0 auto;
+  }
+`;

--- a/frontend/src/components/Template/CustomerTemplate/style.tsx
+++ b/frontend/src/components/Template/CustomerTemplate/style.tsx
@@ -4,12 +4,14 @@ export const BaseCustomerTemplate = styled.div`
   display: flex;
   width: 100vw;
   height: 100vh;
-  align-items: center;
+
+  @media screen and (min-width: 768px) {
+    align-items: center;
+  }
 `;
 
 export const ContentContainer = styled.main`
   display: flex;
-  position: relative;
   flex-direction: column;
   height: 90vh;
   max-width: 450px;
@@ -17,7 +19,13 @@ export const ContentContainer = styled.main`
   border-radius: 8px;
 
   @media screen and (min-width: 768px) {
+    position: relative;
     width: 80%;
     margin: 0 auto;
+  }
+
+  @media screen and (max-width: 768px) {
+    width: 100%;
+    position: static;
   }
 `;

--- a/frontend/src/pages/CouponList/CouponDetail/style.tsx
+++ b/frontend/src/pages/CouponList/CouponDetail/style.tsx
@@ -1,20 +1,32 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
+import { popup } from '../../../style/keyframes';
 
 export const CouponDetailContainer = styled.section<{ $isDetail: boolean }>`
-  opacity: ${({ $isDetail }) => ($isDetail ? '1' : '0')};
-
+  display: none;
   position: absolute;
   top: 0;
-  right: 0;
+  left: 0;
   width: 100vw;
   height: 100vh;
-  transform: translateX(${({ $isDetail }) => ($isDetail ? '0' : '500px')});
-  transition: all 0.4s ease-in-out;
+  background: white;
+  transform: translateY(100%);
+
+  ${({ $isDetail }) =>
+    $isDetail &&
+    css`
+      display: flex;
+      animation: ${popup} 0.4s;
+      transform: translateY(0);
+    `}
 
   background: white;
 
   h1 {
     white-space: pre-line;
+  }
+
+  @media screen and (min-width: 768px) {
+    max-width: 450px;
   }
 
   > :nth-child(2) {

--- a/frontend/src/pages/CouponList/style.tsx
+++ b/frontend/src/pages/CouponList/style.tsx
@@ -26,7 +26,6 @@ export const NameContainer = styled.div`
   display: flex;
   align-items: center;
   justify-content: space-between;
-  width: 100%;
   height: 36px;
   gap: 10px;
 `;
@@ -132,8 +131,8 @@ export const CouponListContainer = styled.div<{
 
 export const DetailButton = styled.button<{ $isDetail: boolean }>`
   position: fixed;
-  bottom: 30px;
-  right: 30px;
+  bottom: 10%;
+  right: calc(50% - 170px);
   border-radius: 50%;
   width: 60px;
   height: 60px;
@@ -141,4 +140,8 @@ export const DetailButton = styled.button<{ $isDetail: boolean }>`
   background: white;
   box-shadow: 2px 2px 4px 4px rgba(0, 0, 0, 0.1);
   z-index: ${({ $isDetail }) => ($isDetail ? -1 : 4)};
+
+  @media screen and (max-width: 768px) {
+    bottom: 5%;
+  }
 `;

--- a/frontend/src/pages/CouponList/style.tsx
+++ b/frontend/src/pages/CouponList/style.tsx
@@ -58,7 +58,8 @@ export const MaxStampCount = styled.span`
 
 export const BackDrop = styled.div<{ $couponMainColor: string }>`
   z-index: -10;
-  width: 100vw;
+  width: 100%;
+  max-width: 450px;
   overflow: hidden;
   height: 100%;
   position: absolute;
@@ -73,10 +74,6 @@ export const BackDrop = styled.div<{ $couponMainColor: string }>`
   opacity: 0.7;
   left: 50%;
   transform: translateX(-50%);
-
-  @media screen and (min-width: 768px) {
-    max-width: 450px;
-  }
 `;
 
 export const CouponListContainer = styled.div<{
@@ -131,7 +128,7 @@ export const CouponListContainer = styled.div<{
 
 export const DetailButton = styled.button<{ $isDetail: boolean }>`
   position: fixed;
-  bottom: 10%;
+  bottom: 30px;
   right: calc(50% - 170px);
   border-radius: 50%;
   width: 60px;
@@ -140,8 +137,4 @@ export const DetailButton = styled.button<{ $isDetail: boolean }>`
   background: white;
   box-shadow: 2px 2px 4px 4px rgba(0, 0, 0, 0.1);
   z-index: ${({ $isDetail }) => ($isDetail ? -1 : 4)};
-
-  @media screen and (max-width: 768px) {
-    bottom: 5%;
-  }
 `;

--- a/frontend/src/pages/CouponList/style.tsx
+++ b/frontend/src/pages/CouponList/style.tsx
@@ -3,6 +3,7 @@ import { detail, swap } from '../../style/keyframes';
 
 export const HeaderContainer = styled.header`
   display: flex;
+  width: 100%;
   height: 65px;
   justify-content: space-between;
   align-items: center;
@@ -71,6 +72,12 @@ export const BackDrop = styled.div<{ $couponMainColor: string }>`
     white
   );
   opacity: 0.7;
+  left: 50%;
+  transform: translateX(-50%);
+
+  @media screen and (min-width: 768px) {
+    max-width: 450px;
+  }
 `;
 
 export const CouponListContainer = styled.div<{
@@ -101,7 +108,7 @@ export const CouponListContainer = styled.div<{
     $isDetail &&
     css`
       :nth-last-child(1) {
-        transform: translateY(-250%) scale(0.86);
+        transform: translateY(-219%) scale(0.86);
         animation: ${detail} 0.3s;
       }
       :nth-last-child(n + 2) {

--- a/frontend/src/style/keyframes.ts
+++ b/frontend/src/style/keyframes.ts
@@ -18,6 +18,16 @@ export const detail = keyframes`
   }
   
   100%{
-    transform: translateY(-250%) scale(0.86);
+    transform: translateY(-219%) scale(0.86);
+  }
+`;
+
+export const popup = keyframes`
+  0% {
+    transform: translateY(100%);
+  }
+
+  100% {
+    transform: translateY(0);
   }
 `;


### PR DESCRIPTION
## 주요 변경사항

- 최소 태블릿(768px) 뷰포트 기준으로 pc환경에서의 뷰를 최대한 모바일에서 보이는 것처럼 변경했습니다.

## 리뷰어에게...

동작 화면
<img width="1384" alt="스크린샷 2023-08-01 오후 9 21 33" src="https://github.com/woowacourse-teams/2023-stamp-crush/assets/90092440/f5f3d76e-4630-4be4-9074-594a6797b8f7">

## 관련 이슈

closes

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [x] `milestone` 설정
