### PR TITLE
[FE] fix: 구글드라이브 호스팅 이미지 url color-thief cors에러 해결

### DIFF
--- a/frontend/src/components/ProgressBar/index.tsx
+++ b/frontend/src/components/ProgressBar/index.tsx
@@ -6,7 +6,7 @@ interface ProgressBarProps {
   color?: string;
 }
 
-const ProgressBar = ({ stampCount, maxCount, color = 'skyblue' }: ProgressBarProps) => {
+const ProgressBar = ({ stampCount, maxCount, color = 'gray' }: ProgressBarProps) => {
   return (
     <Bar>
       <Progress $width={(stampCount / maxCount) * 100} $color={color} />

--- a/frontend/src/pages/CouponList/index.tsx
+++ b/frontend/src/pages/CouponList/index.tsx
@@ -28,6 +28,7 @@ import Alert from '../../components/Alert';
 import useModal from '../../hooks/useModal';
 import { CiCircleMore } from 'react-icons/ci';
 import { postIsFavorites } from '../../api/post';
+import { addGoogleProxyUrl } from '../../utils';
 
 const CouponList = () => {
   const navigate = useNavigate();
@@ -143,7 +144,7 @@ const CouponList = () => {
         </NameContainer>
         <ProgressBarContainer aria-label="스탬프 개수">
           <Color
-            src={currentCoupon.couponInfos[0].frontImageUrl}
+            src={addGoogleProxyUrl(currentCoupon.couponInfos[0].frontImageUrl)}
             format="hex"
             crossOrigin="anonymous"
           >

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -52,3 +52,7 @@ export const isEmptyData = (data: string | undefined) => {
 
   return data.length === 0;
 };
+
+export const addGoogleProxyUrl = (url: string) =>
+  'https://images1-focus-opensocial.googleusercontent.com/gadgets/proxy?container=focus&refresh=2592000&url=' +
+  encodeURIComponent(url);


### PR DESCRIPTION
## 주요 변경사항

unsplash나 picksom과는 다르게 google drive의 이미지 url은 color-thief-react가 제대로 작동하지 않는 문제가 있었습니다. 
찾아보니까 cors에러였고, 구글 프록시 서버를 넣어줌으로써 해결하였습니다.🎊
[참고링크](https://lokeshdhakar.com/projects/color-thief/)

## 리뷰어에게...
![ezgif-4-aa3fc1675c](https://github.com/woowacourse-teams/2023-stamp-crush/assets/62367797/78b55744-4d28-40ab-b359-de0ce2c66922)


## 관련 이슈

closes #280 

## 체크리스트

- [ ] `reviewers` 설정
- [ ] `label` 설정
- [ ] `milestone` 설정
