### PR TITLE
[BE] fix: 고객 쿠폰 조회에서 isFavorites를 상수가 아닌 데이터베이스 값으로 변경한다 

### DIFF
--- a/backend/src/main/java/com/stampcrush/backend/api/visitor/coupon/VisitorCouponFindApiController.java
+++ b/backend/src/main/java/com/stampcrush/backend/api/visitor/coupon/VisitorCouponFindApiController.java
@@ -1,7 +1,7 @@
 package com.stampcrush.backend.api.visitor.coupon;
 
 import com.stampcrush.backend.api.visitor.coupon.response.CustomerCouponsFindResponse;
-import com.stampcrush.backend.application.visitor.coupon.VisitorCustomerCouponFindService;
+import com.stampcrush.backend.application.visitor.coupon.VisitorCouponFindService;
 import com.stampcrush.backend.application.visitor.coupon.dto.CustomerCouponFindResultDto;
 import com.stampcrush.backend.config.resolver.CustomerAuth;
 import lombok.RequiredArgsConstructor;
@@ -15,13 +15,13 @@ import java.util.List;
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/api")
-public class VisitorCustomerCouponFindApiController {
+public class VisitorCouponFindApiController {
 
-    private final VisitorCustomerCouponFindService visitorCustomerCouponFindService;
+    private final VisitorCouponFindService visitorCouponFindService;
 
     @GetMapping("/coupons")
     public ResponseEntity<CustomerCouponsFindResponse> findOneCouponForOneCafe(CustomerAuth customer) {
-        List<CustomerCouponFindResultDto> coupons = visitorCustomerCouponFindService.findOneCouponForOneCafe(customer.getId());
+        List<CustomerCouponFindResultDto> coupons = visitorCouponFindService.findOneCouponForOneCafe(customer.getId());
         return ResponseEntity.ok()
                 .body(CustomerCouponsFindResponse.from(coupons));
     }

--- a/backend/src/main/java/com/stampcrush/backend/application/visitor/coupon/VisitorCouponFindService.java
+++ b/backend/src/main/java/com/stampcrush/backend/application/visitor/coupon/VisitorCouponFindService.java
@@ -1,6 +1,7 @@
 package com.stampcrush.backend.application.visitor.coupon;
 
 import com.stampcrush.backend.application.visitor.coupon.dto.CustomerCouponFindResultDto;
+import com.stampcrush.backend.application.visitor.favorites.VisitorFavoritesFindService;
 import com.stampcrush.backend.entity.cafe.Cafe;
 import com.stampcrush.backend.entity.coupon.Coupon;
 import com.stampcrush.backend.entity.coupon.CouponStampCoordinate;
@@ -23,8 +24,7 @@ import java.util.Optional;
 @Service
 public class VisitorCouponFindService {
 
-    private static final Boolean IS_FAVORITES_TEMPORARY_VALUE = Boolean.TRUE;
-
+    private final VisitorFavoritesFindService visitorFavoritesFindService;
     private final CustomerRepository customerRepository;
     private final CouponRepository couponRepository;
     private final CouponStampCoordinateRepository couponStampCoordinateRepository;
@@ -36,9 +36,7 @@ public class VisitorCouponFindService {
         List<CustomerCouponFindResultDto> response = new ArrayList<>();
         for (Coupon coupon : coupons) {
             Cafe cafe = coupon.getCafe();
-
-
-            Boolean isFavorites = IS_FAVORITES_TEMPORARY_VALUE;
+            Boolean isFavorites = visitorFavoritesFindService.findIsFavorites(cafe, customer);
             List<CouponStampCoordinate> coordinates = couponStampCoordinateRepository.findByCouponDesign(coupon.getCouponDesign());
             response.add(CustomerCouponFindResultDto.of(cafe, coupon, isFavorites, coordinates));
         }

--- a/backend/src/main/java/com/stampcrush/backend/application/visitor/coupon/VisitorCouponFindService.java
+++ b/backend/src/main/java/com/stampcrush/backend/application/visitor/coupon/VisitorCouponFindService.java
@@ -21,7 +21,7 @@ import java.util.Optional;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 @Service
-public class VisitorCustomerCouponFindService {
+public class VisitorCouponFindService {
 
     private static final Boolean IS_FAVORITES_TEMPORARY_VALUE = Boolean.TRUE;
 
@@ -36,6 +36,8 @@ public class VisitorCustomerCouponFindService {
         List<CustomerCouponFindResultDto> response = new ArrayList<>();
         for (Coupon coupon : coupons) {
             Cafe cafe = coupon.getCafe();
+
+
             Boolean isFavorites = IS_FAVORITES_TEMPORARY_VALUE;
             List<CouponStampCoordinate> coordinates = couponStampCoordinateRepository.findByCouponDesign(coupon.getCouponDesign());
             response.add(CustomerCouponFindResultDto.of(cafe, coupon, isFavorites, coordinates));

--- a/backend/src/main/java/com/stampcrush/backend/application/visitor/favorites/VisitorFavoritesFindService.java
+++ b/backend/src/main/java/com/stampcrush/backend/application/visitor/favorites/VisitorFavoritesFindService.java
@@ -1,0 +1,29 @@
+package com.stampcrush.backend.application.visitor.favorites;
+
+import com.stampcrush.backend.entity.cafe.Cafe;
+import com.stampcrush.backend.entity.favorites.Favorites;
+import com.stampcrush.backend.entity.user.Customer;
+import com.stampcrush.backend.repository.favorites.FavoritesRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class VisitorFavoritesFindService {
+
+    private final FavoritesRepository favoritesRepository;
+
+    public boolean findIsFavorites(Cafe cafe, Customer customer) {
+        Optional<Favorites> favorites = favoritesRepository.findByCafeAndCustomer(cafe, customer);
+
+        if (favorites.isEmpty()) {
+            return false;
+        }
+
+        return favorites.get().getIsFavorites();
+    }
+}


### PR DESCRIPTION
## 주요 변경사항

- 구현 시점에 하디의 favorites 내용이 없어서, 하드코딩으로 박아놨었는데 추가되어서 이후에 저도 변경했습니다.
- repository는 하디가 작성했던 메서드를 그대로 사용했는데, 테스트 코드가 없더라고요. favorites의 동작과 운명을 같이하겠습니다. 

## 리뷰어에게...

## 관련 이슈

closes #309 

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [x] `milestone` 설정
