### PR TITLE
[BE] refactor: 리워드 조회와 사용에 관한 테스트 추가 작성

### DIFF
--- a/backend/src/test/java/com/stampcrush/backend/acceptance/RewardAcceptanceTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/RewardAcceptanceTest.java
@@ -1,0 +1,181 @@
+package com.stampcrush.backend.acceptance;
+
+import com.stampcrush.backend.api.manager.cafe.request.CafeCreateRequest;
+import com.stampcrush.backend.api.manager.coupon.request.CouponCreateRequest;
+import com.stampcrush.backend.api.manager.coupon.request.StampCreateRequest;
+import com.stampcrush.backend.api.manager.reward.request.RewardUsedUpdateRequest;
+import com.stampcrush.backend.api.manager.reward.response.RewardFindResponse;
+import com.stampcrush.backend.entity.user.Customer;
+import com.stampcrush.backend.entity.user.Owner;
+import com.stampcrush.backend.entity.user.RegisterCustomer;
+import com.stampcrush.backend.entity.user.TemporaryCustomer;
+import com.stampcrush.backend.repository.user.OwnerRepository;
+import com.stampcrush.backend.repository.user.RegisterCustomerRepository;
+import com.stampcrush.backend.repository.user.TemporaryCustomerRepository;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.http.ContentType.JSON;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class RewardAcceptanceTest extends AcceptanceTest {
+
+    // TODO 회원가입, 로그인 구현 후 제거
+    @Autowired
+    private OwnerRepository ownerRepository;
+
+    // TODO 회원가입, 로그인 구현 후 제거
+    @Autowired
+    private RegisterCustomerRepository registerCustomerRepository;
+
+    // TODO 회원가입, 로그인 구현 후 제거
+    @Autowired
+    private TemporaryCustomerRepository temporaryCustomerRepository;
+
+    @Test
+    void 카페사장이_가입_회원의_리워드를_사용한다() {
+        // given
+        Customer customer = 가입_회원_생성_후_가입_고객_반환();
+        Owner owner = 카페_사장_생성_후_사장_반환();
+        CafeCreateRequest cafeCreateRequest = new CafeCreateRequest("cafe", "잠실", "루터회관", "111111111");
+        Long cafeId = 카페_생성_후_카페_아이디_반환(owner, cafeCreateRequest);
+        CouponCreateRequest couponCreateRequest = new CouponCreateRequest(cafeId);
+        Long couponId = 쿠폰_생성_후_쿠폰_아이디_반환(owner, couponCreateRequest, customer.getId());
+        StampCreateRequest stampCreateRequest = new StampCreateRequest(10);
+        스탬프_찍은_후_리워드_생성(owner, customer.getId(), couponId, stampCreateRequest);
+        List<RewardFindResponse> rewards = 리워드_목록_조회(owner, cafeId, customer.getId());
+        Long rewardId = rewards.get(0).getId();
+
+        //when
+        RewardUsedUpdateRequest request = new RewardUsedUpdateRequest(cafeId, true);
+        리워드_사용(owner, request, customer.getId(), rewardId);
+        List<RewardFindResponse> restRewards = 리워드_목록_조회(owner, cafeId, customer.getId());
+
+        // then
+        SoftAssertions softAssertions = new SoftAssertions();
+        softAssertions.assertThat(rewards.size()).isEqualTo(1);
+        softAssertions.assertThat(restRewards.size()).isEqualTo(0);
+        softAssertions.assertAll();
+    }
+
+    @Test
+    void 카페사장이_임시_회원의_리워드를_사용할_수_없다() {
+        // given
+        Customer customer = 임시_회원_생성_후_가입_고객_반환();
+        Owner owner = 카페_사장_생성_후_사장_반환();
+        CafeCreateRequest cafeCreateRequest = new CafeCreateRequest("cafe", "잠실", "루터회관", "111111111");
+        Long cafeId = 카페_생성_후_카페_아이디_반환(owner, cafeCreateRequest);
+        CouponCreateRequest couponCreateRequest = new CouponCreateRequest(cafeId);
+        Long couponId = 쿠폰_생성_후_쿠폰_아이디_반환(owner, couponCreateRequest, customer.getId());
+        StampCreateRequest stampCreateRequest = new StampCreateRequest(10);
+        스탬프_찍은_후_리워드_생성(owner, customer.getId(), couponId, stampCreateRequest);
+        List<RewardFindResponse> rewards = 리워드_목록_조회(owner, cafeId, customer.getId());
+        Long rewardId = rewards.get(0).getId();
+
+        //when
+        RewardUsedUpdateRequest request = new RewardUsedUpdateRequest(cafeId, true);
+        리워드_사용(owner, request, customer.getId(), rewardId);
+        List<RewardFindResponse> restRewards = 리워드_목록_조회(owner, cafeId, customer.getId());
+
+        // then
+        SoftAssertions softAssertions = new SoftAssertions();
+        softAssertions.assertThat(rewards.size()).isEqualTo(1);
+        softAssertions.assertThat(restRewards.size()).isEqualTo(1);
+        softAssertions.assertAll();
+    }
+
+    @Test
+    void 카페사장이_가입_회원의_리워드를_조회한다() {
+        // given
+        Customer customer = 가입_회원_생성_후_가입_고객_반환();
+        Owner owner = 카페_사장_생성_후_사장_반환();
+        CafeCreateRequest cafeCreateRequest = new CafeCreateRequest("cafe", "잠실", "루터회관", "111111111");
+        Long cafeId = 카페_생성_후_카페_아이디_반환(owner, cafeCreateRequest);
+        CouponCreateRequest couponCreateRequest = new CouponCreateRequest(cafeId);
+        Long couponId = 쿠폰_생성_후_쿠폰_아이디_반환(owner, couponCreateRequest, customer.getId());
+        StampCreateRequest stampCreateRequest = new StampCreateRequest(10);
+        스탬프_찍은_후_리워드_생성(owner, customer.getId(), couponId, stampCreateRequest);
+        List<TemporaryCustomer> all = temporaryCustomerRepository.findAll();
+
+        // when
+        List<RewardFindResponse> rewards = 리워드_목록_조회(owner, cafeId, customer.getId());
+
+        // then
+        assertThat(rewards.size()).isEqualTo(1);
+    }
+
+    // TODO 회원가입, 로그인 구현 후 API CAll 로 대체
+    private Customer 가입_회원_생성_후_가입_고객_반환() {
+        return registerCustomerRepository.save(new RegisterCustomer("leo", "01022222222", "leoId", "5678"));
+    }
+
+    // TODO 회원가입, 로그인 구현 후 API CAll 로 대체
+    private Customer 임시_회원_생성_후_가입_고객_반환() {
+        return temporaryCustomerRepository.save(TemporaryCustomer.from("01011111111"));
+    }
+
+    // TODO 회원가입, 로그인 구현 후 API CAll 로 대체
+    private Owner 카페_사장_생성_후_사장_반환() {
+        return ownerRepository.save(new Owner("hardy", "hardyId", "1234", "01011111111"));
+    }
+
+    private Long 카페_생성_후_카페_아이디_반환(Owner owner, CafeCreateRequest cafeCreateRequest) {
+        return Long.valueOf(
+                given()
+                        .contentType(JSON)
+                        .body(cafeCreateRequest)
+                        .auth().preemptive().basic(owner.getLoginId(), owner.getEncryptedPassword())
+                        .when()
+                        .post("/api/admin/cafes")
+                        .thenReturn()
+                        .header("Location")
+                        .split("/")[2]);
+    }
+
+    private Long 쿠폰_생성_후_쿠폰_아이디_반환(Owner owner, CouponCreateRequest couponCreateRequest, Long customerId) {
+        return given()
+                .contentType(JSON)
+                .body(couponCreateRequest)
+                .auth().preemptive().basic(owner.getLoginId(), owner.getEncryptedPassword())
+                .when()
+                .post("/api/admin/customers/" + customerId + "/coupons")
+                .thenReturn()
+                .jsonPath()
+                .getLong("couponId");
+    }
+
+    private void 스탬프_찍은_후_리워드_생성(Owner owner, Long customerId, Long couponId, StampCreateRequest stampCreateRequest) {
+        given()
+                .contentType(JSON)
+                .body(stampCreateRequest)
+                .auth().preemptive().basic(owner.getLoginId(), owner.getEncryptedPassword())
+                .when()
+                .post("/api/admin/customers/" + customerId + "/coupons/" + couponId + "/stamps");
+    }
+
+    private List<RewardFindResponse> 리워드_목록_조회(Owner owner, Long cafeId, Long customerId) {
+        return given()
+                .queryParam("cafe-id", cafeId)
+                .queryParam("used", false)
+                .contentType(JSON)
+                .auth().preemptive().basic(owner.getLoginId(), owner.getEncryptedPassword())
+                .when()
+                .get("/api/admin/customers/" + customerId + "/rewards")
+                .thenReturn()
+                .jsonPath()
+                .getList("rewards", RewardFindResponse.class);
+    }
+
+    private void 리워드_사용(Owner owner, RewardUsedUpdateRequest rewardUsedUpdateRequest, Long customerId, Long rewardId) {
+        given()
+                .contentType(JSON)
+                .body(rewardUsedUpdateRequest)
+                .auth().preemptive().basic(owner.getLoginId(), owner.getEncryptedPassword())
+                .when()
+                .patch("/api/admin/customers/" + customerId + "/rewards/" + rewardId);
+    }
+}

--- a/backend/src/test/java/com/stampcrush/backend/api/reward/ManagerRewardFindApiControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/reward/ManagerRewardFindApiControllerTest.java
@@ -1,0 +1,60 @@
+package com.stampcrush.backend.api.reward;
+
+import com.stampcrush.backend.api.manager.reward.ManagerRewardFindApiController;
+import com.stampcrush.backend.application.manager.reward.ManagerRewardFindService;
+import com.stampcrush.backend.application.manager.reward.dto.RewardFindDto;
+import com.stampcrush.backend.application.manager.reward.dto.RewardFindResultDto;
+import com.stampcrush.backend.config.WebMvcConfig;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(value = ManagerRewardFindApiController.class,
+        excludeFilters =
+        @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebMvcConfig.class))
+public class ManagerRewardFindApiControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private ManagerRewardFindService managerRewardFindService;
+
+    @Test
+    void 리워드_목록을_조회한다() throws Exception {
+        // given
+        String ids = "$.rewards[?(@.id == '%s')]";
+        String names = "$.rewards[?(@.name == '%s')]";
+        List<RewardFindResultDto> expectedServiceReturn = List.of(
+                new RewardFindResultDto(1L, "Americano"),
+                new RewardFindResultDto(3L, "HotChocoLatte")
+        );
+        when(managerRewardFindService.findRewards(any(RewardFindDto.class)))
+                .thenReturn(expectedServiceReturn);
+
+        // when, then
+        mockMvc.perform(
+                        get("/api/admin/customers/1/rewards")
+                                .param("cafe-id", "1")
+                                .param("used", "false")
+                                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath(ids, "1").exists())
+                .andExpect(jsonPath(ids, "3").exists())
+                .andExpect(jsonPath(names, "Americano").exists())
+                .andExpect(jsonPath(names, "HotChocoLatte").exists());
+    }
+}

--- a/backend/src/test/java/com/stampcrush/backend/api/reward/MangerRewardCommandApiControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/reward/MangerRewardCommandApiControllerTest.java
@@ -1,0 +1,78 @@
+package com.stampcrush.backend.api.reward;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.stampcrush.backend.api.manager.reward.ManagerRewardCommandApiController;
+import com.stampcrush.backend.api.manager.reward.request.RewardUsedUpdateRequest;
+import com.stampcrush.backend.application.manager.reward.ManagerRewardCommandService;
+import com.stampcrush.backend.application.manager.reward.dto.RewardUsedUpdateDto;
+import com.stampcrush.backend.config.WebMvcConfig;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(value = ManagerRewardCommandApiController.class,
+        excludeFilters =
+        @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebMvcConfig.class))
+public class MangerRewardCommandApiControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private ManagerRewardCommandService managerRewardCommandService;
+
+    @Test
+    void 리워드를_사용한다() throws Exception {
+        // given
+        RewardUsedUpdateRequest request = new RewardUsedUpdateRequest(1L, true);
+        doNothing()
+                .when(managerRewardCommandService)
+                .useReward(any(RewardUsedUpdateDto.class));
+
+        // when, then
+        mockMvc.perform(
+                        patch("/api/admin/customers/1/rewards/1")
+                                .content(objectMapper.writeValueAsString(request))
+                                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void 리워드_사용시_used_가_false_이면_상태코드가_BAD_REQUEST_이다() throws Exception {
+        // given
+        RewardUsedUpdateRequest request = new RewardUsedUpdateRequest(1L, false);
+
+        // when, then
+        mockMvc.perform(
+                        patch("/api/admin/customers/1/rewards/1")
+                                .content(objectMapper.writeValueAsString(request))
+                                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void 리워드_사용시_cafeId_가_양수가_아니면_상태코드가_BAD_REQUEST_이다() throws Exception {
+        // given
+        RewardUsedUpdateRequest request = new RewardUsedUpdateRequest(-1L, true);
+
+        // when, then
+        mockMvc.perform(
+                        patch("/api/admin/customers/1/rewards/1")
+                                .content(objectMapper.writeValueAsString(request))
+                                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
+    }
+}


### PR DESCRIPTION
## 주요 변경사항
- `ManagerRewardCommandApiController`, `ManagerRewardFindApiController` 단위 테스트 작성
- 리워드 사용과 조회 인수테스트 작성

## 리뷰어에게...
- 컨트롤러 단위 테스트에서 인증 관련 `webConfig`는 필터로 제외하였습니다.
- 그 이유는 컨트롤러의 파라미터 바인딩, 예외 처리에 관련된 부분을 제외하고 추가적인 작업이라 생각이 들어서입니다.
- 인증관련된 테스트는 하나로 하는것도 괜찮아보입니다.

## 관련 이슈

closes #337 

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [x] `milestone` 설정
