### PR TITLE
[FE] fix: 3차데모 이후 발견한 버그 수정 및 리팩토링

### DIFF
--- a/frontend/src/pages/CouponList/CafeInfo/index.tsx
+++ b/frontend/src/pages/CouponList/CafeInfo/index.tsx
@@ -1,0 +1,72 @@
+import Color from 'color-thief-react';
+import { AiFillStar, AiOutlineStar } from 'react-icons/ai';
+import ProgressBar from '../../../components/ProgressBar';
+import { addGoogleProxyUrl } from '../../../utils';
+import {
+  BackDrop,
+  CafeName,
+  InfoContainer,
+  MaxStampCount,
+  NameContainer,
+  ProgressBarContainer,
+  StampCount,
+} from './style';
+
+interface CafeInfoProps {
+  cafeName: string;
+  stampCount: number;
+  maxStampCount: number;
+  isFavorites: boolean;
+  frontImageUrl: string;
+  onClickStar: () => void;
+}
+
+const CafeInfo = ({
+  cafeName,
+  stampCount,
+  maxStampCount,
+  isFavorites,
+  frontImageUrl,
+  onClickStar,
+}: CafeInfoProps) => {
+  return (
+    <>
+      <InfoContainer>
+        <NameContainer>
+          <CafeName aria-label="카페 이름">{cafeName}</CafeName>
+          {isFavorites ? (
+            <AiFillStar
+              size={40}
+              color={'#FFD600'}
+              onClick={onClickStar}
+              aria-label="즐겨찾기 해제"
+              role="button"
+            />
+          ) : (
+            <AiOutlineStar
+              size={40}
+              color={'#FFD600'}
+              onClick={onClickStar}
+              aria-label="즐겨찾기 등록"
+              role="button"
+            />
+          )}
+        </NameContainer>
+        <ProgressBarContainer aria-label="스탬프 개수">
+          <Color src={addGoogleProxyUrl(frontImageUrl)} format="hex" crossOrigin="anonymous">
+            {({ data: color }) => (
+              <>
+                <BackDrop $couponMainColor={color ? color : 'gray'} />
+                <ProgressBar stampCount={stampCount} maxCount={maxStampCount} color={color} />
+              </>
+            )}
+          </Color>
+          <StampCount aria-label={`현재 스탬프 개수 ${stampCount}개`}>{stampCount}</StampCount>/
+          <MaxStampCount aria-label="필요한 스탬프 개수">{maxStampCount}</MaxStampCount>
+        </ProgressBarContainer>
+      </InfoContainer>
+    </>
+  );
+};
+
+export default CafeInfo;

--- a/frontend/src/pages/CouponList/CafeInfo/style.tsx
+++ b/frontend/src/pages/CouponList/CafeInfo/style.tsx
@@ -53,7 +53,7 @@ export const BackDrop = styled.div<{ $couponMainColor: string }>`
   background: linear-gradient(
     white,
     rgba(255, 255, 255, 0.5) 32%,
-    ${(props) => props.$couponMainColor} 80%,
+    ${({ $couponMainColor }) => $couponMainColor} 80%,
     white
   );
   opacity: 0.7;

--- a/frontend/src/pages/CouponList/CafeInfo/style.tsx
+++ b/frontend/src/pages/CouponList/CafeInfo/style.tsx
@@ -1,0 +1,62 @@
+import { styled } from 'styled-components';
+
+export const InfoContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  padding: 60px 30px;
+  gap: 20px;
+`;
+
+export const NameContainer = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: 36px;
+  gap: 10px;
+`;
+
+export const CafeName = styled.span`
+  font-size: 36px;
+  font-weight: 700;
+  margin-top: 5px;
+`;
+
+export const ProgressBarContainer = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 24px;
+  color: #888;
+`;
+
+export const StampCount = styled.span`
+  margin-left: 10px;
+  font-size: 36px;
+  font-weight: 600;
+  color: black;
+`;
+
+export const MaxStampCount = styled.span`
+  font-size: 24px;
+  color: #f3b209;
+`;
+
+export const BackDrop = styled.div<{ $couponMainColor: string }>`
+  z-index: -10;
+  width: 100%;
+  max-width: 450px;
+  overflow: hidden;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  right: 0;
+  background: linear-gradient(
+    white,
+    rgba(255, 255, 255, 0.5) 32%,
+    ${(props) => props.$couponMainColor} 80%,
+    white
+  );
+  opacity: 0.7;
+  left: 50%;
+  transform: translateX(-50%);
+`;

--- a/frontend/src/pages/CouponList/Coupon/index.tsx
+++ b/frontend/src/pages/CouponList/Coupon/index.tsx
@@ -3,11 +3,11 @@ import { CouponWrapper } from './style';
 
 interface CouponProps {
   coupon: CouponType;
-  onClick: () => void;
   isFocused: boolean;
+  onClick: () => void;
 }
 
-const Coupon = ({ coupon, onClick, isFocused }: CouponProps) => {
+const Coupon = ({ coupon, isFocused, onClick }: CouponProps) => {
   return (
     <CouponWrapper
       $src={coupon.couponInfos[0].frontImageUrl}

--- a/frontend/src/pages/CouponList/CouponDetail/index.tsx
+++ b/frontend/src/pages/CouponList/CouponDetail/index.tsx
@@ -24,9 +24,7 @@ interface CouponDetailProps {
 
 const CouponDetail = ({ isDetail, isShown, coupon, cafe, closeDetail }: CouponDetailProps) => {
   // FIXME: cafeName 등 넘겨받은 데이터 이후에 알맞게 변경
-  const couponInfos = coupon.couponInfos[0];
-
-  const cafeName = coupon.cafeInfo.name;
+  const [couponInfos] = coupon.couponInfos;
 
   // FIXME: 이후 카페 관리 병합 후 parseUtil 사용
   return (
@@ -44,24 +42,24 @@ const CouponDetail = ({ isDetail, isShown, coupon, cafe, closeDetail }: CouponDe
         <BiArrowBack size={24} />
       </CloseButton>
       <OverviewContainer>
-        <Text variant="subTitle">{cafeName}</Text>
+        <Text variant="subTitle">{coupon.cafeInfo.name}</Text>
         <Text>{cafe.introduction}</Text>
       </OverviewContainer>
       <ContentContainer>
         <Text ariaLabel="쿠폰 정책">
-          <FaRegBell size={24} />
+          <FaRegBell size={22} />
           {`스탬프 ${couponInfos.maxStampCount}개를 채우면 ${couponInfos.rewardName} 무료!`}
         </Text>
         <Text ariaLabel="영업 시간">
-          <FaRegClock size={24} />
-          {`여는 시간 ${cafe.openTime}\n닫는 시간 ${cafe.closeTime}`}
+          <FaRegClock size={22} />
+          {`${cafe.openTime} - ${cafe.closeTime}`}
         </Text>
         <Text ariaLabel="전화번호">
-          <FaPhoneAlt size={24} />
+          <FaPhoneAlt size={22} />
           {parsePhoneNumber(cafe.telephoneNumber)}
         </Text>
         <Text ariaLabel="주소">
-          <FaLocationDot size={24} />
+          <FaLocationDot size={22} />
           {cafe.roadAddress + ' ' + cafe.detailAddress}
         </Text>
       </ContentContainer>

--- a/frontend/src/pages/CouponList/CouponDetail/style.tsx
+++ b/frontend/src/pages/CouponList/CouponDetail/style.tsx
@@ -47,8 +47,9 @@ export const OverviewContainer = styled.div`
   width: 100%;
   height: 130px;
   top: 260px;
-  padding: 0 10px;
+  padding: 0 30px;
   gap: 10px;
+  line-height: 24px;
   word-break: break-all;
   overflow: hidden;
 
@@ -69,11 +70,10 @@ export const ContentContainer = styled.div`
   display: flex;
   flex-direction: column;
   position: absolute;
-  bottom: 25%;
+  bottom: 15%;
   left: 50px;
   width: 300px;
-  height: 100px;
-  gap: 20px;
+  gap: 10px;
 
   :nth-child(n) {
     display: flex;

--- a/frontend/src/pages/CouponList/FlippedCoupon/style.tsx
+++ b/frontend/src/pages/CouponList/FlippedCoupon/style.tsx
@@ -46,11 +46,11 @@ export const BackImage = styled(CouponImage)`
 `;
 
 export const StampImage = styled.img<{ $x: number; $y: number }>`
-  width: 30px;
-  height: 30px;
+  width: 40px;
+  height: 40px;
   position: absolute;
-  top: ${({ $y }) => `${$y - 15}px`};
-  right: ${({ $x }) => `${$x - 15}px`};
+  top: ${({ $y }) => `${$y - 20}px`};
+  right: ${({ $x }) => `${$x - 20}px`};
   object-fit: cover;
   backface-visibility: hidden;
   transform-style: preserve-3d;

--- a/frontend/src/pages/CouponList/index.tsx
+++ b/frontend/src/pages/CouponList/index.tsx
@@ -43,7 +43,7 @@ const CouponList = () => {
 
   const { data: cafeData, status: cafeStatus } = useQuery<CafeRes>(['cafeInfos'], {
     queryFn: () => getCafeInfo(cafeId),
-    enabled: !!(cafeId !== 0),
+    enabled: cafeId !== 0,
   });
 
   const { mutate: mutateIsFavorites } = useMutation(

--- a/frontend/src/pages/CouponList/index.tsx
+++ b/frontend/src/pages/CouponList/index.tsx
@@ -19,7 +19,6 @@ import Alert from '../../components/Alert';
 import useModal from '../../hooks/useModal';
 import { CiCircleMore } from 'react-icons/ci';
 import { postIsFavorites } from '../../api/post';
-import { addGoogleProxyUrl } from '../../utils';
 import CafeInfo from './CafeInfo';
 
 const CouponList = () => {
@@ -37,7 +36,7 @@ const CouponList = () => {
   const {
     data: couponData,
     status: couponStatus,
-    refetch,
+    refetch: couponsRefetch,
   } = useQuery<CouponRes>(['coupons'], getCoupons, {
     onSuccess: (data) => {
       setCurrentIndex(data.coupons.length - 1);
@@ -71,7 +70,7 @@ const CouponList = () => {
   );
 
   useEffect(() => {
-    refetch();
+    couponsRefetch();
   }, []);
 
   if (couponStatus === 'error' || cafeStatus === 'error') return <>에러가 발생했습니다.</>;

--- a/frontend/src/pages/CouponList/index.tsx
+++ b/frontend/src/pages/CouponList/index.tsx
@@ -33,16 +33,11 @@ const CouponList = () => {
   const couponListContainerRef = useRef<HTMLDivElement>(null);
 
   const queryClient = useQueryClient();
-  const {
-    data: couponData,
-    status: couponStatus,
-    refetch: couponsRefetch,
-  } = useQuery<CouponRes>(['coupons'], getCoupons, {
+  const { data: couponData, status: couponStatus } = useQuery<CouponRes>(['coupons'], getCoupons, {
     onSuccess: (data) => {
       setCurrentIndex(data.coupons.length - 1);
       data.coupons.length !== 0 && setCafeId(data.coupons[data.coupons.length - 1].cafeInfo.id);
     },
-    refetchOnMount: false,
     refetchOnWindowFocus: false,
   });
 
@@ -68,10 +63,6 @@ const CouponList = () => {
       },
     },
   );
-
-  useEffect(() => {
-    couponsRefetch();
-  }, []);
 
   if (couponStatus === 'error' || cafeStatus === 'error') return <>에러가 발생했습니다.</>;
   if (couponStatus === 'loading' || cafeStatus === 'loading') return <>로딩 중입니다.</>;

--- a/frontend/src/pages/CouponList/index.tsx
+++ b/frontend/src/pages/CouponList/index.tsx
@@ -1,26 +1,17 @@
 import Coupon from './Coupon';
 import {
-  BackDrop,
-  CafeName,
   CouponListContainer,
   DetailButton,
   HeaderContainer,
   InfoContainer,
   LogoImg,
-  MaxStampCount,
-  NameContainer,
-  ProgressBarContainer,
-  StampCount,
 } from './style';
-import { MouseEvent, useRef, useState } from 'react';
+import { MouseEvent, useEffect, useRef, useState } from 'react';
 import { getCafeInfo, getCoupons } from '../../api/get';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import AdminHeaderLogo from '../../assets/admin_header_logo.png';
 import { ROUTER_PATH } from '../../constants';
 import { GoPerson } from 'react-icons/go';
-import { AiFillStar, AiOutlineStar } from 'react-icons/ai';
-import ProgressBar from '../../components/ProgressBar';
-import Color from 'color-thief-react';
 import { useNavigate } from 'react-router-dom';
 import CouponDetail from './CouponDetail';
 import type { CafeRes, CouponRes, PostIsFavoritesReq } from '../../types/api';
@@ -29,6 +20,7 @@ import useModal from '../../hooks/useModal';
 import { CiCircleMore } from 'react-icons/ci';
 import { postIsFavorites } from '../../api/post';
 import { addGoogleProxyUrl } from '../../utils';
+import CafeInfo from './CafeInfo';
 
 const CouponList = () => {
   const navigate = useNavigate();
@@ -42,7 +34,11 @@ const CouponList = () => {
   const couponListContainerRef = useRef<HTMLDivElement>(null);
 
   const queryClient = useQueryClient();
-  const { data: couponData, status: couponStatus } = useQuery<CouponRes>(['coupons'], getCoupons, {
+  const {
+    data: couponData,
+    status: couponStatus,
+    refetch,
+  } = useQuery<CouponRes>(['coupons'], getCoupons, {
     onSuccess: (data) => {
       setCurrentIndex(data.coupons.length - 1);
       data.coupons.length !== 0 && setCafeId(data.coupons[data.coupons.length - 1].cafeInfo.id);
@@ -74,11 +70,16 @@ const CouponList = () => {
     },
   );
 
-  if (couponStatus === 'error') return <>에러가 발생했습니다.</>;
-  if (couponStatus === 'loading') return <>로딩 중입니다.</>;
+  useEffect(() => {
+    refetch();
+  }, []);
+
+  if (couponStatus === 'error' || cafeStatus === 'error') return <>에러가 발생했습니다.</>;
+  if (couponStatus === 'loading' || cafeStatus === 'loading') return <>로딩 중입니다.</>;
 
   const { coupons } = couponData;
   const currentCoupon = coupons[currentIndex];
+  const [currentCouponInfo] = currentCoupon.couponInfos;
 
   const swapCoupon = (e: MouseEvent<HTMLDivElement>) => {
     if (!couponListContainerRef.current || isDetail) return;
@@ -108,8 +109,8 @@ const CouponList = () => {
 
   const openCouponDetail = () => {
     setCafeId(currentCoupon.cafeInfo.id);
-
     setIsDetail(true);
+
     setTimeout(() => {
       setIsFlippedCouponShown(true);
     }, 700);
@@ -131,7 +132,7 @@ const CouponList = () => {
   const changeFavorites = () => {
     mutateIsFavorites({
       cafeId: currentCoupon.cafeInfo.id,
-      isFavorites: !currentCoupon.couponInfos[0].isFavorites,
+      isFavorites: !currentCouponInfo.isFavorites,
     });
   };
 
@@ -142,64 +143,23 @@ const CouponList = () => {
         <GoPerson size={24} onClick={navigateMyPage} aria-label="마이 페이지" role="button" />
       </HeaderContainer>
       {coupons.length === 0 ? (
-        <>보유하고 있는 쿠폰이 없습니다.</>
+        <InfoContainer>보유하고 있는 쿠폰이 없습니다.</InfoContainer>
       ) : (
         <>
-          <InfoContainer>
-            <NameContainer>
-              <CafeName aria-label="카페 이름">{currentCoupon.cafeInfo.name}</CafeName>
-              {currentCoupon.couponInfos[0].isFavorites ? (
-                <AiFillStar
-                  size={40}
-                  color={'#FFD600'}
-                  onClick={openAlert}
-                  aria-label="즐겨찾기 해제"
-                  role="button"
-                />
-              ) : (
-                <AiOutlineStar
-                  size={40}
-                  color={'#FFD600'}
-                  onClick={openAlert}
-                  aria-label="즐겨찾기 등록"
-                  role="button"
-                />
-              )}
-            </NameContainer>
-            <ProgressBarContainer aria-label="스탬프 개수">
-              <Color
-                src={addGoogleProxyUrl(currentCoupon.couponInfos[0].frontImageUrl)}
-                format="hex"
-                crossOrigin="anonymous"
-              >
-                {({ data: color }) => (
-                  <>
-                    <BackDrop $couponMainColor={color ? color : 'gray'} />
-                    <ProgressBar
-                      stampCount={currentCoupon.couponInfos[0].stampCount}
-                      maxCount={currentCoupon.couponInfos[0].maxStampCount}
-                      color={color}
-                    />
-                  </>
-                )}
-              </Color>
-              <StampCount
-                aria-label={`현재 스탬프 개수 ${currentCoupon.couponInfos[0].stampCount}개`}
-              >
-                {currentCoupon.couponInfos[0].stampCount}
-              </StampCount>
-              /
-              <MaxStampCount aria-label="필요한 스탬프 개수">
-                {currentCoupon.couponInfos[0].maxStampCount}
-              </MaxStampCount>
-            </ProgressBarContainer>
-          </InfoContainer>
+          <CafeInfo
+            cafeName={currentCoupon.cafeInfo.name}
+            stampCount={currentCouponInfo.stampCount}
+            maxStampCount={currentCouponInfo.maxStampCount}
+            isFavorites={currentCouponInfo.isFavorites}
+            frontImageUrl={currentCouponInfo.frontImageUrl}
+            onClickStar={openAlert}
+          />
           <CouponListContainer
             ref={couponListContainerRef}
-            onClick={swapCoupon}
             $isLast={isLast}
             $isDetail={isDetail}
             $isShown={isFlippedCouponShown}
+            onClick={swapCoupon}
           >
             {coupons.map(({ cafeInfo, couponInfos }, index) => (
               <Coupon
@@ -212,15 +172,13 @@ const CouponList = () => {
               />
             ))}
           </CouponListContainer>
-          {cafeStatus !== 'loading' && cafeStatus !== 'error' && (
-            <CouponDetail
-              coupon={currentCoupon}
-              cafe={cafeData.cafe}
-              closeDetail={closeCouponDetail}
-              isDetail={isDetail}
-              isShown={isFlippedCouponShown}
-            />
-          )}
+          <CouponDetail
+            coupon={currentCoupon}
+            cafe={cafeData.cafe}
+            isDetail={isDetail}
+            isShown={isFlippedCouponShown}
+            closeDetail={closeCouponDetail}
+          />
           <DetailButton onClick={openCouponDetail} $isDetail={isDetail} aria-label="쿠폰 상세 보기">
             <CiCircleMore size={36} color={'#424242'} />
           </DetailButton>


### PR DESCRIPTION
## 주요 변경사항

- 쿠폰리스트 ->  마이페이지 -> 다시 쿠폰리스트에 왔을때, 컴포넌트가 재렌더링되어 useState의 currentIndex가 0이 되어서 쿠폰이 넘어가지 않던 버그를 refetch를 통해 해결하였습니다.
- 쿠폰리스트 파일의 코드가 너무 길어져서 상단 카페 정보 부분의 코드를 컴포넌트로 분리하였습니다.

## 리뷰어에게...

## 관련 이슈

closes

## 체크리스트

- [ ] `reviewers` 설정
- [ ] `label` 설정
- [ ] `milestone` 설정
