### PR TITLE
[BE] refactor: 쿠폰 발급, 스탬프 적립, 쿠폰 적립하는 고객 조회에 대한 api테스트 작성

### DIFF
--- a/backend/src/main/java/com/stampcrush/backend/api/manager/coupon/response/CafeCustomerFindResponse.java
+++ b/backend/src/main/java/com/stampcrush/backend/api/manager/coupon/response/CafeCustomerFindResponse.java
@@ -4,13 +4,11 @@ import com.stampcrush.backend.application.manager.coupon.dto.CafeCustomerFindRes
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
 
 import java.time.format.DateTimeFormatter;
 
 @AllArgsConstructor
 @NoArgsConstructor
-@ToString
 @Getter
 public class CafeCustomerFindResponse {
 

--- a/backend/src/main/java/com/stampcrush/backend/api/manager/coupon/response/CafeCustomerFindResponse.java
+++ b/backend/src/main/java/com/stampcrush/backend/api/manager/coupon/response/CafeCustomerFindResponse.java
@@ -1,15 +1,16 @@
 package com.stampcrush.backend.api.manager.coupon.response;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import com.stampcrush.backend.application.manager.coupon.dto.CafeCustomerFindResultDto;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
-import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 @AllArgsConstructor
 @NoArgsConstructor
+@ToString
 @Getter
 public class CafeCustomerFindResponse {
 
@@ -19,9 +20,7 @@ public class CafeCustomerFindResponse {
     private int rewardCount;
     private int visitCount;
     private int maxStampCount;
-
-    @JsonFormat(pattern = "yyyy:MM:dd")
-    private LocalDateTime firstVisitDate;
+    private String firstVisitDate;
     private Boolean isRegistered;
 
     public static CafeCustomerFindResponse from(CafeCustomerFindResultDto serviceDto) {
@@ -32,7 +31,7 @@ public class CafeCustomerFindResponse {
                 serviceDto.getRewardCount(),
                 serviceDto.getVisitCount(),
                 serviceDto.getMaxStampCount(),
-                serviceDto.getFirstVisitDate(),
+                serviceDto.getFirstVisitDate().format(DateTimeFormatter.ofPattern("yyyy:MM:dd")),
                 serviceDto.isRegistered()
         );
     }

--- a/backend/src/main/java/com/stampcrush/backend/api/manager/coupon/response/CafeCustomersFindResponse.java
+++ b/backend/src/main/java/com/stampcrush/backend/api/manager/coupon/response/CafeCustomersFindResponse.java
@@ -1,13 +1,15 @@
 package com.stampcrush.backend.api.manager.coupon.response;
 
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 
+@NoArgsConstructor
 @Getter
 public class CafeCustomersFindResponse {
 
-    private final List<CafeCustomerFindResponse> customers;
+    private List<CafeCustomerFindResponse> customers;
 
     public CafeCustomersFindResponse(List<CafeCustomerFindResponse> customers) {
         this.customers = customers;

--- a/backend/src/main/java/com/stampcrush/backend/api/manager/coupon/response/CustomerAccumulatingCouponFindResponse.java
+++ b/backend/src/main/java/com/stampcrush/backend/api/manager/coupon/response/CustomerAccumulatingCouponFindResponse.java
@@ -1,13 +1,12 @@
 package com.stampcrush.backend.api.manager.coupon.response;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import com.stampcrush.backend.application.manager.coupon.dto.CustomerAccumulatingCouponFindResultDto;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 @EqualsAndHashCode
 @AllArgsConstructor
@@ -19,9 +18,7 @@ public class CustomerAccumulatingCouponFindResponse {
     private Long customerId;
     private String nickname;
     private int stampCount;
-
-    @JsonFormat(pattern = "yyyy:MM:dd")
-    private LocalDateTime expireDate;
+    private String expireDate;
     private Boolean isPrevious;
     private int maxStampCount;
 
@@ -31,7 +28,7 @@ public class CustomerAccumulatingCouponFindResponse {
                 serviceDto.getCustomerId(),
                 serviceDto.getNickname(),
                 serviceDto.getStampCount(),
-                serviceDto.getExpireDate(),
+                serviceDto.getExpireDate().format(DateTimeFormatter.ofPattern("yyyy:MM:dd")),
                 serviceDto.isPrevious(),
                 serviceDto.getMaxStampCount()
         );

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/coupon/ManagerCouponCommandIntegrationTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/coupon/ManagerCouponCommandIntegrationTest.java
@@ -23,6 +23,7 @@ import static com.stampcrush.backend.acceptance.step.CafeCreateStep.카페_생�
 import static io.restassured.http.ContentType.JSON;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.springframework.http.HttpStatus.UNAUTHORIZED;
 
 public class ManagerCouponCommandIntegrationTest extends AcceptanceTest {
 
@@ -124,7 +125,29 @@ public class ManagerCouponCommandIntegrationTest extends AcceptanceTest {
                 () -> assertThat(coupons).usingRecursiveFieldByFieldElementComparatorIgnoringFields("expireDate")
                         .containsExactlyInAnyOrder(expected)
         );
+    }
 
+    @Test
+    void 사장님_인증_정보_없이_쿠폰을_생성하려고_하면_예외발생() {
+        // given
+        Owner owner = 사장_생성();
+        Long savedCafeId = 카페_생성_요청하고_아이디_반환(owner, CAFE_CREATE_REQUEST);
+        RegisterCustomer savedCustomer = registerCustomerRepository.save(new RegisterCustomer("name", "phone", "id", "pw"));
+        CouponCreateRequest reqeust = new CouponCreateRequest(savedCafeId);
+
+        // when
+        ExtractableResponse<Response> extract = RestAssured.given().log().all()
+                .contentType(JSON)
+                .body(reqeust)
+                .when()
+                .post("/api/admin/customers/{customerId}/coupons", savedCustomer.getId())
+                .then()
+                .log().all()
+                .extract();
+
+        // then
+        int status = extract.statusCode();
+        assertThat(status).isEqualTo(UNAUTHORIZED.value());
     }
 
     private Long 쿠폰_생성_후_아이디_반환(Owner owner, RegisterCustomer savedCustomer, CouponCreateRequest reqeust) {

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/coupon/ManagerCouponCommandIntegrationTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/coupon/ManagerCouponCommandIntegrationTest.java
@@ -1,13 +1,18 @@
 package com.stampcrush.backend.acceptance.coupon;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.stampcrush.backend.acceptance.AcceptanceTest;
 import com.stampcrush.backend.api.manager.coupon.request.CouponCreateRequest;
-import com.stampcrush.backend.api.visitor.coupon.response.CustomerCouponFindResponse;
+import com.stampcrush.backend.api.manager.coupon.request.StampCreateRequest;
+import com.stampcrush.backend.api.manager.coupon.response.CouponCreateResponse;
+import com.stampcrush.backend.api.manager.coupon.response.CustomerAccumulatingCouponFindResponse;
 import com.stampcrush.backend.entity.user.Owner;
 import com.stampcrush.backend.entity.user.RegisterCustomer;
 import com.stampcrush.backend.repository.user.OwnerRepository;
 import com.stampcrush.backend.repository.user.RegisterCustomerRepository;
 import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -17,6 +22,7 @@ import static com.stampcrush.backend.acceptance.step.CafeCreateStep.CAFE_CREATE_
 import static com.stampcrush.backend.acceptance.step.CafeCreateStep.카페_생성_요청하고_아이디_반환;
 import static io.restassured.http.ContentType.JSON;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 public class ManagerCouponCommandIntegrationTest extends AcceptanceTest {
 
@@ -26,14 +32,103 @@ public class ManagerCouponCommandIntegrationTest extends AcceptanceTest {
     @Autowired
     private RegisterCustomerRepository registerCustomerRepository;
 
+    @Autowired
+    private ObjectMapper objectMapper;
+
     @Test
     void 쿠폰을_발급한다() {
+        // given
         Owner owner = 사장_생성();
         Long savedCafeId = 카페_생성_요청하고_아이디_반환(owner, CAFE_CREATE_REQUEST);
         RegisterCustomer savedCustomer = registerCustomerRepository.save(new RegisterCustomer("name", "phone", "id", "pw"));
         CouponCreateRequest reqeust = new CouponCreateRequest(savedCafeId);
 
-        RestAssured.given().log().all()
+        // when
+        Long couponId = 쿠폰_생성_후_아이디_반환(owner, savedCustomer, reqeust);
+
+        List<CustomerAccumulatingCouponFindResponse> coupons = RestAssured.given().log().all()
+                .auth().preemptive()
+                .basic(savedCustomer.getLoginId(), savedCustomer.getEncryptedPassword())
+                .queryParam("cafe-id", savedCafeId)
+                .queryParam("active", true)
+                .when()
+                .get("api/admin/customers/{customerId}/coupons", savedCustomer.getId())
+                .thenReturn()
+                .jsonPath()
+                .getList("coupons", CustomerAccumulatingCouponFindResponse.class);
+
+        CustomerAccumulatingCouponFindResponse expected = new CustomerAccumulatingCouponFindResponse(
+                couponId,
+                savedCustomer.getId(),
+                savedCustomer.getNickname(),
+                0,
+                null,
+                false,
+                10
+        );
+
+        // then
+        assertAll(
+                () -> assertThat(coupons.size()).isEqualTo(1),
+                () -> assertThat(coupons).usingRecursiveFieldByFieldElementComparatorIgnoringFields("expireDate")
+                        .containsExactlyInAnyOrder(expected)
+        );
+    }
+
+    @Test
+    void 스탬프를_적립한다() {
+        // given
+        Owner owner = 사장_생성();
+        Long savedCafeId = 카페_생성_요청하고_아이디_반환(owner, CAFE_CREATE_REQUEST);
+        RegisterCustomer savedCustomer = registerCustomerRepository.save(new RegisterCustomer("name", "phone", "id", "pw"));
+        CouponCreateRequest reqeust = new CouponCreateRequest(savedCafeId);
+
+        // when
+        Long couponId = 쿠폰_생성_후_아이디_반환(owner, savedCustomer, reqeust);
+
+        StampCreateRequest stampCreateRequest = new StampCreateRequest(4);
+        RestAssured.given()
+                .log().all()
+                .body(stampCreateRequest)
+                .contentType(JSON)
+                .auth().preemptive()
+                .basic(owner.getLoginId(), owner.getEncryptedPassword())
+                .when()
+                .post("/api/admin/customers/{customerId}/coupons/{couponId}/stamps", savedCustomer.getId(), couponId)
+                .then().log().all();
+
+        List<CustomerAccumulatingCouponFindResponse> coupons = RestAssured.given().log().all()
+                .auth().preemptive()
+                .basic(savedCustomer.getLoginId(), savedCustomer.getEncryptedPassword())
+                .queryParam("cafe-id", savedCafeId)
+                .queryParam("active", true)
+                .when()
+                .get("api/admin/customers/{customerId}/coupons", savedCustomer.getId())
+                .thenReturn()
+                .jsonPath()
+                .getList("coupons", CustomerAccumulatingCouponFindResponse.class);
+
+        CustomerAccumulatingCouponFindResponse expected = new CustomerAccumulatingCouponFindResponse(
+                couponId,
+                savedCustomer.getId(),
+                savedCustomer.getNickname(),
+                stampCreateRequest.getEarningStampCount(),
+                null,
+                false,
+                10
+        );
+
+        // then
+        assertAll(
+                () -> assertThat(coupons.size()).isEqualTo(1),
+                () -> assertThat(coupons).usingRecursiveFieldByFieldElementComparatorIgnoringFields("expireDate")
+                        .containsExactlyInAnyOrder(expected)
+        );
+
+    }
+
+    private Long 쿠폰_생성_후_아이디_반환(Owner owner, RegisterCustomer savedCustomer, CouponCreateRequest reqeust) {
+        ExtractableResponse<Response> extract = RestAssured.given().log().all()
                 .contentType(JSON)
                 .auth().preemptive()
                 .basic(owner.getLoginId(), owner.getEncryptedPassword())
@@ -41,18 +136,11 @@ public class ManagerCouponCommandIntegrationTest extends AcceptanceTest {
                 .when()
                 .post("/api/admin/customers/{customerId}/coupons", savedCustomer.getId())
                 .then()
-                .log().all();
+                .log().all()
+                .extract();
 
-        List<CustomerCouponFindResponse> coupons = RestAssured.given().log().all()
-                .auth().preemptive()
-                .basic(savedCustomer.getLoginId(), savedCustomer.getEncryptedPassword())
-                .when()
-                .get("/api/coupons")
-                .thenReturn()
-                .jsonPath()
-                .getList("coupons", CustomerCouponFindResponse.class);
-
-        assertThat(coupons.size()).isEqualTo(1);
+        CouponCreateResponse couponCreateResponse = extract.body().as(CouponCreateResponse.class);
+        return couponCreateResponse.getCouponId();
     }
 
     private Owner 사장_생성() {

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/coupon/ManagerCouponCommandIntegrationTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/coupon/ManagerCouponCommandIntegrationTest.java
@@ -1,0 +1,62 @@
+package com.stampcrush.backend.acceptance.coupon;
+
+import com.stampcrush.backend.acceptance.AcceptanceTest;
+import com.stampcrush.backend.api.manager.coupon.request.CouponCreateRequest;
+import com.stampcrush.backend.api.visitor.coupon.response.CustomerCouponFindResponse;
+import com.stampcrush.backend.entity.user.Owner;
+import com.stampcrush.backend.entity.user.RegisterCustomer;
+import com.stampcrush.backend.repository.user.OwnerRepository;
+import com.stampcrush.backend.repository.user.RegisterCustomerRepository;
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+
+import static com.stampcrush.backend.acceptance.step.CafeCreateStep.CAFE_CREATE_REQUEST;
+import static com.stampcrush.backend.acceptance.step.CafeCreateStep.카페_생성_요청하고_아이디_반환;
+import static io.restassured.http.ContentType.JSON;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ManagerCouponCommandIntegrationTest extends AcceptanceTest {
+
+    @Autowired
+    private OwnerRepository ownerRepository;
+
+    @Autowired
+    private RegisterCustomerRepository registerCustomerRepository;
+
+    @Test
+    void 쿠폰을_발급한다() {
+        Owner owner = 사장_생성();
+        Long savedCafeId = 카페_생성_요청하고_아이디_반환(owner, CAFE_CREATE_REQUEST);
+        RegisterCustomer savedCustomer = registerCustomerRepository.save(new RegisterCustomer("name", "phone", "id", "pw"));
+        CouponCreateRequest reqeust = new CouponCreateRequest(savedCafeId);
+
+        RestAssured.given().log().all()
+                .contentType(JSON)
+                .auth().preemptive()
+                .basic(owner.getLoginId(), owner.getEncryptedPassword())
+                .body(reqeust)
+                .when()
+                .post("/api/admin/customers/{customerId}/coupons", savedCustomer.getId())
+                .then()
+                .log().all();
+
+        List<CustomerCouponFindResponse> coupons = RestAssured.given().log().all()
+                .auth().preemptive()
+                .basic(savedCustomer.getLoginId(), savedCustomer.getEncryptedPassword())
+                .when()
+                .get("/api/coupons")
+                .thenReturn()
+                .jsonPath()
+                .getList("coupons", CustomerCouponFindResponse.class);
+
+        assertThat(coupons.size()).isEqualTo(1);
+    }
+
+    private Owner 사장_생성() {
+        return ownerRepository.save(new Owner("owner", "id", "pw", "phone"));
+    }
+
+}

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/coupon/ManagerCouponCommandIntegrationTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/coupon/ManagerCouponCommandIntegrationTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.stampcrush.backend.acceptance.AcceptanceTest;
 import com.stampcrush.backend.api.manager.coupon.request.CouponCreateRequest;
 import com.stampcrush.backend.api.manager.coupon.request.StampCreateRequest;
+import com.stampcrush.backend.api.manager.coupon.response.CafeCustomerFindResponse;
 import com.stampcrush.backend.api.manager.coupon.response.CouponCreateResponse;
 import com.stampcrush.backend.api.manager.coupon.response.CustomerAccumulatingCouponFindResponse;
 import com.stampcrush.backend.entity.user.Owner;
@@ -88,15 +89,7 @@ public class ManagerCouponCommandIntegrationTest extends AcceptanceTest {
         Long couponId = 쿠폰_생성_후_아이디_반환(owner, savedCustomer, reqeust);
 
         StampCreateRequest stampCreateRequest = new StampCreateRequest(4);
-        RestAssured.given()
-                .log().all()
-                .body(stampCreateRequest)
-                .contentType(JSON)
-                .auth().preemptive()
-                .basic(owner.getLoginId(), owner.getEncryptedPassword())
-                .when()
-                .post("/api/admin/customers/{customerId}/coupons/{couponId}/stamps", savedCustomer.getId(), couponId)
-                .then().log().all();
+        스탬프를_적립한다(owner, savedCustomer, couponId, stampCreateRequest);
 
         List<CustomerAccumulatingCouponFindResponse> coupons = RestAssured.given().log().all()
                 .auth().preemptive()
@@ -148,6 +141,72 @@ public class ManagerCouponCommandIntegrationTest extends AcceptanceTest {
         // then
         int status = extract.statusCode();
         assertThat(status).isEqualTo(UNAUTHORIZED.value());
+    }
+
+    @Test
+    void 특정_카페의_방문한_고객들의_정보를_조회한다() {
+        // given
+        Owner owner = 사장_생성();
+        Long savedCafeId = 카페_생성_요청하고_아이디_반환(owner, CAFE_CREATE_REQUEST);
+        RegisterCustomer customer1 = registerCustomerRepository.save(new RegisterCustomer("name", "phone", "id", "pw"));
+        CouponCreateRequest reqeust1 = new CouponCreateRequest(savedCafeId);
+        Long coupon1Id = 쿠폰_생성_후_아이디_반환(owner, customer1, reqeust1);
+
+        RegisterCustomer customer2 = registerCustomerRepository.save(new RegisterCustomer("name2", "phone2", "id2", "pw2"));
+        CouponCreateRequest reqeust2 = new CouponCreateRequest(savedCafeId);
+        Long coupon2Id = 쿠폰_생성_후_아이디_반환(owner, customer2, reqeust2);
+
+        StampCreateRequest coupon1StampCreateRequest = new StampCreateRequest(5);
+        스탬프를_적립한다(owner, customer1, coupon1Id, coupon1StampCreateRequest);
+
+        StampCreateRequest coupon2StampCreateRequest = new StampCreateRequest(21);
+        스탬프를_적립한다(owner, customer2, coupon2Id, coupon2StampCreateRequest);
+
+        // when
+        List<CafeCustomerFindResponse> customers = RestAssured.given().log().all()
+                .auth().preemptive()
+                .basic(owner.getLoginId(), owner.getEncryptedPassword())
+                .when()
+                .get("/api/admin/cafes/{cafeId}/customers", savedCafeId)
+                .thenReturn()
+                .jsonPath()
+                .getList("customers", CafeCustomerFindResponse.class);
+
+        // then
+        CafeCustomerFindResponse customer1Expected = new CafeCustomerFindResponse(
+                coupon1Id,
+                customer1.getNickname(),
+                coupon1StampCreateRequest.getEarningStampCount(),
+                0,
+                1,
+                10,
+                null,
+                true);
+
+        CafeCustomerFindResponse customer2Expected = new CafeCustomerFindResponse(
+                coupon2Id,
+                customer2.getNickname(),
+                coupon2StampCreateRequest.getEarningStampCount() % 10,
+                coupon2StampCreateRequest.getEarningStampCount() / 10,
+                1,
+                10,
+                null,
+                true);
+
+        assertThat(customers).usingRecursiveFieldByFieldElementComparatorIgnoringFields("visitCount", "firstVisitDate")
+                .containsExactlyInAnyOrder(customer1Expected, customer2Expected);
+    }
+
+    private static void 스탬프를_적립한다(Owner owner, RegisterCustomer customer1, Long coupon1Id, StampCreateRequest coupon1StampCreateRequest) {
+        RestAssured.given()
+                .log().all()
+                .body(coupon1StampCreateRequest)
+                .contentType(JSON)
+                .auth().preemptive()
+                .basic(owner.getLoginId(), owner.getEncryptedPassword())
+                .when()
+                .post("/api/admin/customers/{customerId}/coupons/{couponId}/stamps", customer1.getId(), coupon1Id)
+                .then().log().all();
     }
 
     private Long 쿠폰_생성_후_아이디_반환(Owner owner, RegisterCustomer savedCustomer, CouponCreateRequest reqeust) {

--- a/backend/src/test/java/com/stampcrush/backend/api/coupon/ManagerCouponCommandApiControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/coupon/ManagerCouponCommandApiControllerTest.java
@@ -76,9 +76,11 @@ public class ManagerCouponCommandApiControllerTest {
 
     @Test
     void 스탬프를_적립한다() throws Exception {
+        // given, when
         StampCreateRequest stampCreateRequest = new StampCreateRequest(4);
         String request = objectMapper.writeValueAsString(stampCreateRequest);
 
+        // then
         mockMvc.perform(post(API_PREFIX + "/customers/{customerId}/coupons/{couponId}/stamps", 1L, 1L)
                         .content(request)
                         .contentType(APPLICATION_JSON)
@@ -88,9 +90,11 @@ public class ManagerCouponCommandApiControllerTest {
 
     @Test
     void 적립하려는_스탬프가_음수면_예외발생() throws Exception {
+        // given, when
         StampCreateRequest stampCreateRequest = new StampCreateRequest(-1);
         String request = objectMapper.writeValueAsString(stampCreateRequest);
 
+        // then
         mockMvc.perform(post(API_PREFIX + "/customers/{customerId}/coupons/{couponId}/stamps", 1L, 1L)
                         .content(request)
                         .contentType(APPLICATION_JSON)

--- a/backend/src/test/java/com/stampcrush/backend/api/coupon/ManagerCouponCommandApiControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/coupon/ManagerCouponCommandApiControllerTest.java
@@ -1,0 +1,100 @@
+package com.stampcrush.backend.api.coupon;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.stampcrush.backend.api.manager.coupon.ManagerCouponCommandApiController;
+import com.stampcrush.backend.api.manager.coupon.request.CouponCreateRequest;
+import com.stampcrush.backend.api.manager.coupon.request.StampCreateRequest;
+import com.stampcrush.backend.api.manager.coupon.response.CouponCreateResponse;
+import com.stampcrush.backend.application.manager.coupon.ManagerCouponCommandService;
+import com.stampcrush.backend.config.WebMvcConfig;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(value = ManagerCouponCommandApiController.class,
+        excludeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebMvcConfig.class))
+public class ManagerCouponCommandApiControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private ManagerCouponCommandService managerCouponCommandService;
+
+    public static String API_PREFIX = "/api/admin";
+
+    @Test
+    void 쿠폰을_신규_발급한다() throws Exception {
+        // given
+        given(managerCouponCommandService.createCoupon(anyLong(), anyLong()))
+                .willReturn(1L);
+
+        CouponCreateRequest couponCreateRequest = new CouponCreateRequest(1L);
+        String request = objectMapper.writeValueAsString(couponCreateRequest);
+
+        // when
+        MvcResult mvcResult = mockMvc.perform(
+                        post("/api/admin/customers/{customerId}/coupons", 1L)
+                                .content(request)
+                                .contentType(APPLICATION_JSON))
+                .andExpect(status().isCreated())
+                .andReturn();
+
+        // then
+        String responseBody = mvcResult.getResponse().getContentAsString();
+        CouponCreateResponse couponCreateResponse = objectMapper.readValue(responseBody, CouponCreateResponse.class);
+        assertThat(couponCreateResponse.getCouponId()).isEqualTo(1);
+    }
+
+    @Test
+    void 카페_id가_음수면_예외발생() throws Exception {
+        // given
+        CouponCreateRequest couponCreateRequest = new CouponCreateRequest(-1L);
+        String request = objectMapper.writeValueAsString(couponCreateRequest);
+
+        // when, then
+        mockMvc.perform(post("/api/admin/customers/{customerId}/coupons", 1L)
+                .content(request)
+                .contentType(APPLICATION_JSON)
+        ).andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void 스탬프를_적립한다() throws Exception {
+        StampCreateRequest stampCreateRequest = new StampCreateRequest(4);
+        String request = objectMapper.writeValueAsString(stampCreateRequest);
+
+        mockMvc.perform(post(API_PREFIX + "/customers/{customerId}/coupons/{couponId}/stamps", 1L, 1L)
+                        .content(request)
+                        .contentType(APPLICATION_JSON)
+                )
+                .andExpect(status().isCreated());
+    }
+
+    @Test
+    void 적립하려는_스탬프가_음수면_예외발생() throws Exception {
+        StampCreateRequest stampCreateRequest = new StampCreateRequest(-1);
+        String request = objectMapper.writeValueAsString(stampCreateRequest);
+
+        mockMvc.perform(post(API_PREFIX + "/customers/{customerId}/coupons/{couponId}/stamps", 1L, 1L)
+                        .content(request)
+                        .contentType(APPLICATION_JSON)
+                )
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/backend/src/test/java/com/stampcrush/backend/api/coupon/ManagerCouponFindApiControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/coupon/ManagerCouponFindApiControllerTest.java
@@ -1,0 +1,59 @@
+package com.stampcrush.backend.api.coupon;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.stampcrush.backend.api.manager.coupon.ManagerCouponFindApiController;
+import com.stampcrush.backend.application.manager.coupon.ManagerCouponFindService;
+import com.stampcrush.backend.application.manager.coupon.dto.CafeCustomerFindResultDto;
+import com.stampcrush.backend.config.WebMvcConfig;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(value = ManagerCouponFindApiController.class,
+        excludeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebMvcConfig.class))
+public class ManagerCouponFindApiControllerTest {
+
+    public static String API_PREFIX = "/api/admin";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private ManagerCouponFindService managerCouponFindService;
+
+    @Test
+    void 카페에_방문한_고객들의_정보를_조회한다() throws Exception {
+        CafeCustomerFindResultDto customerInfo1 = new CafeCustomerFindResultDto(1L, "name1", 5, 0, 3, LocalDateTime.now(), false, 10);
+        CafeCustomerFindResultDto customerInfo2 = new CafeCustomerFindResultDto(2L, "name2", 6, 0, 6, LocalDateTime.now(), true, 10);
+        given(managerCouponFindService.findCouponsByCafe(anyLong()))
+                .willReturn(List.of(customerInfo1, customerInfo2));
+
+        MvcResult mvcResult = mockMvc.perform(get(API_PREFIX + "/cafes/{cafeId}/customers", 1L))
+                .andExpect(status().isOk())
+                .andReturn();
+    }
+
+    @Test
+    void 특정_카페의_적립중인_쿠폰이_있는_고객을_조회한다() throws Exception {
+        mockMvc.perform(get(API_PREFIX + "/customers/{customerId}/coupons", 1L)
+                        .param("cafe-id", String.valueOf(1L))
+                        .param("active", "true"))
+                .andExpect(status().isOk());
+    }
+}

--- a/backend/src/test/java/com/stampcrush/backend/api/coupon/ManagerCouponFindApiControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/coupon/ManagerCouponFindApiControllerTest.java
@@ -1,6 +1,5 @@
 package com.stampcrush.backend.api.coupon;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.stampcrush.backend.api.manager.coupon.ManagerCouponFindApiController;
 import com.stampcrush.backend.application.manager.coupon.ManagerCouponFindService;
 import com.stampcrush.backend.application.manager.coupon.dto.CafeCustomerFindResultDto;
@@ -30,27 +29,25 @@ public class ManagerCouponFindApiControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
-    @Autowired
-    private ObjectMapper objectMapper;
-
     @MockBean
     private ManagerCouponFindService managerCouponFindService;
 
     @Test
     void 카페에_방문한_고객들의_정보를_조회한다() throws Exception {
+        // given, when
         CafeCustomerFindResultDto customerInfo1 = new CafeCustomerFindResultDto(1L, "name1", 5, 0, 3, LocalDateTime.now(), false, 10);
         CafeCustomerFindResultDto customerInfo2 = new CafeCustomerFindResultDto(2L, "name2", 6, 0, 6, LocalDateTime.now(), true, 10);
         given(managerCouponFindService.findCouponsByCafe(anyLong()))
                 .willReturn(List.of(customerInfo1, customerInfo2));
 
+        // then
         mockMvc.perform(get(API_PREFIX + "/cafes/{cafeId}/customers", 1L))
-                .andExpect(status().isOk())
-                .andReturn();
-
+                .andExpect(status().isOk());
     }
 
     @Test
     void 특정_카페의_적립중인_쿠폰이_있는_고객을_조회한다() throws Exception {
+        // when, then
         mockMvc.perform(get(API_PREFIX + "/customers/{customerId}/coupons", 1L)
                         .param("cafe-id", String.valueOf(1L))
                         .param("active", "true"))

--- a/backend/src/test/java/com/stampcrush/backend/api/coupon/ManagerCouponFindApiControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/coupon/ManagerCouponFindApiControllerTest.java
@@ -12,7 +12,6 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.MvcResult;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -44,9 +43,10 @@ public class ManagerCouponFindApiControllerTest {
         given(managerCouponFindService.findCouponsByCafe(anyLong()))
                 .willReturn(List.of(customerInfo1, customerInfo2));
 
-        MvcResult mvcResult = mockMvc.perform(get(API_PREFIX + "/cafes/{cafeId}/customers", 1L))
+        mockMvc.perform(get(API_PREFIX + "/cafes/{cafeId}/customers", 1L))
                 .andExpect(status().isOk())
                 .andReturn();
+
     }
 
     @Test


### PR DESCRIPTION
## 주요 변경사항

- 테스트 컨벤션에 맞춰 테스트 코드 수정했습니다.
- reponse의 localDateTime들은 String으로 넘겨주도록 수정했습니다.
    - 프론트에서도 String으로 받더라구요

## 리뷰어에게...

- 현재 응답dto의 LocalDateTime에 @JsonFormat이 붙어있는데 이로 인해 역직렬화 문제가 있어서 해결해야 합니다.

## 관련 이슈

close #346 

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [x] `milestone` 설정
