### PR TITLE
[BE] refactor: API 변경사항에 맞도록 CustomerCouponFindResponse 수정

### DIFF
--- a/backend/src/main/java/com/stampcrush/backend/api/visitor/coupon/response/CustomerCouponFindResponse.java
+++ b/backend/src/main/java/com/stampcrush/backend/api/visitor/coupon/response/CustomerCouponFindResponse.java
@@ -29,9 +29,14 @@ public class CustomerCouponFindResponse {
 
         private final Long id;
         private final String name;
+        private final Boolean isFavorites;
 
         static CafeInfoResponse from(CustomerCouponFindResultDto.CafeInfoDto cafeInfoDto) {
-            return new CafeInfoResponse(cafeInfoDto.getId(), cafeInfoDto.getName());
+            return new CafeInfoResponse(
+                    cafeInfoDto.getId(),
+                    cafeInfoDto.getName(),
+                    cafeInfoDto.getIsFavorites()
+            );
         }
     }
 
@@ -40,7 +45,6 @@ public class CustomerCouponFindResponse {
     private static class CustomerCouponInfoResponse {
 
         private final Long id;
-        private final Boolean isFavorites;
         private final CouponStatus status;
         private final Integer stampCount;
         private final Integer maxStampCount;
@@ -53,7 +57,6 @@ public class CustomerCouponFindResponse {
         static CustomerCouponInfoResponse from(CustomerCouponFindResultDto.CouponInfoDto couponInfoDto) {
             return new CustomerCouponInfoResponse(
                     couponInfoDto.getId(),
-                    couponInfoDto.getIsFavorites(),
                     couponInfoDto.getStatus(),
                     couponInfoDto.getStampCount(),
                     couponInfoDto.getMaxStampCount(),

--- a/backend/src/main/java/com/stampcrush/backend/application/visitor/coupon/VisitorCouponFindService.java
+++ b/backend/src/main/java/com/stampcrush/backend/application/visitor/coupon/VisitorCouponFindService.java
@@ -15,7 +15,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -33,14 +32,16 @@ public class VisitorCouponFindService {
         Customer customer = findExistingCustomer(customerId);
         List<Coupon> coupons = couponRepository.findByCustomerAndStatus(customer, CouponStatus.ACCUMULATING);
 
-        List<CustomerCouponFindResultDto> response = new ArrayList<>();
-        for (Coupon coupon : coupons) {
-            Cafe cafe = coupon.getCafe();
-            Boolean isFavorites = visitorFavoritesFindService.findIsFavorites(cafe, customer);
-            List<CouponStampCoordinate> coordinates = couponStampCoordinateRepository.findByCouponDesign(coupon.getCouponDesign());
-            response.add(CustomerCouponFindResultDto.of(cafe, coupon, isFavorites, coordinates));
-        }
-        return response;
+        return coupons.stream()
+                .map(coupon -> formatToDto(customer, coupon))
+                .toList();
+    }
+
+    private CustomerCouponFindResultDto formatToDto(Customer customer, Coupon coupon) {
+        Cafe cafe = coupon.getCafe();
+        Boolean isFavorites = visitorFavoritesFindService.findIsFavorites(cafe, customer);
+        List<CouponStampCoordinate> coordinates = couponStampCoordinateRepository.findByCouponDesign(coupon.getCouponDesign());
+        return CustomerCouponFindResultDto.of(cafe, coupon, isFavorites, coordinates);
     }
 
     private Customer findExistingCustomer(Long customerId) {

--- a/backend/src/main/java/com/stampcrush/backend/application/visitor/coupon/dto/CustomerCouponFindResultDto.java
+++ b/backend/src/main/java/com/stampcrush/backend/application/visitor/coupon/dto/CustomerCouponFindResultDto.java
@@ -22,19 +22,21 @@ public class CustomerCouponFindResultDto {
             Boolean isFavorites,
             List<CouponStampCoordinate> coordinates
     ) {
-        CafeInfoDto cafeInfoDto = CafeInfoDto.from(cafe);
-        CouponInfoDto couponInfoDto = CouponInfoDto.of(coupon, isFavorites, coordinates);
+        CafeInfoDto cafeInfoDto = CafeInfoDto.of(cafe, isFavorites);
+        CouponInfoDto couponInfoDto = CouponInfoDto.of(coupon, coordinates);
         return new CustomerCouponFindResultDto(cafeInfoDto, couponInfoDto);
     }
 
     @Getter
     @RequiredArgsConstructor
     public static class CafeInfoDto {
+
         private final Long id;
         private final String name;
+        private final Boolean isFavorites;
 
-        public static CafeInfoDto from(Cafe cafe) {
-            return new CafeInfoDto(cafe.getId(), cafe.getName());
+        public static CafeInfoDto of(Cafe cafe, Boolean isFavorites) {
+            return new CafeInfoDto(cafe.getId(), cafe.getName(), isFavorites);
         }
     }
 
@@ -42,7 +44,6 @@ public class CustomerCouponFindResultDto {
     @RequiredArgsConstructor
     public static class CouponInfoDto {
         private final Long id;
-        private final Boolean isFavorites;
         private final CouponStatus status;
         private final Integer stampCount;
         private final Integer maxStampCount;
@@ -52,10 +53,9 @@ public class CustomerCouponFindResultDto {
         private final String stampImageUrl;
         private final List<CouponCoordinatesDto> coordinates;
 
-        public static CouponInfoDto of(Coupon coupon, Boolean isFavorites, List<CouponStampCoordinate> coordinates) {
+        public static CouponInfoDto of(Coupon coupon, List<CouponStampCoordinate> coordinates) {
             return new CouponInfoDto(
                     coupon.getId(),
-                    isFavorites,
                     coupon.getStatus(),
                     coupon.getStampCount(),
                     coupon.getCouponMaxStampCount(),


### PR DESCRIPTION
## 주요 변경사항

- 라잇과 해당 API response 형태를 수정하기로 해서, 작게 수정했습니다! 

- 수정 후

```json
{
	"coupons" : [ 
		{
			"cafeInfo": {
					"id": 1,
					"name": "하디카페",
					"isFavorites": true,

				},
			"couponInfos": [ 
				{
          "id": 1,
					"status": "ACCUMULATING" ("REWARDED", "EXPIRED"),
					"stampCount" : 3,
					"maxStampCount" : 8,
					"rewardName": "아메리카노",
					"frontImageUrl": "http://localhost:3000",
					"backImageUrl" : "http://localhost:3000",
					"stampImageUrl" : "http://localhost:3000",
					"coordinates" : [
							{
								"order" : 1,
								"xCoordinate" : 2,
								"yCoordinate" : 5
							},
							{
								"order" : 2,
								"xCoordinate" : 5,
								"yCoordinate" : 5
							},
					}
							// ... 
				],
			},
		// 카페 여러 개 
		]
}
```

## 리뷰어에게...

## 관련 이슈 

closes #371 

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [x] `milestone` 설정
