### PR TITLE
[FE] bug: 쿠폰 상세 페이지에서 발생한 버그를 수정한다. 

### DIFF
--- a/frontend/src/pages/Admin/ManageCafe/index.tsx
+++ b/frontend/src/pages/Admin/ManageCafe/index.tsx
@@ -8,11 +8,12 @@ import {
   PreviewContentContainer,
   PreviewEmptyCouponImage,
   PreviewOverviewContainer,
+  RestrictionLabel,
   TextArea,
   Wrapper,
 } from './style';
 import TimeRangePicker from './TimeRangePicker';
-import { ChangeEventHandler, FormEventHandler, useEffect, useMemo, useState } from 'react';
+import { ChangeEvent, FormEventHandler, useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import {
   ImageUpLoadInput,
@@ -35,7 +36,7 @@ const ManageCafe = () => {
   const navigate = useNavigate();
   const [cafeImage, uploadCafeImage] = useUploadImage();
   const [phoneNumber, setPhoneNumber] = useState('');
-  const [introduction, setIntroduction] = useState('내용을 입력해주세요');
+  const [introduction, setIntroduction] = useState('');
   const [openTime, setOpenTime] = useState<Time>({ hour: '10', minute: '00' });
   const [closeTime, setCloseTime] = useState<Time>({ hour: '18', minute: '00' });
 
@@ -72,11 +73,15 @@ const ManageCafe = () => {
     },
   );
 
-  const inputPhoneNumber: ChangeEventHandler<HTMLInputElement> = (e) => {
-    setPhoneNumber(e.target.value);
+  const inputPhoneNumber = (e: ChangeEvent<HTMLInputElement>) => {
+    const { value } = e.target;
+
+    const removeHyphenPhoneNumber = value.replace(/-/g, '');
+
+    setPhoneNumber(removeHyphenPhoneNumber);
   };
 
-  const inputIntroduction: ChangeEventHandler<HTMLTextAreaElement> = (e) => {
+  const inputIntroduction = (e: ChangeEvent<HTMLTextAreaElement>) => {
     setIntroduction(e.target.value);
   };
 
@@ -89,7 +94,7 @@ const ManageCafe = () => {
       closeTime: parseTime(closeTime),
       telephoneNumber: phoneNumber,
       cafeImageUrl: cafeImage === '' ? 'https://picsum.photos/200/300' : cafeImage,
-      introduction: introduction === '내용을 입력해주세요' ? '' : introduction,
+      introduction: introduction === '' ? '' : introduction,
     };
 
     mutate(cafeInfoBody);
@@ -117,8 +122,10 @@ const ManageCafe = () => {
           <Input
             id="phone-number-input"
             placeholder="전화번호를 입력해주세요"
-            maxLength={phoneNumber.startsWith('02') ? 10 : 11}
+            maxLength={phoneNumber.startsWith('02') ? 12 : 13}
+            pattern="[0-9]{2,3}-[0-9]{3,4}-[0-9]{4}"
             onChange={inputPhoneNumber}
+            value={parsePhoneNumber(phoneNumber)}
           />
         </Wrapper>
         <Wrapper>
@@ -132,7 +139,16 @@ const ManageCafe = () => {
         </Wrapper>
         <Wrapper>
           <Text>소개글</Text>
-          <TextArea rows={8} cols={50} onChange={inputIntroduction} />
+          <TextArea
+            rows={8}
+            cols={50}
+            onChange={inputIntroduction}
+            maxLength={150}
+            value={introduction}
+          />
+          <RestrictionLabel
+            $isExceed={introduction.length >= 150}
+          >{`${introduction.length}/150`}</RestrictionLabel>
         </Wrapper>
         <Button type="submit" variant="primary" size="medium">
           저장하기

--- a/frontend/src/pages/Admin/ManageCafe/index.tsx
+++ b/frontend/src/pages/Admin/ManageCafe/index.tsx
@@ -93,13 +93,15 @@ const ManageCafe = () => {
       openTime: parseTime(openTime),
       closeTime: parseTime(closeTime),
       telephoneNumber: phoneNumber,
+      // FIXME: 하드코딩 된 값 변경하기
       cafeImageUrl: cafeImage === '' ? 'https://picsum.photos/200/300' : cafeImage,
-      introduction: introduction === '' ? '' : introduction,
+      introduction: introduction,
     };
 
     mutate(cafeInfoBody);
   };
 
+  // TODO: 로딩, 에러 컴포넌트 만들기
   if (status === 'loading') return <>로딩 중입니다.</>;
   if (status === 'error') return <>에러가 발생했습니다.</>;
 

--- a/frontend/src/pages/Admin/ManageCafe/style.tsx
+++ b/frontend/src/pages/Admin/ManageCafe/style.tsx
@@ -49,6 +49,10 @@ export const PreviewOverviewContainer = styled.div`
   gap: 10px;
   word-break: break-all;
   overflow: hidden;
+
+  :nth-child(2) {
+    overflow: scroll;
+  }
 `;
 
 export const PreviewContentContainer = styled.div`
@@ -83,4 +87,9 @@ export const PreviewEmptyCouponImage = styled.div`
   font-weight: 500;
   background: white;
   border: 3px dotted black;
+`;
+
+export const RestrictionLabel = styled.label<{ $isExceed: boolean }>`
+  color: ${({ $isExceed }) => ($isExceed ? 'tomato' : '#aaa')};
+  margin-left: auto;
 `;

--- a/frontend/src/pages/CouponList/CouponDetail/index.tsx
+++ b/frontend/src/pages/CouponList/CouponDetail/index.tsx
@@ -21,18 +21,19 @@ interface CouponDetailProps {
   isDetail: boolean;
   isShown: boolean;
   coupon: Coupon;
-  cafeId: number;
   closeDetail: (e: MouseEvent<HTMLButtonElement>) => void;
 }
 
-const CouponDetail = ({ isDetail, isShown, coupon, cafeId, closeDetail }: CouponDetailProps) => {
+const CouponDetail = ({ isDetail, isShown, coupon, closeDetail }: CouponDetailProps) => {
   const [couponInfos] = coupon.couponInfos;
+  const cafeId = coupon.cafeInfo.id;
 
   const { data: cafeData, status: cafeStatus } = useQuery<CafeRes>(['cafeInfos', cafeId], {
     queryFn: () => getCafeInfo(cafeId),
     enabled: cafeId !== 0,
   });
 
+  // TODO: 로딩, 에러 컴포넌트 만들기
   if (cafeStatus === 'loading') return null;
   if (cafeStatus === 'error') return null;
 

--- a/frontend/src/pages/CouponList/CouponDetail/index.tsx
+++ b/frontend/src/pages/CouponList/CouponDetail/index.tsx
@@ -1,4 +1,4 @@
-import { MouseEvent } from 'react';
+import { MouseEvent, useEffect } from 'react';
 import FlippedCoupon from '../FlippedCoupon';
 import Text from '../../../components/Text';
 import {
@@ -11,25 +11,44 @@ import {
 import { BiArrowBack } from 'react-icons/bi';
 import { FaRegClock, FaPhoneAlt, FaRegBell } from 'react-icons/fa';
 import { FaLocationDot } from 'react-icons/fa6';
-import { Cafe, Coupon } from '../../../types';
+import { Coupon } from '../../../types';
 import { parsePhoneNumber } from '../../../utils';
+import { useQuery } from '@tanstack/react-query';
+import { CafeRes } from '../../../types/api';
+import { getCafeInfo } from '../../../api/get';
 
 interface CouponDetailProps {
   isDetail: boolean;
   isShown: boolean;
   coupon: Coupon;
-  cafe: Cafe;
+  cafeId: number;
   closeDetail: (e: MouseEvent<HTMLButtonElement>) => void;
 }
 
-const CouponDetail = ({ isDetail, isShown, coupon, cafe, closeDetail }: CouponDetailProps) => {
+const CouponDetail = ({ isDetail, isShown, coupon, cafeId, closeDetail }: CouponDetailProps) => {
   // FIXME: cafeName 등 넘겨받은 데이터 이후에 알맞게 변경
   const [couponInfos] = coupon.couponInfos;
+
+  const {
+    data: cafeData,
+    status: cafeStatus,
+    refetch,
+  } = useQuery<CafeRes>(['cafeInfos'], {
+    queryFn: () => getCafeInfo(cafeId),
+    enabled: cafeId !== 0,
+  });
+
+  useEffect(() => {
+    refetch();
+  }, [cafeId]);
+
+  if (cafeStatus === 'loading') return null;
+  if (cafeStatus === 'error') return null;
 
   // FIXME: 이후 카페 관리 병합 후 parseUtil 사용
   return (
     <CouponDetailContainer $isDetail={isDetail}>
-      <CafeImage src={cafe.cafeImageUrl} />
+      <CafeImage src={cafeData.cafe.cafeImageUrl} />
       <FlippedCoupon
         frontImageUrl={couponInfos.frontImageUrl}
         backImageUrl={couponInfos.backImageUrl}
@@ -43,7 +62,7 @@ const CouponDetail = ({ isDetail, isShown, coupon, cafe, closeDetail }: CouponDe
       </CloseButton>
       <OverviewContainer>
         <Text variant="subTitle">{coupon.cafeInfo.name}</Text>
-        <Text>{cafe.introduction}</Text>
+        <Text>{cafeData.cafe.introduction}</Text>
       </OverviewContainer>
       <ContentContainer>
         <Text ariaLabel="쿠폰 정책">
@@ -52,15 +71,15 @@ const CouponDetail = ({ isDetail, isShown, coupon, cafe, closeDetail }: CouponDe
         </Text>
         <Text ariaLabel="영업 시간">
           <FaRegClock size={22} />
-          {`${cafe.openTime} - ${cafe.closeTime}`}
+          {`${cafeData.cafe.openTime} - ${cafeData.cafe.closeTime}`}
         </Text>
         <Text ariaLabel="전화번호">
           <FaPhoneAlt size={22} />
-          {parsePhoneNumber(cafe.telephoneNumber)}
+          {parsePhoneNumber(cafeData.cafe.telephoneNumber)}
         </Text>
         <Text ariaLabel="주소">
           <FaLocationDot size={22} />
-          {cafe.roadAddress + ' ' + cafe.detailAddress}
+          {cafeData.cafe.roadAddress + ' ' + cafeData.cafe.detailAddress}
         </Text>
       </ContentContainer>
     </CouponDetailContainer>

--- a/frontend/src/pages/CouponList/CouponDetail/index.tsx
+++ b/frontend/src/pages/CouponList/CouponDetail/index.tsx
@@ -26,26 +26,16 @@ interface CouponDetailProps {
 }
 
 const CouponDetail = ({ isDetail, isShown, coupon, cafeId, closeDetail }: CouponDetailProps) => {
-  // FIXME: cafeName 등 넘겨받은 데이터 이후에 알맞게 변경
   const [couponInfos] = coupon.couponInfos;
 
-  const {
-    data: cafeData,
-    status: cafeStatus,
-    refetch,
-  } = useQuery<CafeRes>(['cafeInfos'], {
+  const { data: cafeData, status: cafeStatus } = useQuery<CafeRes>(['cafeInfos', cafeId], {
     queryFn: () => getCafeInfo(cafeId),
     enabled: cafeId !== 0,
   });
 
-  useEffect(() => {
-    refetch();
-  }, [cafeId]);
-
   if (cafeStatus === 'loading') return null;
   if (cafeStatus === 'error') return null;
 
-  // FIXME: 이후 카페 관리 병합 후 parseUtil 사용
   return (
     <CouponDetailContainer $isDetail={isDetail}>
       <CafeImage src={cafeData.cafe.cafeImageUrl} />

--- a/frontend/src/pages/CouponList/CouponDetail/style.tsx
+++ b/frontend/src/pages/CouponList/CouponDetail/style.tsx
@@ -84,6 +84,7 @@ export const ContentContainer = styled.div`
     align-items: center;
     justify-content: flex-start;
     gap: 10px;
+    overflow: hidden;
   }
 `;
 

--- a/frontend/src/pages/CouponList/CouponDetail/style.tsx
+++ b/frontend/src/pages/CouponList/CouponDetail/style.tsx
@@ -51,11 +51,14 @@ export const OverviewContainer = styled.div`
   gap: 10px;
   line-height: 24px;
   word-break: break-all;
-  overflow: hidden;
 
   :nth-child(1) {
     padding: 5px 20px;
     border-bottom: 2px solid black;
+  }
+
+  :nth-child(2) {
+    overflow: scroll;
   }
 `;
 

--- a/frontend/src/pages/CouponList/index.tsx
+++ b/frontend/src/pages/CouponList/index.tsx
@@ -6,7 +6,7 @@ import {
   InfoContainer,
   LogoImg,
 } from './style';
-import { MouseEvent, useRef, useState } from 'react';
+import { MouseEvent, useEffect, useRef, useState } from 'react';
 import { getCoupons } from '../../api/get';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import AdminHeaderLogo from '../../assets/admin_header_logo.png';
@@ -32,12 +32,16 @@ const CouponList = () => {
   const couponListContainerRef = useRef<HTMLDivElement>(null);
 
   const queryClient = useQueryClient();
+
   const { data: couponData, status: couponStatus } = useQuery<CouponRes>(['coupons'], getCoupons, {
-    onSuccess: (data) => {
-      setCurrentIndex(data.coupons.length - 1);
-    },
     refetchOnWindowFocus: false,
   });
+
+  useEffect(() => {
+    if (couponData) {
+      setCurrentIndex(couponData?.coupons.length - 1);
+    }
+  }, [couponData]);
 
   const { mutate: mutateIsFavorites } = useMutation(
     ({ cafeId, isFavorites }: PostIsFavoritesReq) => postIsFavorites({ cafeId, isFavorites }),
@@ -70,7 +74,7 @@ const CouponList = () => {
     const coupon = couponListContainerRef.current.lastElementChild;
     if (e.target !== coupon) return;
     setIsLast(true);
-    console.log(currentCoupon.cafeInfo.id);
+
     setTimeout(() => {
       setIsLast(false);
       couponListContainerRef.current?.prepend(coupon);

--- a/frontend/src/pages/CouponList/index.tsx
+++ b/frontend/src/pages/CouponList/index.tsx
@@ -160,7 +160,6 @@ const CouponList = () => {
           </CouponListContainer>
           <CouponDetail
             coupon={currentCoupon}
-            cafeId={currentCoupon.cafeInfo.id}
             isDetail={isDetail}
             isShown={isFlippedCouponShown}
             closeDetail={closeCouponDetail}

--- a/frontend/src/pages/CouponList/index.tsx
+++ b/frontend/src/pages/CouponList/index.tsx
@@ -6,15 +6,15 @@ import {
   InfoContainer,
   LogoImg,
 } from './style';
-import { MouseEvent, useEffect, useRef, useState } from 'react';
-import { getCafeInfo, getCoupons } from '../../api/get';
+import { MouseEvent, useRef, useState } from 'react';
+import { getCoupons } from '../../api/get';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import AdminHeaderLogo from '../../assets/admin_header_logo.png';
 import { ROUTER_PATH } from '../../constants';
 import { GoPerson } from 'react-icons/go';
 import { useNavigate } from 'react-router-dom';
 import CouponDetail from './CouponDetail';
-import type { CafeRes, CouponRes, PostIsFavoritesReq } from '../../types/api';
+import type { CouponRes, PostIsFavoritesReq } from '../../types/api';
 import Alert from '../../components/Alert';
 import useModal from '../../hooks/useModal';
 import { CiCircleMore } from 'react-icons/ci';
@@ -29,21 +29,14 @@ const CouponList = () => {
   const [alertMessage, setAlertMessage] = useState('');
   const [isDetail, setIsDetail] = useState(false);
   const [isFlippedCouponShown, setIsFlippedCouponShown] = useState(false);
-  const [cafeId, setCafeId] = useState(0);
   const couponListContainerRef = useRef<HTMLDivElement>(null);
 
   const queryClient = useQueryClient();
   const { data: couponData, status: couponStatus } = useQuery<CouponRes>(['coupons'], getCoupons, {
     onSuccess: (data) => {
       setCurrentIndex(data.coupons.length - 1);
-      data.coupons.length !== 0 && setCafeId(data.coupons[data.coupons.length - 1].cafeInfo.id);
     },
     refetchOnWindowFocus: false,
-  });
-
-  const { data: cafeData, status: cafeStatus } = useQuery<CafeRes>(['cafeInfos'], {
-    queryFn: () => getCafeInfo(cafeId),
-    enabled: cafeId !== 0,
   });
 
   const { mutate: mutateIsFavorites } = useMutation(
@@ -64,8 +57,8 @@ const CouponList = () => {
     },
   );
 
-  if (couponStatus === 'error' || cafeStatus === 'error') return <>에러가 발생했습니다.</>;
-  if (couponStatus === 'loading' || cafeStatus === 'loading') return <>로딩 중입니다.</>;
+  if (couponStatus === 'error') return <>에러가 발생했습니다.</>;
+  if (couponStatus === 'loading') return <>로딩 중입니다.</>;
 
   const { coupons } = couponData;
   const currentCoupon = coupons[currentIndex];
@@ -77,7 +70,7 @@ const CouponList = () => {
     const coupon = couponListContainerRef.current.lastElementChild;
     if (e.target !== coupon) return;
     setIsLast(true);
-
+    console.log(currentCoupon.cafeInfo.id);
     setTimeout(() => {
       setIsLast(false);
       couponListContainerRef.current?.prepend(coupon);
@@ -98,7 +91,6 @@ const CouponList = () => {
   };
 
   const openCouponDetail = () => {
-    setCafeId(currentCoupon.cafeInfo.id);
     setIsDetail(true);
 
     setTimeout(() => {
@@ -164,7 +156,7 @@ const CouponList = () => {
           </CouponListContainer>
           <CouponDetail
             coupon={currentCoupon}
-            cafe={cafeData.cafe}
+            cafeId={currentCoupon.cafeInfo.id}
             isDetail={isDetail}
             isShown={isFlippedCouponShown}
             closeDetail={closeCouponDetail}

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -28,22 +28,13 @@ export const parseTime = (value: Time) => {
 
 export const parsePhoneNumber = (phoneNumber: string | undefined) => {
   if (!phoneNumber) return;
-  const number = phoneNumber.replace(/\D/g, ''); // Remove all non-numeric characters
 
-  if (number.startsWith('02')) {
-    return number.length <= 2
-      ? number
-      : number.length <= 6
-      ? number.substring(0, 2) + '-' + number.substring(2)
-      : number.length <= 9
-      ? number.substring(0, 2) + '-' + number.substring(2, 5) + '-' + number.substring(5)
-      : number.substring(0, 2) + '-' + number.substring(2, 6) + '-' + number.substring(6, 10);
+  const parsedPhoneNumber = phoneNumber.replace(/[^0-9]/g, '');
+
+  if (parsedPhoneNumber.startsWith('02')) {
+    return parsedPhoneNumber.replace(/^(\d{2})(\d{3,4})(\d{4})$/, '$1-$2-$3');
   } else {
-    return number.length < 4
-      ? number
-      : number.length < 7
-      ? number.substring(0, 3) + '-' + number.substring(3)
-      : number.substring(0, 3) + '-' + number.substring(3, 7) + '-' + number.substring(7, 11);
+    return parsedPhoneNumber.replace(/^(\d{2,3})(\d{3,4})(\d{4})$/, '$1-$2-$3');
   }
 };
 


### PR DESCRIPTION
## 주요 변경사항

- [x] 필요한 카페 정보 조회 인덱스 혼선(고객 모드) 
ㄴ 해당 문제를 해결하기 위해 기존에 `CouponList.index.tsx`에 존재하던 `cafeId` 상태를 제거하였습니다. 
상태가 비동기적으로 동작하기 때문에 해당 문제가 발생하는 것으로 판단하였고, `CurrentCoupon`의 `cafeInfo.id`를 `CouponDetail` 컴포넌트에 `props`로 전달하여 최신 상태의 `cafeId`를 컴포넌트가 알게 하고자 하였습니다. 
`CouponDetail` 내부에서 `useQuery`로 `get` 요청을 보내고 `useEffect` 내에서 `refetch`를 하도록 하였는데, 다른 방법으로 `refetch`를 할 수 있는 방법을 알고 계신 리뷰어께서는 말씀해주시면 감사하겠습니다.

- [x] 텍스트가 잘려보임

- [x] 소개글 리워드 등 텍스트가 길어지면 어떻게 보여줄지

- [x] 전화번호에 숫자 외 문자를 넣었을 때 이미지 초기화

- [x] 카페 관리 페이지의 전화번호 입력시에도 자동으로 parse되고, 다른 문자는 입력을 방지함.(정규표현식으로) 

++ 유틸의 `parsePhoneNumber`을 닉값을 하기 위해 `정규표현식`으로 바꾸어봤습니다.

## 리뷰어에게...

## 관련 이슈

closes #358 
closes #360 
closes #370 

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [x] `milestone` 설정
