### PR TITLE
[FE] feat: 쿠폰 상세 페이지의 쿠폰 삭제 기능을 구현한다.

### DIFF
--- a/frontend/src/api/delete.ts
+++ b/frontend/src/api/delete.ts
@@ -1,0 +1,5 @@
+import { api, customerHeader } from '.';
+
+export const deleteCoupon = async (couponId: number) => {
+  return await api.delete(`/coupons/${couponId}`, customerHeader);
+};

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -39,8 +39,9 @@ export const api = {
       body: JSON.stringify(payload),
     }),
 
-  delete: (path: string) =>
+  delete: (path: string, init?: RequestInit) =>
     request(path, {
+      headers: init?.headers,
       method: 'DELETE',
     }),
 };

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -238,4 +238,8 @@ export const handlers = [
   rest.post('/cafes/:cafeId/favorites', async (req, res, ctx) => {
     return res(ctx.status(200));
   }),
+
+  rest.delete('/coupons/:couponId', async (req, res, ctx) => {
+    return res(ctx.status(204));
+  }),
 ];

--- a/frontend/src/pages/CouponList/CouponDetail/index.tsx
+++ b/frontend/src/pages/CouponList/CouponDetail/index.tsx
@@ -1,4 +1,3 @@
-import { MouseEvent, useEffect } from 'react';
 import FlippedCoupon from '../FlippedCoupon';
 import Text from '../../../components/Text';
 import {
@@ -6,74 +5,121 @@ import {
   CloseButton,
   ContentContainer,
   CouponDetailContainer,
+  DeleteButton,
   OverviewContainer,
 } from './style';
 import { BiArrowBack } from 'react-icons/bi';
-import { FaRegClock, FaPhoneAlt, FaRegBell } from 'react-icons/fa';
+import { FaRegClock, FaPhoneAlt, FaRegBell, FaRegTrashAlt } from 'react-icons/fa';
 import { FaLocationDot } from 'react-icons/fa6';
 import { Coupon } from '../../../types';
 import { parsePhoneNumber } from '../../../utils';
-import { useQuery } from '@tanstack/react-query';
-import { CafeRes } from '../../../types/api';
+import {
+  QueryObserverResult,
+  RefetchOptions,
+  RefetchQueryFilters,
+  useMutation,
+  useQuery,
+} from '@tanstack/react-query';
+import { CafeRes, CouponRes } from '../../../types/api';
 import { getCafeInfo } from '../../../api/get';
+import { deleteCoupon } from '../../../api/delete';
+import useModal from '../../../hooks/useModal';
+import Alert from '../../../components/Alert';
 
 interface CouponDetailProps {
   isDetail: boolean;
   isShown: boolean;
   coupon: Coupon;
-  closeDetail: (e: MouseEvent<HTMLButtonElement>) => void;
+  refetchCoupons: <TPageData>(
+    options?: (RefetchOptions & RefetchQueryFilters<TPageData>) | undefined,
+  ) => Promise<QueryObserverResult<CouponRes, unknown>>;
+  closeDetail: () => void;
 }
 
-const CouponDetail = ({ isDetail, isShown, coupon, closeDetail }: CouponDetailProps) => {
+const CouponDetail = ({
+  isDetail,
+  isShown,
+  coupon,
+  refetchCoupons,
+  closeDetail,
+}: CouponDetailProps) => {
   const [couponInfos] = coupon.couponInfos;
   const cafeId = coupon.cafeInfo.id;
+  const { isOpen, openModal, closeModal } = useModal();
 
   const { data: cafeData, status: cafeStatus } = useQuery<CafeRes>(['cafeInfos', cafeId], {
     queryFn: () => getCafeInfo(cafeId),
+
     enabled: cafeId !== 0,
   });
+
+  const { mutate: mutateDeleteCoupon } = useMutation(() => deleteCoupon(couponInfos.id), {
+    onSuccess: () => {
+      closeDetail();
+      refetchCoupons();
+      closeModal();
+    },
+  });
+
+  const openDeleteAlert = () => {
+    openModal();
+  };
 
   // TODO: 로딩, 에러 컴포넌트 만들기
   if (cafeStatus === 'loading') return null;
   if (cafeStatus === 'error') return null;
 
   return (
-    <CouponDetailContainer $isDetail={isDetail}>
-      <CafeImage src={cafeData.cafe.cafeImageUrl} />
-      <FlippedCoupon
-        frontImageUrl={couponInfos.frontImageUrl}
-        backImageUrl={couponInfos.backImageUrl}
-        stampImageUrl={couponInfos.stampImageUrl}
-        isShown={isShown}
-        coordinates={couponInfos.coordinates}
-        stampCount={couponInfos.stampCount}
-      />
-      <CloseButton onClick={closeDetail} aria-label="홈으로 돌아가기" role="button">
-        <BiArrowBack size={24} />
-      </CloseButton>
-      <OverviewContainer>
-        <Text variant="subTitle">{coupon.cafeInfo.name}</Text>
-        <Text>{cafeData.cafe.introduction}</Text>
-      </OverviewContainer>
-      <ContentContainer>
-        <Text ariaLabel="쿠폰 정책">
-          <FaRegBell size={22} />
-          {`스탬프 ${couponInfos.maxStampCount}개를 채우면 ${couponInfos.rewardName} 무료!`}
-        </Text>
-        <Text ariaLabel="영업 시간">
-          <FaRegClock size={22} />
-          {`${cafeData.cafe.openTime} - ${cafeData.cafe.closeTime}`}
-        </Text>
-        <Text ariaLabel="전화번호">
-          <FaPhoneAlt size={22} />
-          {parsePhoneNumber(cafeData.cafe.telephoneNumber)}
-        </Text>
-        <Text ariaLabel="주소">
-          <FaLocationDot size={22} />
-          {cafeData.cafe.roadAddress + ' ' + cafeData.cafe.detailAddress}
-        </Text>
-      </ContentContainer>
-    </CouponDetailContainer>
+    <>
+      <CouponDetailContainer $isDetail={isDetail}>
+        <CafeImage src={cafeData.cafe.cafeImageUrl} />
+        <FlippedCoupon
+          frontImageUrl={couponInfos.frontImageUrl}
+          backImageUrl={couponInfos.backImageUrl}
+          stampImageUrl={couponInfos.stampImageUrl}
+          isShown={isShown}
+          coordinates={couponInfos.coordinates}
+          stampCount={couponInfos.stampCount}
+        />
+        <CloseButton onClick={closeDetail} aria-label="홈으로 돌아가기" role="button">
+          <BiArrowBack size={24} />
+        </CloseButton>
+        <DeleteButton onClick={openDeleteAlert}>
+          <FaRegTrashAlt size={24} />
+        </DeleteButton>
+        <OverviewContainer>
+          <Text variant="subTitle">{coupon.cafeInfo.name}</Text>
+          <Text>{cafeData.cafe.introduction}</Text>
+        </OverviewContainer>
+        <ContentContainer>
+          <Text ariaLabel="쿠폰 정책">
+            <FaRegBell size={22} />
+            {`스탬프 ${couponInfos.maxStampCount}개를 채우면 ${couponInfos.rewardName} 무료!`}
+          </Text>
+          <Text ariaLabel="영업 시간">
+            <FaRegClock size={22} />
+            {`${cafeData.cafe.openTime} - ${cafeData.cafe.closeTime}`}
+          </Text>
+          <Text ariaLabel="전화번호">
+            <FaPhoneAlt size={22} />
+            {parsePhoneNumber(cafeData.cafe.telephoneNumber)}
+          </Text>
+          <Text ariaLabel="주소">
+            <FaLocationDot size={22} />
+            {cafeData.cafe.roadAddress + ' ' + cafeData.cafe.detailAddress}
+          </Text>
+        </ContentContainer>
+      </CouponDetailContainer>
+      {isOpen && (
+        <Alert
+          text="쿠폰을 삭제하시겠습니까?"
+          rightOption={'네'}
+          leftOption={'아니오'}
+          onClickRight={mutateDeleteCoupon}
+          onClickLeft={closeModal}
+        />
+      )}
+    </>
   );
 };
 

--- a/frontend/src/pages/CouponList/CouponDetail/style.tsx
+++ b/frontend/src/pages/CouponList/CouponDetail/style.tsx
@@ -97,3 +97,13 @@ export const CloseButton = styled.button`
   color: black;
   background: transparent;
 `;
+
+export const DeleteButton = styled.button`
+  position: absolute;
+  top: 15px;
+  right: 15px;
+  width: 24px;
+  height: 24px;
+  color: black;
+  background: transparent;
+`;

--- a/frontend/src/pages/CouponList/index.tsx
+++ b/frontend/src/pages/CouponList/index.tsx
@@ -33,7 +33,11 @@ const CouponList = () => {
 
   const queryClient = useQueryClient();
 
-  const { data: couponData, status: couponStatus } = useQuery<CouponRes>(['coupons'], getCoupons, {
+  const {
+    data: couponData,
+    status: couponStatus,
+    refetch: refetchCoupons,
+  } = useQuery<CouponRes>(['coupons'], getCoupons, {
     refetchOnWindowFocus: false,
   });
 
@@ -162,6 +166,7 @@ const CouponList = () => {
             coupon={currentCoupon}
             isDetail={isDetail}
             isShown={isFlippedCouponShown}
+            refetchCoupons={refetchCoupons}
             closeDetail={closeCouponDetail}
           />
           <DetailButton onClick={openCouponDetail} $isDetail={isDetail} aria-label="쿠폰 상세 보기">


### PR DESCRIPTION
## 주요 변경사항

- 쿠폰 상세 페이지의 쿠폰 삭제 기능을 구현하였습니다.
- `Alert`를 사용하여 재차 확인합니다.
- 통신 없이 동작만을 구현하였습니다.

## 리뷰어에게...
![delete_coupon](https://github.com/woowacourse-team#395 23-stamp-crush/assets/90092440/a4d7c86d-44e9-41d9-a8d0-e429f2908449)

## 관련 이슈

closes #395

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [x] `milestone` 설정
