### PR TITLE
[BE] feat: 스탬프 적립 시 VisitHistory데이터를 추가한다.

### DIFF
--- a/backend/src/main/java/com/stampcrush/backend/application/manager/coupon/ManagerCouponCommandService.java
+++ b/backend/src/main/java/com/stampcrush/backend/application/manager/coupon/ManagerCouponCommandService.java
@@ -11,6 +11,7 @@ import com.stampcrush.backend.entity.coupon.CouponStatus;
 import com.stampcrush.backend.entity.reward.Reward;
 import com.stampcrush.backend.entity.user.Customer;
 import com.stampcrush.backend.entity.user.Owner;
+import com.stampcrush.backend.entity.visithistory.VisitHistory;
 import com.stampcrush.backend.exception.CafeNotFoundException;
 import com.stampcrush.backend.exception.CustomerNotFoundException;
 import com.stampcrush.backend.repository.cafe.CafeCouponDesignRepository;
@@ -22,6 +23,7 @@ import com.stampcrush.backend.repository.coupon.CouponRepository;
 import com.stampcrush.backend.repository.reward.RewardRepository;
 import com.stampcrush.backend.repository.user.CustomerRepository;
 import com.stampcrush.backend.repository.user.OwnerRepository;
+import com.stampcrush.backend.repository.visithistory.VisitHistoryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -43,6 +45,7 @@ public class ManagerCouponCommandService {
     private final CouponPolicyRepository couponPolicyRepository;
     private final OwnerRepository ownerRepository;
     private final RewardRepository rewardRepository;
+    private final VisitHistoryRepository visitHistoryRepository;
 
     private record CustomerCoupons(Customer customer, List<Coupon> coupons) {
     }
@@ -92,8 +95,10 @@ public class ManagerCouponCommandService {
         CafePolicy cafePolicy = findCafePolicy(cafe);
         CafeCouponDesign cafeCouponDesign = findCafeCouponDesign(cafe);
         Coupon coupon = findCoupon(stampCreateDto, customer, cafe);
-
         int earningStampCount = stampCreateDto.getEarningStampCount();
+
+        VisitHistory visitHistory = new VisitHistory(cafe, customer, earningStampCount);
+        visitHistoryRepository.save(visitHistory);
         if (coupon.isLessThanMaxStampAfterAccumulateStamp(earningStampCount)) {
             coupon.accumulate(earningStampCount);
             return;

--- a/backend/src/main/java/com/stampcrush/backend/entity/visithistory/VisitHistory.java
+++ b/backend/src/main/java/com/stampcrush/backend/entity/visithistory/VisitHistory.java
@@ -4,6 +4,7 @@ import com.stampcrush.backend.entity.baseentity.BaseDate;
 import com.stampcrush.backend.entity.cafe.Cafe;
 import com.stampcrush.backend.entity.user.Customer;
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 
 import static jakarta.persistence.FetchType.LAZY;
@@ -11,6 +12,7 @@ import static jakarta.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 
 @NoArgsConstructor(access = PROTECTED)
+@AllArgsConstructor
 @Entity
 public class VisitHistory extends BaseDate {
 
@@ -27,4 +29,8 @@ public class VisitHistory extends BaseDate {
     private Customer customer;
 
     private int stampCount;
+
+    public VisitHistory(Cafe cafe, Customer customer, int stampCount) {
+        this(null, cafe, customer, stampCount);
+    }
 }

--- a/backend/src/main/java/com/stampcrush/backend/repository/visithistory/VisitHistoryRepository.java
+++ b/backend/src/main/java/com/stampcrush/backend/repository/visithistory/VisitHistoryRepository.java
@@ -1,0 +1,7 @@
+package com.stampcrush.backend.repository.visithistory;
+
+import com.stampcrush.backend.entity.visithistory.VisitHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface VisitHistoryRepository extends JpaRepository<VisitHistory, Long> {
+}

--- a/backend/src/test/java/com/stampcrush/backend/application/coupon/ManageCouponCommandServiceTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/application/coupon/ManageCouponCommandServiceTest.java
@@ -24,6 +24,7 @@ import com.stampcrush.backend.repository.coupon.StampRepository;
 import com.stampcrush.backend.repository.reward.RewardRepository;
 import com.stampcrush.backend.repository.user.CustomerRepository;
 import com.stampcrush.backend.repository.user.OwnerRepository;
+import com.stampcrush.backend.repository.visithistory.VisitHistoryRepository;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -77,6 +78,9 @@ public class ManageCouponCommandServiceTest {
 
     @Mock
     private RewardRepository rewardRepository;
+
+    @Mock
+    private VisitHistoryRepository visitHistoryRepository;
 
     @Mock
     private StampRepository stampRepository;
@@ -210,6 +214,7 @@ public class ManageCouponCommandServiceTest {
         // then
         then(rewardRepository).should(times(0)).save(any());
         then(couponRepository).should(times(0)).save(any());
+        then(visitHistoryRepository).should(times(1)).save(any());
         assertThat(currentCoupon.getStatus()).isEqualTo(CouponStatus.ACCUMULATING);
     }
 
@@ -226,6 +231,7 @@ public class ManageCouponCommandServiceTest {
         // then
         then(rewardRepository).should(times(1)).save(any());
         then(couponRepository).should(times(0)).save(any());
+        then(visitHistoryRepository).should(times(1)).save(any());
         assertThat(currentCoupon.getStatus()).isEqualTo(CouponStatus.REWARDED);
     }
 
@@ -242,6 +248,7 @@ public class ManageCouponCommandServiceTest {
         // then
         then(rewardRepository).should(times(2)).save(any());
         then(couponRepository).should(times(2)).save(any());
+        then(visitHistoryRepository).should(times(1)).save(any());
     }
 
     @Test
@@ -257,6 +264,7 @@ public class ManageCouponCommandServiceTest {
         // then
         then(rewardRepository).should(times(2)).save(any());
         then(couponRepository).should(times(1)).save(any());
+        then(visitHistoryRepository).should(times(1)).save(any());
     }
 
     @Test
@@ -274,6 +282,7 @@ public class ManageCouponCommandServiceTest {
         // then
         then(rewardRepository).should(times(0)).save(any());
         then(couponRepository).should(times(0)).save(any());
+        then(visitHistoryRepository).should(times(1)).save(any());
         assertThat(currentCoupon.getStatus()).isEqualTo(CouponStatus.ACCUMULATING);
         assertThat(currentCoupon.getStampCount()).isEqualTo(7);
     }
@@ -294,6 +303,7 @@ public class ManageCouponCommandServiceTest {
         // then
         then(rewardRepository).should(times(1)).save(any());
         then(couponRepository).should(times(0)).save(any());
+        then(visitHistoryRepository).should(times(1)).save(any());
         assertThat(currentCoupon.getStatus()).isEqualTo(CouponStatus.REWARDED);
         assertThat(currentCoupon.getStampCount()).isEqualTo(10);
     }
@@ -314,6 +324,7 @@ public class ManageCouponCommandServiceTest {
         // then
         then(rewardRepository).should(times(2)).save(any());
         then(couponRepository).should(times(2)).save(any());
+        then(visitHistoryRepository).should(times(1)).save(any());
     }
 
     @Test
@@ -330,6 +341,7 @@ public class ManageCouponCommandServiceTest {
         // then
         then(rewardRepository).should(times(2)).save(any());
         then(couponRepository).should(times(1)).save(any());
+        then(visitHistoryRepository).should(times(1)).save(any());
     }
 
     private void 스탬프_적립을_위해_필요한_엔티티를_조회한다(int maxStampCount, Coupon coupon) {


### PR DESCRIPTION
## 주요 변경사항

- stamp적립 서비스 로직에서 VisitHistoryRepository.save()만 추가했습니다~

## 리뷰어에게...

## 관련 이슈

closes #425 

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [x] `milestone` 설정
