### PR TITLE
[BE] refactor: 테스트 코드의 step, Fixture 공통 부분 분리 및 테스트 효율성 향상

### DIFF
--- a/backend/src/test/java/com/stampcrush/backend/acceptance/CafeCouponSettingIntegrationTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/CafeCouponSettingIntegrationTest.java
@@ -6,12 +6,12 @@ import com.stampcrush.backend.entity.cafe.CafeCouponDesign;
 import com.stampcrush.backend.entity.cafe.CafePolicy;
 import com.stampcrush.backend.entity.cafe.CafeStampCoordinate;
 import com.stampcrush.backend.entity.user.Owner;
+import com.stampcrush.backend.fixture.OwnerFixture;
 import com.stampcrush.backend.repository.cafe.CafeCouponDesignRepository;
 import com.stampcrush.backend.repository.cafe.CafePolicyRepository;
 import com.stampcrush.backend.repository.cafe.CafeRepository;
 import com.stampcrush.backend.repository.cafe.CafeStampCoordinateRepository;
 import com.stampcrush.backend.repository.user.OwnerRepository;
-import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
@@ -22,6 +22,7 @@ import org.springframework.http.HttpStatus;
 import java.time.LocalTime;
 import java.util.List;
 
+import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
@@ -45,11 +46,7 @@ public class CafeCouponSettingIntegrationTest extends AcceptanceTest {
     @Test
     void 카페_사장은_쿠폰_세팅에_대한_내용을_수정할_수_있다() {
         // given, when
-        Owner owner = new Owner(
-                "깃짱",
-                "gitchan",
-                "pw1234",
-                "깃짱핸드폰번호");
+        Owner owner = OwnerFixture.GITCHAN;
 
         Cafe savedCafe = cafeRepository.save(
                 new Cafe(
@@ -107,7 +104,7 @@ public class CafeCouponSettingIntegrationTest extends AcceptanceTest {
                 12
         );
 
-        ExtractableResponse<Response> response = RestAssured.given()
+        ExtractableResponse<Response> response = given()
                 .log().all()
                 .contentType(ContentType.JSON)
                 .auth().preemptive().basic(owner.getLoginId(), owner.getEncryptedPassword())

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/CafeCouponSettingIntegrationTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/CafeCouponSettingIntegrationTest.java
@@ -4,7 +4,6 @@ import com.stampcrush.backend.entity.cafe.Cafe;
 import com.stampcrush.backend.entity.cafe.CafeCouponDesign;
 import com.stampcrush.backend.entity.cafe.CafePolicy;
 import com.stampcrush.backend.entity.cafe.CafeStampCoordinate;
-import com.stampcrush.backend.entity.user.Owner;
 import com.stampcrush.backend.fixture.OwnerFixture;
 import com.stampcrush.backend.repository.cafe.CafeCouponDesignRepository;
 import com.stampcrush.backend.repository.cafe.CafePolicyRepository;
@@ -20,6 +19,8 @@ import org.springframework.http.HttpStatus;
 
 import static com.stampcrush.backend.acceptance.step.CafeCouponSettingUpdateStep.CAFE_COUPON_SETTING_UPDATE_REQUEST;
 import static com.stampcrush.backend.fixture.CafeFixture.cafeOfSavedOwner;
+import static com.stampcrush.backend.fixture.CouponDesignFixture.cafeCouponDesignOfSavedCafe;
+import static com.stampcrush.backend.fixture.CouponPolicyFixture.cafePolicyOfSavedCafe;
 import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -44,19 +45,10 @@ public class CafeCouponSettingIntegrationTest extends AcceptanceTest {
     @Test
     void 카페_사장은_쿠폰_세팅에_대한_내용을_수정할_수_있다() {
         // given, when
-        Owner owner = OwnerFixture.GITCHAN;
+        Cafe savedCafe = cafeRepository.save(cafeOfSavedOwner(ownerRepository.save(OwnerFixture.GITCHAN)));
 
-        Cafe savedCafe = cafeRepository.save(
-                cafeOfSavedOwner(ownerRepository.save(owner))
-        );
-
-        CafePolicy savedCafePolicy = cafePolicyRepository.save(
-                cafePolicyOfSavedCafe(savedCafe)
-        );
-
-        CafeCouponDesign savedCafeCouponDesign = cafeCouponDesignRepository.save(
-                cafeCouponDesignOfSavedCafe(savedCafe)
-        );
+        CafePolicy savedCafePolicy = cafePolicyRepository.save(cafePolicyOfSavedCafe(savedCafe));
+        CafeCouponDesign savedCafeCouponDesign = cafeCouponDesignRepository.save(cafeCouponDesignOfSavedCafe(savedCafe));
 
         CafeStampCoordinate savedCafeStampCoordinate1 = cafeStampCoordinateRepository.save(
                 new CafeStampCoordinate(
@@ -73,7 +65,7 @@ public class CafeCouponSettingIntegrationTest extends AcceptanceTest {
         ExtractableResponse<Response> response = given()
                 .log().all()
                 .contentType(ContentType.JSON)
-                .auth().preemptive().basic(owner.getLoginId(), owner.getEncryptedPassword())
+                .auth().preemptive().basic(OwnerFixture.GITCHAN.getLoginId(), OwnerFixture.GITCHAN.getEncryptedPassword())
                 .body(CAFE_COUPON_SETTING_UPDATE_REQUEST)
 
                 .when()
@@ -90,26 +82,6 @@ public class CafeCouponSettingIntegrationTest extends AcceptanceTest {
                 () -> assertThat(cafeCouponDesignRepository.findByCafe(savedCafe)).isNotEmpty(),
                 () -> assertThat(cafePolicyRepository.findById(savedCafePolicy.getId())).isEmpty(),
                 () -> assertThat(cafePolicyRepository.findByCafe(savedCafe)).isNotEmpty()
-        );
-    }
-
-    private static CafeCouponDesign cafeCouponDesignOfSavedCafe(Cafe savedCafe) {
-        return new CafeCouponDesign(
-                "#",
-                "#",
-                "#",
-                false,
-                savedCafe
-        );
-    }
-
-    private static CafePolicy cafePolicyOfSavedCafe(Cafe savedCafe) {
-        return new CafePolicy(
-                2,
-                "아메리카노",
-                12,
-                false,
-                savedCafe
         );
     }
 }

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/CafeCouponSettingIntegrationTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/CafeCouponSettingIntegrationTest.java
@@ -19,9 +19,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 
-import java.time.LocalTime;
 import java.util.List;
 
+import static com.stampcrush.backend.fixture.CafeFixture.cafeOfSavedOwner;
 import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -49,18 +49,7 @@ public class CafeCouponSettingIntegrationTest extends AcceptanceTest {
         Owner owner = OwnerFixture.GITCHAN;
 
         Cafe savedCafe = cafeRepository.save(
-                new Cafe(
-                        "깃짱카페",
-                        LocalTime.NOON,
-                        LocalTime.MIDNIGHT,
-                        "01012345678",
-                        "#",
-                        "안녕하세요",
-                        "서울시 올림픽로 어쩌고",
-                        "루터회관",
-                        "10-222-333",
-                        ownerRepository.save(owner)
-                )
+                cafeOfSavedOwner(ownerRepository.save(owner))
         );
 
         CafePolicy savedCafePolicy = cafePolicyRepository.save(

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/CafeCouponSettingIntegrationTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/CafeCouponSettingIntegrationTest.java
@@ -1,6 +1,5 @@
 package com.stampcrush.backend.acceptance;
 
-import com.stampcrush.backend.api.manager.cafe.request.CafeCouponSettingUpdateRequest;
 import com.stampcrush.backend.entity.cafe.Cafe;
 import com.stampcrush.backend.entity.cafe.CafeCouponDesign;
 import com.stampcrush.backend.entity.cafe.CafePolicy;
@@ -19,8 +18,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 
-import java.util.List;
-
+import static com.stampcrush.backend.acceptance.step.CafeCouponSettingUpdateStep.CAFE_COUPON_SETTING_UPDATE_REQUEST;
 import static com.stampcrush.backend.fixture.CafeFixture.cafeOfSavedOwner;
 import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
@@ -53,23 +51,11 @@ public class CafeCouponSettingIntegrationTest extends AcceptanceTest {
         );
 
         CafePolicy savedCafePolicy = cafePolicyRepository.save(
-                new CafePolicy(
-                        2,
-                        "아메리카노",
-                        12,
-                        false,
-                        savedCafe
-                )
+                cafePolicyOfSavedCafe(savedCafe)
         );
 
         CafeCouponDesign savedCafeCouponDesign = cafeCouponDesignRepository.save(
-                new CafeCouponDesign(
-                        "#",
-                        "#",
-                        "#",
-                        false,
-                        savedCafe
-                )
+                cafeCouponDesignOfSavedCafe(savedCafe)
         );
 
         CafeStampCoordinate savedCafeStampCoordinate1 = cafeStampCoordinateRepository.save(
@@ -84,20 +70,11 @@ public class CafeCouponSettingIntegrationTest extends AcceptanceTest {
                 )
         );
 
-        CafeCouponSettingUpdateRequest request = new CafeCouponSettingUpdateRequest(
-                "newFrontImageUrl",
-                "newBackImageUrl",
-                "newStampImageUrl",
-                List.of(new CafeCouponSettingUpdateRequest.CouponStampCoordinateRequest(1, 2, 1)),
-                "newReward",
-                12
-        );
-
         ExtractableResponse<Response> response = given()
                 .log().all()
                 .contentType(ContentType.JSON)
                 .auth().preemptive().basic(owner.getLoginId(), owner.getEncryptedPassword())
-                .body(request)
+                .body(CAFE_COUPON_SETTING_UPDATE_REQUEST)
 
                 .when()
                 .post("/api/admin/coupon-setting?cafe-id=" + savedCafe.getId())
@@ -113,6 +90,26 @@ public class CafeCouponSettingIntegrationTest extends AcceptanceTest {
                 () -> assertThat(cafeCouponDesignRepository.findByCafe(savedCafe)).isNotEmpty(),
                 () -> assertThat(cafePolicyRepository.findById(savedCafePolicy.getId())).isEmpty(),
                 () -> assertThat(cafePolicyRepository.findByCafe(savedCafe)).isNotEmpty()
+        );
+    }
+
+    private static CafeCouponDesign cafeCouponDesignOfSavedCafe(Cafe savedCafe) {
+        return new CafeCouponDesign(
+                "#",
+                "#",
+                "#",
+                false,
+                savedCafe
+        );
+    }
+
+    private static CafePolicy cafePolicyOfSavedCafe(Cafe savedCafe) {
+        return new CafePolicy(
+                2,
+                "아메리카노",
+                12,
+                false,
+                savedCafe
         );
     }
 }

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/CafeIntegrationTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/CafeIntegrationTest.java
@@ -5,8 +5,8 @@ import com.stampcrush.backend.api.visitor.cafe.response.CafeInfoFindResponse;
 import com.stampcrush.backend.application.visitor.cafe.dto.CafeInfoFindByCustomerResultDto;
 import com.stampcrush.backend.entity.cafe.Cafe;
 import com.stampcrush.backend.entity.user.Customer;
-import com.stampcrush.backend.entity.user.Owner;
 import com.stampcrush.backend.entity.user.RegisterCustomer;
+import com.stampcrush.backend.fixture.OwnerFixture;
 import com.stampcrush.backend.repository.cafe.CafeRepository;
 import com.stampcrush.backend.repository.user.CustomerRepository;
 import com.stampcrush.backend.repository.user.OwnerRepository;
@@ -18,8 +18,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 
-import java.time.LocalTime;
-
+import static com.stampcrush.backend.fixture.CafeFixture.cafeOfSavedOwner;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 
@@ -47,23 +46,8 @@ public class CafeIntegrationTest extends AcceptanceTest {
     @Test
     void 고객이_카페정보를_조회한다() {
         // given
-        Cafe savedCafe = cafeRepository.save(new Cafe(
-                "깃짱카페",
-                LocalTime.NOON,
-                LocalTime.MIDNIGHT,
-                "01012345678",
-                "#",
-                "안녕하세요",
-                "서울시 올림픽로 어쩌고",
-                "루터회관",
-                "10-222-333",
-                ownerRepository.save(
-                        new Owner(
-                                "깃짱",
-                                "깃짱아이디",
-                                "깃짱비밀번호",
-                                "깃짱핸드폰번호")
-                )));
+        Cafe savedCafe = cafeRepository.save(cafeOfSavedOwner(ownerRepository.save(OwnerFixture.GITCHAN))
+        );
 
         // when
         ExtractableResponse<Response> response = requestFindCafeByCustomer(customer, savedCafe.getId());

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/CustomerCouponFindAcceptanceTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/CustomerCouponFindAcceptanceTest.java
@@ -16,12 +16,12 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 
-import static com.stampcrush.backend.acceptance.step.CafeCouponSettingUpdateStep.CAFE_COUPON_SETTING_UPDATE_REQUEST;
-import static com.stampcrush.backend.acceptance.step.CafeCouponSettingUpdateStep.카페_쿠폰_정책_수정_요청;
-import static com.stampcrush.backend.acceptance.step.CafeCreateStep.CAFE_CREATE_REQUEST;
-import static com.stampcrush.backend.acceptance.step.CafeCreateStep.카페_생성_요청하고_아이디_반환;
-import static com.stampcrush.backend.acceptance.step.CouponCreateStep.쿠폰_생성_요청하고_아이디_반환;
-import static com.stampcrush.backend.acceptance.step.CouponFindStep.고객의_쿠폰_카페별로_1개씩_조회_요청;
+import static com.stampcrush.backend.acceptance.step.ManagerCafeCouponSettingUpdateStep.CAFE_COUPON_SETTING_UPDATE_REQUEST;
+import static com.stampcrush.backend.acceptance.step.ManagerCafeCouponSettingUpdateStep.카페_쿠폰_정책_수정_요청;
+import static com.stampcrush.backend.acceptance.step.ManagerCafeCreateStep.CAFE_CREATE_REQUEST;
+import static com.stampcrush.backend.acceptance.step.ManagerCafeCreateStep.카페_생성_요청하고_아이디_반환;
+import static com.stampcrush.backend.acceptance.step.ManagerCouponCreateStep.쿠폰_생성_요청하고_아이디_반환;
+import static com.stampcrush.backend.acceptance.step.VisitorCouponFindStep.고객의_쿠폰_카페별로_1개씩_조회_요청;
 import static com.stampcrush.backend.fixture.OwnerFixture.GITCHAN;
 import static com.stampcrush.backend.fixture.OwnerFixture.JENA;
 import static org.assertj.core.api.Assertions.assertThat;

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/ManagerCafeCouponSettingCommandUpdateAcceptanceTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/ManagerCafeCouponSettingCommandUpdateAcceptanceTest.java
@@ -17,7 +17,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 
-import static com.stampcrush.backend.acceptance.step.CafeCouponSettingUpdateStep.CAFE_COUPON_SETTING_UPDATE_REQUEST;
+import static com.stampcrush.backend.acceptance.step.ManagerCafeCouponSettingUpdateStep.CAFE_COUPON_SETTING_UPDATE_REQUEST;
 import static com.stampcrush.backend.fixture.CafeFixture.cafeOfSavedOwner;
 import static com.stampcrush.backend.fixture.CouponDesignFixture.cafeCouponDesignOfSavedCafe;
 import static com.stampcrush.backend.fixture.CouponPolicyFixture.cafePolicyOfSavedCafe;
@@ -25,7 +25,7 @@ import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-public class CafeCouponSettingIntegrationTest extends AcceptanceTest {
+public class ManagerCafeCouponSettingCommandUpdateAcceptanceTest extends AcceptanceTest {
 
     @Autowired
     private CafeRepository cafeRepository;

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/ManagerCouponCommandAcceptanceTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/ManagerCouponCommandAcceptanceTest.java
@@ -165,11 +165,8 @@ public class ManagerCouponCommandAcceptanceTest extends AcceptanceTest {
         쿠폰에_스탬프를_적립_요청(owner, customer2, coupon2Id, coupon2StampCreateRequest);
 
         // when
-        List<CafeCustomerFindResponse> customers = given().log().all()
-                .auth().preemptive()
-                .basic(owner.getLoginId(), owner.getEncryptedPassword())
-                .when()
-                .get("/api/admin/cafes/{cafeId}/customers", savedCafeId)
+        List<CafeCustomerFindResponse> customers = 고객_조회_요청(owner, savedCafeId)
+
                 .thenReturn()
                 .jsonPath()
                 .getList("customers", CafeCustomerFindResponse.class);
@@ -197,6 +194,16 @@ public class ManagerCouponCommandAcceptanceTest extends AcceptanceTest {
 
         assertThat(customers).usingRecursiveFieldByFieldElementComparatorIgnoringFields("visitCount", "firstVisitDate")
                 .containsExactlyInAnyOrder(customer1Expected, customer2Expected);
+    }
+
+    private static Response 고객_조회_요청(Owner owner, Long savedCafeId) {
+        return given()
+                .log().all()
+                .auth().preemptive()
+                .basic(owner.getLoginId(), owner.getEncryptedPassword())
+
+                .when()
+                .get("/api/admin/cafes/{cafeId}/customers", savedCafeId);
     }
 
     @Test

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/ManagerCouponCommandAcceptanceTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/ManagerCouponCommandAcceptanceTest.java
@@ -241,8 +241,19 @@ public class ManagerCouponCommandAcceptanceTest extends AcceptanceTest {
         쿠폰에_스탬프를_적립_요청(owner, customer, newCouponId, newCouponStampCreate);
 
         // when
-        List<CustomerAccumulatingCouponFindResponse> coupons = 고객의_쿠폰_조회하고_결과_반환(savedCafeId, customer);
+        List<CustomerAccumulatingCouponFindResponse> coupons = given()
+                .log().all()
+                .queryParam("cafe-id", savedCafeId)
+                .queryParam("active", true)
+                .auth().preemptive()
+                .basic(owner.getLoginId(), owner.getEncryptedPassword())
 
+                .when()
+                .get("/api/admin/customers/{customerId}/coupons", customer.getId())
+
+                .thenReturn()
+                .jsonPath()
+                .getList("coupons", CustomerAccumulatingCouponFindResponse.class);
         // then
         CustomerAccumulatingCouponFindResponse expected = new CustomerAccumulatingCouponFindResponse(newCouponId,
                 customer.getId(),

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/ManagerCouponCommandAcceptanceTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/ManagerCouponCommandAcceptanceTest.java
@@ -1,6 +1,5 @@
 package com.stampcrush.backend.acceptance;
 
-import com.stampcrush.backend.acceptance.AcceptanceTest;
 import com.stampcrush.backend.api.manager.coupon.request.CouponCreateRequest;
 import com.stampcrush.backend.api.manager.coupon.request.StampCreateRequest;
 import com.stampcrush.backend.api.manager.coupon.response.CafeCustomerFindResponse;
@@ -18,14 +17,14 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.List;
 
-import static com.stampcrush.backend.acceptance.step.CafeCreateStep.CAFE_CREATE_REQUEST;
-import static com.stampcrush.backend.acceptance.step.CafeCreateStep.카페_생성_요청하고_아이디_반환;
+import static com.stampcrush.backend.acceptance.step.ManagerCafeCreateStep.CAFE_CREATE_REQUEST;
+import static com.stampcrush.backend.acceptance.step.ManagerCafeCreateStep.카페_생성_요청하고_아이디_반환;
 import static io.restassured.http.ContentType.JSON;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.springframework.http.HttpStatus.UNAUTHORIZED;
 
-public class ManagerCouponCommandIntegrationTest extends AcceptanceTest {
+public class ManagerCouponCommandAcceptanceTest extends AcceptanceTest {
 
     @Autowired
     private OwnerRepository ownerRepository;

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/ManagerCouponCommandAcceptanceTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/ManagerCouponCommandAcceptanceTest.java
@@ -19,6 +19,7 @@ import static com.stampcrush.backend.acceptance.step.ManagerCafeCreateStep.CAFE_
 import static com.stampcrush.backend.acceptance.step.ManagerCafeCreateStep.카페_생성_요청하고_아이디_반환;
 import static com.stampcrush.backend.acceptance.step.ManagerCouponCreateStep.쿠폰_생성_요청하고_아이디_반환;
 import static com.stampcrush.backend.acceptance.step.ManagerCouponFindStep.고객의_쿠폰_조회하고_결과_반환;
+import static com.stampcrush.backend.acceptance.step.ManagerStampCreateStep.쿠폰에_스탬프를_적립_요청;
 import static com.stampcrush.backend.fixture.CustomerFixture.REGISTER_CUSTOMER_YOUNGHO;
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
@@ -233,16 +234,7 @@ public class ManagerCouponCommandAcceptanceTest extends AcceptanceTest {
         쿠폰에_스탬프를_적립_요청(owner, customer, newCouponId, newCouponStampCreate);
 
         // when
-        List<CustomerAccumulatingCouponFindResponse> coupons = given().log().all()
-                .queryParam("cafe-id", savedCafeId)
-                .queryParam("active", true)
-                .auth().preemptive()
-                .basic(owner.getLoginId(), owner.getEncryptedPassword())
-                .when()
-                .get("/api/admin/customers/{customerId}/coupons", customer.getId())
-                .thenReturn()
-                .jsonPath()
-                .getList("coupons", CustomerAccumulatingCouponFindResponse.class);
+        List<CustomerAccumulatingCouponFindResponse> coupons = 고객의_쿠폰_조회하고_결과_반환(savedCafeId, customer);
 
         // then
         CustomerAccumulatingCouponFindResponse expected = new CustomerAccumulatingCouponFindResponse(newCouponId,
@@ -270,32 +262,10 @@ public class ManagerCouponCommandAcceptanceTest extends AcceptanceTest {
         쿠폰에_스탬프를_적립_요청(owner, customer, oldCouponId, oldCouponStampCreate);
 
         // when
-        List<CustomerAccumulatingCouponFindResponse> coupons = given().log().all()
-                .queryParam("cafe-id", savedCafeId)
-                .queryParam("active", true)
-                .auth().preemptive()
-                .basic(owner.getLoginId(), owner.getEncryptedPassword())
-                .when()
-                .get("/api/admin/customers/{customerId}/coupons", customer.getId())
-                .thenReturn()
-                .jsonPath()
-                .getList("coupons", CustomerAccumulatingCouponFindResponse.class);
+        List<CustomerAccumulatingCouponFindResponse> coupons = 고객의_쿠폰_조회하고_결과_반환(savedCafeId, customer);
 
         // then
         assertThat(coupons).isEmpty();
-    }
-
-    public static ExtractableResponse<Response> 쿠폰에_스탬프를_적립_요청(Owner owner, RegisterCustomer customer, Long couponId, StampCreateRequest stampCreateRequest) {
-        return given()
-                .log().all()
-                .body(stampCreateRequest)
-                .contentType(JSON)
-                .auth().preemptive()
-                .basic(owner.getLoginId(), owner.getEncryptedPassword())
-                .when()
-                .post("/api/admin/customers/{customerId}/coupons/{couponId}/stamps", customer.getId(), couponId)
-                .then().log().all()
-                .extract();
     }
 
     private Owner 사장_생성() {

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/ManagerCouponCommandAcceptanceTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/ManagerCouponCommandAcceptanceTest.java
@@ -3,7 +3,6 @@ package com.stampcrush.backend.acceptance;
 import com.stampcrush.backend.api.manager.coupon.request.CouponCreateRequest;
 import com.stampcrush.backend.api.manager.coupon.request.StampCreateRequest;
 import com.stampcrush.backend.api.manager.coupon.response.CafeCustomerFindResponse;
-import com.stampcrush.backend.api.manager.coupon.response.CouponCreateResponse;
 import com.stampcrush.backend.api.manager.coupon.response.CustomerAccumulatingCouponFindResponse;
 import com.stampcrush.backend.entity.user.Owner;
 import com.stampcrush.backend.entity.user.RegisterCustomer;
@@ -18,6 +17,7 @@ import java.util.List;
 
 import static com.stampcrush.backend.acceptance.step.ManagerCafeCreateStep.CAFE_CREATE_REQUEST;
 import static com.stampcrush.backend.acceptance.step.ManagerCafeCreateStep.카페_생성_요청하고_아이디_반환;
+import static com.stampcrush.backend.acceptance.step.ManagerCouponCreateStep.쿠폰_생성_요청하고_아이디_반환;
 import static com.stampcrush.backend.acceptance.step.ManagerCouponFindStep.고객의_쿠폰_조회하고_결과_반환;
 import static com.stampcrush.backend.fixture.CustomerFixture.REGISTER_CUSTOMER_YOUNGHO;
 import static io.restassured.RestAssured.given;
@@ -43,7 +43,7 @@ public class ManagerCouponCommandAcceptanceTest extends AcceptanceTest {
         CouponCreateRequest reqeust = new CouponCreateRequest(savedCafeId);
 
         // when
-        Long couponId = 쿠폰_생성_후_아이디_반환(owner, savedCustomer, reqeust);
+        Long couponId = 쿠폰_생성_요청하고_아이디_반환(owner, reqeust, savedCustomer.getId());
 
         List<CustomerAccumulatingCouponFindResponse> coupons = 고객의_쿠폰_조회하고_결과_반환(savedCafeId, savedCustomer);
 
@@ -75,10 +75,10 @@ public class ManagerCouponCommandAcceptanceTest extends AcceptanceTest {
         CouponCreateRequest reqeust = new CouponCreateRequest(savedCafeId);
 
         // when
-        Long couponId = 쿠폰_생성_후_아이디_반환(owner, savedCustomer, reqeust);
+        Long couponId = 쿠폰_생성_요청하고_아이디_반환(owner, reqeust, savedCustomer.getId());
 
         StampCreateRequest stampCreateRequest = new StampCreateRequest(4);
-        쿠폰에_스탬프를_적립한다(owner, savedCustomer, couponId, stampCreateRequest);
+        쿠폰에_스탬프를_적립_요청(owner, savedCustomer, couponId, stampCreateRequest);
 
         List<CustomerAccumulatingCouponFindResponse> coupons = 고객의_쿠폰_조회하고_결과_반환(savedCafeId, savedCustomer);
 
@@ -151,17 +151,17 @@ public class ManagerCouponCommandAcceptanceTest extends AcceptanceTest {
         Long savedCafeId = 카페_생성_요청하고_아이디_반환(owner, CAFE_CREATE_REQUEST);
         RegisterCustomer customer1 = registerCustomerRepository.save(new RegisterCustomer("name", "phone", "id", "pw"));
         CouponCreateRequest reqeust1 = new CouponCreateRequest(savedCafeId);
-        Long coupon1Id = 쿠폰_생성_후_아이디_반환(owner, customer1, reqeust1);
+        Long coupon1Id = 쿠폰_생성_요청하고_아이디_반환(owner, reqeust1, customer1.getId());
 
         RegisterCustomer customer2 = registerCustomerRepository.save(new RegisterCustomer("name2", "phone2", "id2", "pw2"));
         CouponCreateRequest reqeust2 = new CouponCreateRequest(savedCafeId);
-        Long coupon2Id = 쿠폰_생성_후_아이디_반환(owner, customer2, reqeust2);
+        Long coupon2Id = 쿠폰_생성_요청하고_아이디_반환(owner, reqeust2, customer2.getId());
 
         StampCreateRequest coupon1StampCreateRequest = new StampCreateRequest(5);
-        쿠폰에_스탬프를_적립한다(owner, customer1, coupon1Id, coupon1StampCreateRequest);
+        쿠폰에_스탬프를_적립_요청(owner, customer1, coupon1Id, coupon1StampCreateRequest);
 
         StampCreateRequest coupon2StampCreateRequest = new StampCreateRequest(21);
-        쿠폰에_스탬프를_적립한다(owner, customer2, coupon2Id, coupon2StampCreateRequest);
+        쿠폰에_스탬프를_적립_요청(owner, customer2, coupon2Id, coupon2StampCreateRequest);
 
         // when
         List<CafeCustomerFindResponse> customers = given().log().all()
@@ -224,13 +224,13 @@ public class ManagerCouponCommandAcceptanceTest extends AcceptanceTest {
 
         RegisterCustomer customer = registerCustomerRepository.save(new RegisterCustomer("name2", "phone2", "id2", "pw2"));
         CouponCreateRequest couponCreateRequest = new CouponCreateRequest(savedCafeId);
-        Long oldCouponId = 쿠폰_생성_후_아이디_반환(owner, customer, couponCreateRequest);
+        Long oldCouponId = 쿠폰_생성_요청하고_아이디_반환(owner, couponCreateRequest, customer.getId());
         StampCreateRequest oldCouponStampCreate = new StampCreateRequest(3);
-        쿠폰에_스탬프를_적립한다(owner, customer, oldCouponId, oldCouponStampCreate);
+        쿠폰에_스탬프를_적립_요청(owner, customer, oldCouponId, oldCouponStampCreate);
 
-        Long newCouponId = 쿠폰_생성_후_아이디_반환(owner, customer, couponCreateRequest);
+        Long newCouponId = 쿠폰_생성_요청하고_아이디_반환(owner, couponCreateRequest, customer.getId());
         StampCreateRequest newCouponStampCreate = new StampCreateRequest(8);
-        쿠폰에_스탬프를_적립한다(owner, customer, newCouponId, newCouponStampCreate);
+        쿠폰에_스탬프를_적립_요청(owner, customer, newCouponId, newCouponStampCreate);
 
         // when
         List<CustomerAccumulatingCouponFindResponse> coupons = given().log().all()
@@ -265,9 +265,9 @@ public class ManagerCouponCommandAcceptanceTest extends AcceptanceTest {
 
         RegisterCustomer customer = registerCustomerRepository.save(new RegisterCustomer("name2", "phone2", "id2", "pw2"));
         CouponCreateRequest couponCreateRequest = new CouponCreateRequest(savedCafeId);
-        Long oldCouponId = 쿠폰_생성_후_아이디_반환(owner, customer, couponCreateRequest);
+        Long oldCouponId = 쿠폰_생성_요청하고_아이디_반환(owner, couponCreateRequest, customer.getId());
         StampCreateRequest oldCouponStampCreate = new StampCreateRequest(10); // 리워드 받고 쿠폰 만료됨
-        쿠폰에_스탬프를_적립한다(owner, customer, oldCouponId, oldCouponStampCreate);
+        쿠폰에_스탬프를_적립_요청(owner, customer, oldCouponId, oldCouponStampCreate);
 
         // when
         List<CustomerAccumulatingCouponFindResponse> coupons = given().log().all()
@@ -285,7 +285,7 @@ public class ManagerCouponCommandAcceptanceTest extends AcceptanceTest {
         assertThat(coupons).isEmpty();
     }
 
-    public static ExtractableResponse<Response> 쿠폰에_스탬프를_적립한다(Owner owner, RegisterCustomer customer, Long couponId, StampCreateRequest stampCreateRequest) {
+    public static ExtractableResponse<Response> 쿠폰에_스탬프를_적립_요청(Owner owner, RegisterCustomer customer, Long couponId, StampCreateRequest stampCreateRequest) {
         return given()
                 .log().all()
                 .body(stampCreateRequest)
@@ -296,22 +296,6 @@ public class ManagerCouponCommandAcceptanceTest extends AcceptanceTest {
                 .post("/api/admin/customers/{customerId}/coupons/{couponId}/stamps", customer.getId(), couponId)
                 .then().log().all()
                 .extract();
-    }
-
-    private Long 쿠폰_생성_후_아이디_반환(Owner owner, RegisterCustomer savedCustomer, CouponCreateRequest reqeust) {
-        ExtractableResponse<Response> extract = given().log().all()
-                .contentType(JSON)
-                .auth().preemptive()
-                .basic(owner.getLoginId(), owner.getEncryptedPassword())
-                .body(reqeust)
-                .when()
-                .post("/api/admin/customers/{customerId}/coupons", savedCustomer.getId())
-                .then()
-                .log().all()
-                .extract();
-
-        CouponCreateResponse couponCreateResponse = extract.body().as(CouponCreateResponse.class);
-        return couponCreateResponse.getCouponId();
     }
 
     private Owner 사장_생성() {

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/ManagerCustomerCommandAcceptanceTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/ManagerCustomerCommandAcceptanceTest.java
@@ -24,7 +24,7 @@ import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.OK;
 
-public class CustomerIntegrationTest extends AcceptanceTest {
+public class ManagerCustomerCommandAcceptanceTest extends AcceptanceTest {
 
     @Autowired
     private CustomerRepository customerRepository;

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/ManagerRewardCommandAcceptanceTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/ManagerRewardCommandAcceptanceTest.java
@@ -22,7 +22,7 @@ import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class RewardAcceptanceTest extends AcceptanceTest {
+public class ManagerRewardCommandAcceptanceTest extends AcceptanceTest {
 
     // TODO 회원가입, 로그인 구현 후 제거
     @Autowired

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/ManagerSampleCouponFindAcceptanceTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/ManagerSampleCouponFindAcceptanceTest.java
@@ -21,7 +21,7 @@ import static com.stampcrush.backend.fixture.SampleCouponFixture.*;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-public class SampleCouponIntegrationTest extends AcceptanceTest {
+public class ManagerSampleCouponFindAcceptanceTest extends AcceptanceTest {
 
     @Autowired
     private SampleFrontImageRepository sampleFrontImageRepository;

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/VisitorCafeFindAcceptanceTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/VisitorCafeFindAcceptanceTest.java
@@ -15,16 +15,13 @@ import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.MediaType;
 
+import static com.stampcrush.backend.acceptance.step.VisitorCafeFindStep.고객의_카페_정보_조회_요청;
 import static com.stampcrush.backend.fixture.CafeFixture.cafeOfSavedOwner;
-import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 
-public class CafeIntegrationTest extends AcceptanceTest {
-
-    private static final int NOT_EXIST_CAFE_ID = 1;
+public class VisitorCafeFindAcceptanceTest extends AcceptanceTest {
 
     @Autowired
     private CafeRepository cafeRepository;
@@ -43,7 +40,7 @@ public class CafeIntegrationTest extends AcceptanceTest {
         );
 
         // when
-        ExtractableResponse<Response> response = requestFindCafeByCustomer(customer, savedCafe.getId());
+        ExtractableResponse<Response> response = 고객의_카페_정보_조회_요청((RegisterCustomer) customer, savedCafe.getId());
         CafeInfoFindByCustomerResponse cafeInfoFindByCustomerResponse = response.body().as(CafeInfoFindByCustomerResponse.class);
 
         // then
@@ -56,30 +53,9 @@ public class CafeIntegrationTest extends AcceptanceTest {
     void 고객이_존재하지_않는_카페를_조회하면_에러가_발생한다() {
         Customer customer = customerRepository.save(CustomerFixture.REGISTER_CUSTOMER_JENA);
 
-        given()
-                .log().all()
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .auth().preemptive().basic(((RegisterCustomer) customer).getLoginId(), ((RegisterCustomer) customer).getEncryptedPassword())
+        long NOT_EXIST_CAFE_ID = 1L;
+        ExtractableResponse<Response> response = 고객의_카페_정보_조회_요청((RegisterCustomer) customer, NOT_EXIST_CAFE_ID);
 
-                .when()
-                .get("/api/cafes/" + NOT_EXIST_CAFE_ID)
-
-                .then()
-                .statusCode(NOT_FOUND.value())
-                .extract();
-    }
-
-    private ExtractableResponse<Response> requestFindCafeByCustomer(Customer customer, Long cafeId) {
-        return given()
-                .log().all()
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .auth().preemptive().basic(((RegisterCustomer) customer).getLoginId(), ((RegisterCustomer) customer).getEncryptedPassword())
-
-                .when()
-                .get("/api/cafes/" + cafeId)
-
-                .then()
-                .log().all()
-                .extract();
+        assertThat(response.statusCode()).isEqualTo(NOT_FOUND.value());
     }
 }

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/VisitorCouponFindAcceptanceTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/VisitorCouponFindAcceptanceTest.java
@@ -27,7 +27,7 @@ import static com.stampcrush.backend.fixture.OwnerFixture.JENA;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-public class CustomerCouponFindAcceptanceTest extends AcceptanceTest {
+public class VisitorCouponFindAcceptanceTest extends AcceptanceTest {
 
     private static final RegisterCustomer REGISTER_CUSTOMER = new RegisterCustomer("깃짱", "01012345678", "customer1", "customer1");
 

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/VisitorFavoritesCommandAcceptanceTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/VisitorFavoritesCommandAcceptanceTest.java
@@ -23,7 +23,7 @@ import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class FavoritesAcceptanceTest extends AcceptanceTest {
+public class VisitorFavoritesCommandAcceptanceTest extends AcceptanceTest {
 
     // TODO 회원가입, 로그인 구현 후 제거
     @Autowired

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/step/ManagerCafeCouponSettingUpdateStep.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/step/ManagerCafeCouponSettingUpdateStep.java
@@ -10,7 +10,7 @@ import java.util.List;
 
 import static io.restassured.http.ContentType.JSON;
 
-public class CafeCouponSettingUpdateStep {
+public class ManagerCafeCouponSettingUpdateStep {
 
     public static final CafeCouponSettingUpdateRequest CAFE_COUPON_SETTING_UPDATE_REQUEST = new CafeCouponSettingUpdateRequest(
             "frontImageUrl",

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/step/ManagerCafeCreateStep.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/step/ManagerCafeCreateStep.java
@@ -8,7 +8,7 @@ import io.restassured.response.Response;
 
 import static io.restassured.http.ContentType.JSON;
 
-public class CafeCreateStep {
+public class ManagerCafeCreateStep {
 
     public static final CafeCreateRequest CAFE_CREATE_REQUEST = new CafeCreateRequest("깃짱카페", "서초구", "우리집", "01010101010");
 

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/step/ManagerCouponCreateStep.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/step/ManagerCouponCreateStep.java
@@ -8,7 +8,7 @@ import io.restassured.response.Response;
 
 import static io.restassured.http.ContentType.JSON;
 
-public class CouponCreateStep {
+public class ManagerCouponCreateStep {
 
     public static Long 쿠폰_생성_요청하고_아이디_반환(Owner owner, CouponCreateRequest request, Long customerId) {
         ExtractableResponse<Response> response = 쿠폰_생성_요청(owner, request, customerId);

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/step/ManagerCouponCreateStep.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/step/ManagerCouponCreateStep.java
@@ -1,6 +1,7 @@
 package com.stampcrush.backend.acceptance.step;
 
 import com.stampcrush.backend.api.manager.coupon.request.CouponCreateRequest;
+import com.stampcrush.backend.api.manager.coupon.response.CouponCreateResponse;
 import com.stampcrush.backend.entity.user.Owner;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
@@ -12,7 +13,8 @@ public class ManagerCouponCreateStep {
 
     public static Long 쿠폰_생성_요청하고_아이디_반환(Owner owner, CouponCreateRequest request, Long customerId) {
         ExtractableResponse<Response> response = 쿠폰_생성_요청(owner, request, customerId);
-        return response.jsonPath().getLong("couponId");
+        CouponCreateResponse couponCreateResponse = response.body().as(CouponCreateResponse.class);
+        return couponCreateResponse.getCouponId();
     }
 
     public static ExtractableResponse<Response> 쿠폰_생성_요청(Owner owner, CouponCreateRequest request, Long customerId) {

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/step/ManagerCouponFindStep.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/step/ManagerCouponFindStep.java
@@ -1,0 +1,35 @@
+package com.stampcrush.backend.acceptance.step;
+
+import com.stampcrush.backend.api.manager.coupon.response.CustomerAccumulatingCouponFindResponse;
+import com.stampcrush.backend.entity.user.RegisterCustomer;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+
+import java.util.List;
+
+import static io.restassured.RestAssured.given;
+
+public class ManagerCouponFindStep {
+
+    public static List<CustomerAccumulatingCouponFindResponse> 고객의_쿠폰_조회하고_결과_반환(Long savedCafeId, RegisterCustomer savedCustomer) {
+        ExtractableResponse<Response> response = 고객의_쿠폰_조회_요청(savedCafeId, savedCustomer);
+        return response.jsonPath()
+                .getList("coupons", CustomerAccumulatingCouponFindResponse.class);
+    }
+
+    public static ExtractableResponse<Response> 고객의_쿠폰_조회_요청(Long savedCafeId, RegisterCustomer savedCustomer) {
+        return given()
+                .log().all()
+                .auth().preemptive()
+                .basic(savedCustomer.getLoginId(), savedCustomer.getEncryptedPassword())
+                .queryParam("cafe-id", savedCafeId)
+                .queryParam("active", true)
+
+                .when()
+                .get("api/admin/customers/{customerId}/coupons", savedCustomer.getId())
+
+                .then()
+                .log().all()
+                .extract();
+    }
+}

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/step/ManagerStampCreateStep.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/step/ManagerStampCreateStep.java
@@ -1,0 +1,29 @@
+package com.stampcrush.backend.acceptance.step;
+
+import com.stampcrush.backend.api.manager.coupon.request.StampCreateRequest;
+import com.stampcrush.backend.entity.user.Owner;
+import com.stampcrush.backend.entity.user.RegisterCustomer;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.http.ContentType.JSON;
+
+public class ManagerStampCreateStep {
+
+    public static ExtractableResponse<Response> 쿠폰에_스탬프를_적립_요청(Owner owner, RegisterCustomer customer, Long couponId, StampCreateRequest stampCreateRequest) {
+        return given()
+                .log().all()
+                .body(stampCreateRequest)
+                .contentType(JSON)
+                .auth().preemptive()
+                .basic(owner.getLoginId(), owner.getEncryptedPassword())
+
+                .when()
+                .post("/api/admin/customers/{customerId}/coupons/{couponId}/stamps", customer.getId(), couponId)
+
+                .then()
+                .log().all()
+                .extract();
+    }
+}

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/step/ManagerTemporaryCustomerCreateStep.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/step/ManagerTemporaryCustomerCreateStep.java
@@ -8,7 +8,7 @@ import io.restassured.response.Response;
 
 import static io.restassured.http.ContentType.JSON;
 
-public class TemporaryCustomerCreateStep {
+public class ManagerTemporaryCustomerCreateStep {
 
     public static final TemporaryCustomerCreateRequest TEMPORARY_CUSTOMER_CREATE_REQUEST = new TemporaryCustomerCreateRequest("01012345678");
 

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/step/VisitorCafeFindStep.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/step/VisitorCafeFindStep.java
@@ -1,0 +1,26 @@
+package com.stampcrush.backend.acceptance.step;
+
+import com.stampcrush.backend.entity.user.RegisterCustomer;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.springframework.http.MediaType;
+
+import static io.restassured.RestAssured.given;
+
+public final class VisitorCafeFindStep {
+
+    public static ExtractableResponse<Response> 고객의_카페_정보_조회_요청(RegisterCustomer customer, Long cafeId) {
+        return given()
+                .log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .auth().preemptive()
+                .basic(customer.getLoginId(), customer.getEncryptedPassword())
+
+                .when()
+                .get("/api/cafes/" + cafeId)
+
+                .then()
+                .log().all()
+                .extract();
+    }
+}

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/step/VisitorCouponFindStep.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/step/VisitorCouponFindStep.java
@@ -5,7 +5,7 @@ import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 
-public class CouponFindStep {
+public class VisitorCouponFindStep {
 
     public static ExtractableResponse<Response> 고객의_쿠폰_카페별로_1개씩_조회_요청(RegisterCustomer customer) {
         return RestAssured.given()

--- a/backend/src/test/java/com/stampcrush/backend/api/docs/DocsControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/docs/DocsControllerTest.java
@@ -9,6 +9,7 @@ import com.stampcrush.backend.application.manager.cafe.ManagerCafeFindService;
 import com.stampcrush.backend.application.manager.customer.ManagerCustomerCommandService;
 import com.stampcrush.backend.application.manager.customer.ManagerCustomerFindService;
 import com.stampcrush.backend.application.visitor.cafe.VisitorCafeFindService;
+import com.stampcrush.backend.common.KorNamingConverter;
 import com.stampcrush.backend.repository.user.OwnerRepository;
 import com.stampcrush.backend.repository.user.RegisterCustomerRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -28,6 +29,7 @@ import org.springframework.web.filter.CharacterEncodingFilter;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 
+@KorNamingConverter
 @AutoConfigureRestDocs
 @AutoConfigureMockMvc
 @WebMvcTest({ManagerCafeFindApiController.class,

--- a/backend/src/test/java/com/stampcrush/backend/fixture/CafeFixture.java
+++ b/backend/src/test/java/com/stampcrush/backend/fixture/CafeFixture.java
@@ -1,9 +1,9 @@
 package com.stampcrush.backend.fixture;
 
 import com.stampcrush.backend.entity.cafe.Cafe;
+import com.stampcrush.backend.entity.user.Owner;
 
 import java.time.LocalTime;
-
 
 public final class CafeFixture {
 
@@ -19,6 +19,21 @@ public final class CafeFixture {
             "buisnessRegistrationNumber",
             OwnerFixture.GITCHAN
     );
+
+    public static Cafe cafeOfSavedOwner(Owner savedOwner) {
+        return new Cafe(
+                "깃짱카페",
+                LocalTime.NOON,
+                LocalTime.MIDNIGHT,
+                "01012345678",
+                "#",
+                "안녕하세요",
+                "서울시 올림픽로 어쩌고",
+                "루터회관",
+                "10-222-333",
+                savedOwner
+        );
+    }
 
     private CafeFixture() {
     }

--- a/backend/src/test/java/com/stampcrush/backend/fixture/CouponDesignFixture.java
+++ b/backend/src/test/java/com/stampcrush/backend/fixture/CouponDesignFixture.java
@@ -1,5 +1,7 @@
 package com.stampcrush.backend.fixture;
 
+import com.stampcrush.backend.entity.cafe.Cafe;
+import com.stampcrush.backend.entity.cafe.CafeCouponDesign;
 import com.stampcrush.backend.entity.coupon.CouponDesign;
 
 public final class CouponDesignFixture {
@@ -11,6 +13,16 @@ public final class CouponDesignFixture {
     public static final CouponDesign COUPON_DESIGN_5 = new CouponDesign("front", "back", "stamp");
     public static final CouponDesign COUPON_DESIGN_6 = new CouponDesign("front", "back", "stamp");
     public static final CouponDesign COUPON_DESIGN_7 = new CouponDesign("front", "back", "stamp");
+
+    public static CafeCouponDesign cafeCouponDesignOfSavedCafe(Cafe savedCafe) {
+        return new CafeCouponDesign(
+                "#",
+                "#",
+                "#",
+                false,
+                savedCafe
+        );
+    }
 
     private CouponDesignFixture() {
     }

--- a/backend/src/test/java/com/stampcrush/backend/fixture/CouponPolicyFixture.java
+++ b/backend/src/test/java/com/stampcrush/backend/fixture/CouponPolicyFixture.java
@@ -1,5 +1,7 @@
 package com.stampcrush.backend.fixture;
 
+import com.stampcrush.backend.entity.cafe.Cafe;
+import com.stampcrush.backend.entity.cafe.CafePolicy;
 import com.stampcrush.backend.entity.coupon.CouponPolicy;
 
 public final class CouponPolicyFixture {
@@ -11,6 +13,16 @@ public final class CouponPolicyFixture {
     public static final CouponPolicy COUPON_POLICY_5 = new CouponPolicy(10, "아메리카노", 8);
     public static final CouponPolicy COUPON_POLICY_6 = new CouponPolicy(10, "아메리카노", 8);
     public static final CouponPolicy COUPON_POLICY_7 = new CouponPolicy(20, "아메리카노", 8);
+
+    public static CafePolicy cafePolicyOfSavedCafe(Cafe savedCafe) {
+        return new CafePolicy(
+                2,
+                "아메리카노",
+                12,
+                false,
+                savedCafe
+        );
+    }
 
     private CouponPolicyFixture() {
     }

--- a/backend/src/test/java/com/stampcrush/backend/fixture/CouponPolicyFixture.java
+++ b/backend/src/test/java/com/stampcrush/backend/fixture/CouponPolicyFixture.java
@@ -8,11 +8,6 @@ public final class CouponPolicyFixture {
 
     public static final CouponPolicy COUPON_POLICY_1 = new CouponPolicy(10, "아메리카노", 8);
     public static final CouponPolicy COUPON_POLICY_2 = new CouponPolicy(10, "아메리카노", 8);
-    public static final CouponPolicy COUPON_POLICY_3 = new CouponPolicy(10, "아메리카노", 8);
-    public static final CouponPolicy COUPON_POLICY_4 = new CouponPolicy(10, "아메리카노", 8);
-    public static final CouponPolicy COUPON_POLICY_5 = new CouponPolicy(10, "아메리카노", 8);
-    public static final CouponPolicy COUPON_POLICY_6 = new CouponPolicy(10, "아메리카노", 8);
-    public static final CouponPolicy COUPON_POLICY_7 = new CouponPolicy(20, "아메리카노", 8);
 
     public static CafePolicy cafePolicyOfSavedCafe(Cafe savedCafe) {
         return new CafePolicy(

--- a/backend/src/test/java/com/stampcrush/backend/fixture/CustomerFixture.java
+++ b/backend/src/test/java/com/stampcrush/backend/fixture/CustomerFixture.java
@@ -13,6 +13,7 @@ public final class CustomerFixture {
     public static final RegisterCustomer REGISTER_CUSTOMER_GITCHAN = new RegisterCustomer("깃짱", "01012345678", "gitchan", "password");
     public static final RegisterCustomer REGISTER_CUSTOMER_GITCHAN_SAVED = new RegisterCustomer(1L, "깃짱", "01012345678", "gitchan", "password");
     public static final RegisterCustomer REGISTER_CUSTOMER_JENA = new RegisterCustomer("jena", "01012345678", "jena", "1234");
+    public static final RegisterCustomer REGISTER_CUSTOMER_YOUNGHO = new RegisterCustomer("name", "phone", "id", "pw");
 
     private CustomerFixture() {
     }

--- a/backend/src/test/java/com/stampcrush/backend/fixture/CustomerFixture.java
+++ b/backend/src/test/java/com/stampcrush/backend/fixture/CustomerFixture.java
@@ -12,6 +12,7 @@ public final class CustomerFixture {
     public static final RegisterCustomer REGISTER_CUSTOMER_2 = new RegisterCustomer("깃짱 닉네임", "깃짱 번호", "깃짱 아이디", "깃짱 비번");
     public static final RegisterCustomer REGISTER_CUSTOMER_GITCHAN = new RegisterCustomer("깃짱", "01012345678", "gitchan", "password");
     public static final RegisterCustomer REGISTER_CUSTOMER_GITCHAN_SAVED = new RegisterCustomer(1L, "깃짱", "01012345678", "gitchan", "password");
+    public static final RegisterCustomer REGISTER_CUSTOMER_JENA = new RegisterCustomer("jena", "01012345678", "jena", "1234");
 
     private CustomerFixture() {
     }


### PR DESCRIPTION
## 주요 변경사항

너무 변경 파일이 많아서 보기 까다로울 것 같아서 리팩터링한 부분 글로 작성했으니, 꼭 읽고 파일은 훑어보면 될 것 같습니당.
아래 내용 모두 한 건 아니고, step 클래스 이름 바뀐 것 때문에 새로 작성하는 코드에서 못 쓸 것 같아서, 일단 먼저 올려놓을게요! 
이후에 한 번 더 PR을 요청해야 할 것 같아요

- acceptance 패키지에 들어있던 테스트들 전부 AcceptanceTest로 만들고, 최대한 블랙박스 테스트로 만들었음.
- 블랙박스 테스트: RestAssured 들어간 요청 보내는 부분들을 최대한 분리해서 외부에서 우리 API의 상세 내용을 알 수 없도록 함.
- 따라서 분리할 수 있는 부분은 최대한 step으로 분리하고, 공통적인 부분들은 상수를 최대한 없애는 방향으로 리팩터링함.
    - 중간에 인증 헤더 없이 보낸 경우에 대한 반환 같이 불가피한 경우를 제외하고 정상적인 동작만을 step 패키지 안으로 분리함.

- Fixture 역시 최대한 분리함.
    - 특정 필드가 영속화된 내용이어야 하는 경우에는, 일단 public static 메서드로 해당 부분을 파라미터로 받도록 변경함.

- 테스트 효율성 향상
    - 현재 Controller, Service slice test의 경우에 모든 코드가 다 각자 동일한 MockBean을 중복해서 생성하고 있음.
    - 따라서 상위의 ControllerTest, ServiceTest를 생성하고, 공통적인 부분은 모두 분리함.

## 리뷰어에게...

## 관련 이슈

closes

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [x] `milestone` 설정
