### PR TITLE
[BE] feat: 쿠폰 삭제 기능을 구현한다

### DIFF
--- a/backend/src/main/java/com/stampcrush/backend/api/visitor/coupon/VisitorCouponCommandApiController.java
+++ b/backend/src/main/java/com/stampcrush/backend/api/visitor/coupon/VisitorCouponCommandApiController.java
@@ -1,0 +1,24 @@
+package com.stampcrush.backend.api.visitor.coupon;
+
+import com.stampcrush.backend.application.visitor.coupon.VisitorCouponCommandService;
+import com.stampcrush.backend.config.resolver.CustomerAuth;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/coupons")
+public class VisitorCouponCommandApiController {
+
+    private final VisitorCouponCommandService visitorCouponCommandService;
+
+    @DeleteMapping("/{couponId}")
+    public ResponseEntity<Void> deleteCoupon(CustomerAuth customer, @PathVariable Long couponId) {
+        visitorCouponCommandService.deleteCoupon(customer.getId(), couponId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/backend/src/main/java/com/stampcrush/backend/application/visitor/coupon/VisitorCouponCommandService.java
+++ b/backend/src/main/java/com/stampcrush/backend/application/visitor/coupon/VisitorCouponCommandService.java
@@ -17,6 +17,6 @@ public class VisitorCouponCommandService {
     public void deleteCoupon(Long customerId, Long couponId) {
         Coupon coupon = couponRepository.findByIdAndCustomerId(couponId, customerId)
                 .orElseThrow(() -> new CouponNotFoundException("쿠폰을 찾을 수 없습니다."));
-        coupon.delete();
+        couponRepository.delete(coupon);
     }
 }

--- a/backend/src/main/java/com/stampcrush/backend/application/visitor/coupon/VisitorCouponCommandService.java
+++ b/backend/src/main/java/com/stampcrush/backend/application/visitor/coupon/VisitorCouponCommandService.java
@@ -1,0 +1,22 @@
+package com.stampcrush.backend.application.visitor.coupon;
+
+import com.stampcrush.backend.entity.coupon.Coupon;
+import com.stampcrush.backend.exception.CouponNotFoundException;
+import com.stampcrush.backend.repository.coupon.CouponRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class VisitorCouponCommandService {
+
+    private final CouponRepository couponRepository;
+
+    public void deleteCoupon(Long customerId, Long couponId) {
+        Coupon coupon = couponRepository.findByIdAndCustomerId(couponId, customerId)
+                .orElseThrow(() -> new CouponNotFoundException("쿠폰을 찾을 수 없습니다."));
+        coupon.delete();
+    }
+}

--- a/backend/src/main/java/com/stampcrush/backend/entity/coupon/Coupon.java
+++ b/backend/src/main/java/com/stampcrush/backend/entity/coupon/Coupon.java
@@ -6,6 +6,7 @@ import com.stampcrush.backend.entity.user.Customer;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -19,6 +20,7 @@ import static lombok.AccessLevel.PROTECTED;
 
 @Getter
 @NoArgsConstructor(access = PROTECTED)
+@SQLDelete(sql = "UPDATE coupon SET deleted = true WHERE id = ?")
 @Entity
 public class Coupon extends BaseDate {
 
@@ -153,9 +155,5 @@ public class Coupon extends BaseDate {
 
     public String getRewardName() {
         return couponPolicy.getRewardName();
-    }
-
-    public void delete() {
-        this.deleted = Boolean.TRUE;
     }
 }

--- a/backend/src/main/java/com/stampcrush/backend/entity/coupon/Coupon.java
+++ b/backend/src/main/java/com/stampcrush/backend/entity/coupon/Coupon.java
@@ -154,4 +154,8 @@ public class Coupon extends BaseDate {
     public String getRewardName() {
         return couponPolicy.getRewardName();
     }
+
+    public void delete() {
+        this.deleted = Boolean.TRUE;
+    }
 }

--- a/backend/src/main/java/com/stampcrush/backend/entity/coupon/Coupon.java
+++ b/backend/src/main/java/com/stampcrush/backend/entity/coupon/Coupon.java
@@ -7,6 +7,7 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -21,6 +22,7 @@ import static lombok.AccessLevel.PROTECTED;
 @Getter
 @NoArgsConstructor(access = PROTECTED)
 @SQLDelete(sql = "UPDATE coupon SET deleted = true WHERE id = ?")
+@Where(clause = "deleted = false")
 @Entity
 public class Coupon extends BaseDate {
 

--- a/backend/src/main/java/com/stampcrush/backend/exception/CouponNotFoundException.java
+++ b/backend/src/main/java/com/stampcrush/backend/exception/CouponNotFoundException.java
@@ -1,0 +1,16 @@
+package com.stampcrush.backend.exception;
+
+public class CouponNotFoundException extends NotFoundException {
+
+    public CouponNotFoundException(String message) {
+        super(message);
+    }
+
+    public CouponNotFoundException(Throwable cause) {
+        super(cause);
+    }
+
+    public CouponNotFoundException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/backend/src/main/java/com/stampcrush/backend/repository/coupon/CouponRepository.java
+++ b/backend/src/main/java/com/stampcrush/backend/repository/coupon/CouponRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface CouponRepository extends JpaRepository<Coupon, Long> {
 
@@ -18,4 +19,6 @@ public interface CouponRepository extends JpaRepository<Coupon, Long> {
     List<Coupon> findByCafeAndCustomerAndStatus(@Param("cafe") Cafe cafe, @Param("customer") Customer customer, @Param("status") CouponStatus status);
 
     List<Coupon> findByCustomerAndStatus(@Param("customer") Customer customer, @Param("status") CouponStatus status);
+
+    Optional<Coupon> findByIdAndCustomerId(Long id, Long customerId);
 }

--- a/backend/src/test/java/com/stampcrush/backend/api/visitor/coupon/VisitorCouponCommandApiControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/visitor/coupon/VisitorCouponCommandApiControllerTest.java
@@ -1,0 +1,62 @@
+package com.stampcrush.backend.api.visitor.coupon;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.stampcrush.backend.application.visitor.coupon.VisitorCouponCommandService;
+import com.stampcrush.backend.common.KorNamingConverter;
+import com.stampcrush.backend.config.WebMvcConfig;
+import com.stampcrush.backend.exception.CouponNotFoundException;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@KorNamingConverter
+@WebMvcTest(value = VisitorCouponCommandApiController.class,
+        excludeFilters =
+        @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebMvcConfig.class))
+public class VisitorCouponCommandApiControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private VisitorCouponCommandService visitorCouponCommandService;
+
+    @Test
+    void 삭제_하려는_쿠폰_정보가_올바르지_않은_경우_상태코드가_404_이다() throws Exception {
+        // given
+        doThrow(CouponNotFoundException.class)
+                .when(visitorCouponCommandService)
+                .deleteCoupon(any(), any());
+
+        // when, then
+        mockMvc.perform(
+                        delete("/api/coupons/{couponId}", 1L)
+                                .contentType(APPLICATION_JSON))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void 쿠폰을_정상적으로_삭제하면_상태코드가_204_이다() throws Exception {
+        // given
+        doNothing()
+                .when(visitorCouponCommandService)
+                .deleteCoupon(any(), any());
+
+        // when, then
+        mockMvc.perform(
+                        delete("/api/coupons/{couponId}", 1L)
+                                .contentType(APPLICATION_JSON))
+                .andExpect(status().isNoContent());
+    }
+}

--- a/backend/src/test/java/com/stampcrush/backend/application/visitor/coupon/VisitorCouponCommandServiceTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/application/visitor/coupon/VisitorCouponCommandServiceTest.java
@@ -1,0 +1,38 @@
+package com.stampcrush.backend.application.visitor.coupon;
+
+import com.stampcrush.backend.common.KorNamingConverter;
+import com.stampcrush.backend.exception.CouponNotFoundException;
+import com.stampcrush.backend.repository.coupon.CouponRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+
+@KorNamingConverter
+@ExtendWith(MockitoExtension.class)
+public class VisitorCouponCommandServiceTest {
+
+    @InjectMocks
+    private VisitorCouponCommandService visitorCouponCommandService;
+
+    @Mock
+    private CouponRepository couponRepository;
+
+    @Test
+    void 삭제하려는_쿠폰을_찾지_못할_시_예외를_던진다() {
+        // given
+        when(couponRepository.findByIdAndCustomerId(anyLong(), anyLong()))
+                .thenReturn(Optional.empty());
+
+        // when, then
+        assertThatThrownBy(() -> visitorCouponCommandService.deleteCoupon(1L, 1L))
+                .isInstanceOf(CouponNotFoundException.class);
+    }
+}

--- a/backend/src/test/java/com/stampcrush/backend/entity/coupon/CouponTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/entity/coupon/CouponTest.java
@@ -203,4 +203,27 @@ class CouponTest {
         // then
         assertThat(coupon.isSameMaxStampAfterAccumulateStamp(3)).isTrue();
     }
+
+    @Test
+    void 쿠폰을_삭제한다() {
+        // given
+        Coupon coupon = new Coupon(LocalDate.EPOCH, TemporaryCustomer.from("01012345678"), new Cafe(
+                "하디까페",
+                LocalTime.of(12, 30),
+                LocalTime.of(18, 30),
+                "0211111111",
+                "http://www.cafeImage.com",
+                "안녕하세요",
+                "잠실동12길",
+                "14층",
+                "11111111",
+                new Owner("이름", "아이디", "비번", "01012345678")), new CouponDesign(), new CouponPolicy(10, "짱", 10)
+        );
+
+        // when
+        coupon.delete();
+
+        // then
+        assertThat(coupon.getDeleted()).isTrue();
+    }
 }

--- a/backend/src/test/java/com/stampcrush/backend/entity/coupon/CouponTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/entity/coupon/CouponTest.java
@@ -203,27 +203,4 @@ class CouponTest {
         // then
         assertThat(coupon.isSameMaxStampAfterAccumulateStamp(3)).isTrue();
     }
-
-    @Test
-    void 쿠폰을_삭제한다() {
-        // given
-        Coupon coupon = new Coupon(LocalDate.EPOCH, TemporaryCustomer.from("01012345678"), new Cafe(
-                "하디까페",
-                LocalTime.of(12, 30),
-                LocalTime.of(18, 30),
-                "0211111111",
-                "http://www.cafeImage.com",
-                "안녕하세요",
-                "잠실동12길",
-                "14층",
-                "11111111",
-                new Owner("이름", "아이디", "비번", "01012345678")), new CouponDesign(), new CouponPolicy(10, "짱", 10)
-        );
-
-        // when
-        coupon.delete();
-
-        // then
-        assertThat(coupon.getDeleted()).isTrue();
-    }
 }

--- a/backend/src/test/java/com/stampcrush/backend/repository/coupon/CouponRepositoryTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/repository/coupon/CouponRepositoryTest.java
@@ -19,6 +19,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -201,5 +202,14 @@ class CouponRepositoryTest {
 
         // then
         assertThat(visitTime).isEqualTo(coupon1.getCreatedAt());
+    }
+
+    @Test
+    void 쿠폰의_아이디와_고객의_아이디로_쿠폰을_조회한다() {
+        // given, when
+        Optional<Coupon> coupon = couponRepository.findByIdAndCustomerId(coupon1.getId(), tmpCustomer1.getId());
+
+        // then
+        assertThat(coupon).isPresent();
     }
 }


### PR DESCRIPTION
## 주요 변경사항
- 쿠폰 삭제 기능 구현

## 쿠폰 삭제

### Request

**Header**

```json
DELETE /api/coupons/{couponId}

**Authorization: username@password Base64 (customer**)
```

**Body**

None

### Response

**Header** 

```json
HTTP/1.1 204 NO CONTENT
```

**Body**

None

## 리뷰어에게...
- `Step`클래스가 완료되면 인수테스트 넣겠습니다.

- 쿠폰 삭제시 이미 쿠폰이 삭제되있는 경우를 따로 체크하지 않았습니다. 체크하지 않았기에 예외를 따로 던지지도 않고요. 
만약 이미 삭제된 쿠폰에 대해 삭제하라는 요청이 다시 왔을 경우 예외를 터트려야하는가에 대해서 저는 예외를 던지지 않아도 된다는 입장입니다. 결국 클라이언트가 원한 결과는 `쿠폰이 삭제가 된다` 입니다. 그렇기에 쿠폰이 이미 삭제가 된 상태라고 해도 이 경우는 요청이 기대하는 바와 일치하기 때문에 따로 예외를 던지지 않아도 된다고 생각합니다.

여러분의 의견은 어떤지 여쭤보고 싶습니다 !

## 관련 이슈

closes #438 

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [x] `milestone` 설정
