### PR TITLE
[BE] refactor: 남은 리워드 개수 구하는 로직 수정

### DIFF
--- a/backend/src/main/java/com/stampcrush/backend/repository/reward/RewardRepository.java
+++ b/backend/src/main/java/com/stampcrush/backend/repository/reward/RewardRepository.java
@@ -1,5 +1,6 @@
 package com.stampcrush.backend.repository.reward;
 
+import com.stampcrush.backend.entity.cafe.Cafe;
 import com.stampcrush.backend.entity.reward.Reward;
 import com.stampcrush.backend.entity.user.Customer;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -11,4 +12,6 @@ public interface RewardRepository extends JpaRepository<Reward, Long> {
     List<Reward> findAllByCustomerIdAndCafeIdAndUsed(Long CustomerId, Long CafeId, boolean used);
 
     List<Reward> findAllByCustomerAndUsed(Customer customer, boolean used);
+
+    Long countByCafeAndCustomerAndUsed(Cafe cafe, Customer customer, Boolean used);
 }

--- a/backend/src/test/java/com/stampcrush/backend/application/manager/coupon/ManagerCouponFindServiceTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/application/manager/coupon/ManagerCouponFindServiceTest.java
@@ -13,6 +13,7 @@ import com.stampcrush.backend.entity.visithistory.VisitHistory;
 import com.stampcrush.backend.repository.cafe.CafePolicyRepository;
 import com.stampcrush.backend.repository.cafe.CafeRepository;
 import com.stampcrush.backend.repository.coupon.CouponRepository;
+import com.stampcrush.backend.repository.reward.RewardRepository;
 import com.stampcrush.backend.repository.user.CustomerRepository;
 import com.stampcrush.backend.repository.visithistory.VisitHistoryRepository;
 import org.junit.jupiter.api.BeforeAll;
@@ -57,6 +58,9 @@ public class ManagerCouponFindServiceTest {
 
     @Mock
     private VisitHistoryRepository visitHistoryRepository;
+
+    @Mock
+    private RewardRepository rewardRepository;
 
     @BeforeAll
     static void setUp() {

--- a/backend/src/test/java/com/stampcrush/backend/repository/reward/RewardRepositoryTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/repository/reward/RewardRepositoryTest.java
@@ -61,6 +61,26 @@ class RewardRepositoryTest {
         assertThat(findRewards).isEmpty();
     }
 
+    @Test
+    void 해당_고객의_사용_가능한_리워드의_개수를_조회한다() {
+        // given
+        Cafe cafe = createCafe(OwnerFixture.GITCHAN);
+        Customer customer = customerRepository.save(CustomerFixture.REGISTER_CUSTOMER_GITCHAN);
+
+        Reward reward1 = rewardRepository.save(new Reward("Reward1", customer, cafe));
+        rewardRepository.save(new Reward("Reward2", customer, cafe));
+        rewardRepository.save(new Reward("Reward3", customer, cafe));
+        rewardRepository.save(new Reward("Reward4", customer, cafe));
+        rewardRepository.save(new Reward("Reward5", customer, cafe));
+        reward1.useReward(customer, cafe);
+
+        // when
+        Long countOfUnusedReward = rewardRepository.countByCafeAndCustomerAndUsed(cafe, customer, Boolean.FALSE);
+
+        // then
+        assertThat(countOfUnusedReward).isEqualTo(4);
+    }
+
     private Cafe createCafe(Owner owner) {
         Owner savedOwner = ownerRepository.save(owner);
         return cafeRepository.save(


### PR DESCRIPTION
## 주요 변경사항
사장님이 고객의 남은 리워드 개수를 조회할 때, 이미 사용한 리워드까지 조회되는 문제를 해결했습니다.

## 리뷰어에게...
바뀐 부분이 많지는 않습니다.
`RewardRepository`에 대한 의존성 추가를 했습니다.
찾아보니 SpringDataJpa에서 `count` 쿼리의 반환 타입이 `Long`이더군요.

그래서 int로 강제 캐스팅을 했는데, DTO의 rewardcount field type을 Long으로 바꿔도 될것같습니다.

여러분의 의견은 ?? 저는 후자긴해요..(함부로 바꾸면 안될것같아 전자의 방법으로 일단 구현해놨습니다.)
## 관련 이슈

closes #380 

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [x] `milestone` 설정
