### PR TITLE
[BE] fix: 스탬프가 없는 쿠폰을 가지고 있는 고객이 존재하면 방문이력 에러 발생 없앰 (임시 방편)

### DIFF
--- a/backend/src/main/java/com/stampcrush/backend/application/manager/coupon/ManagerCouponFindService.java
+++ b/backend/src/main/java/com/stampcrush/backend/application/manager/coupon/ManagerCouponFindService.java
@@ -11,7 +11,6 @@ import com.stampcrush.backend.entity.visithistory.VisitHistories;
 import com.stampcrush.backend.entity.visithistory.VisitHistory;
 import com.stampcrush.backend.exception.CafeNotFoundException;
 import com.stampcrush.backend.exception.CustomerNotFoundException;
-import com.stampcrush.backend.exception.VisitHistoryNotFoundException;
 import com.stampcrush.backend.repository.cafe.CafePolicyRepository;
 import com.stampcrush.backend.repository.cafe.CafeRepository;
 import com.stampcrush.backend.repository.coupon.CouponRepository;
@@ -85,9 +84,7 @@ public class ManagerCouponFindService {
 
     private VisitHistories findVisitHistories(Cafe cafe, CustomerCoupons customerCoupon) {
         List<VisitHistory> visitHistories = visitHistoryRepository.findByCafeAndCustomer(cafe, customerCoupon.customer);
-        if (visitHistories.isEmpty()) {
-            throw new VisitHistoryNotFoundException("고객의 방문 이력을 찾을 수 없습니다");
-        }
+
         return new VisitHistories(visitHistories);
     }
 

--- a/backend/src/main/java/com/stampcrush/backend/entity/visithistory/VisitHistories.java
+++ b/backend/src/main/java/com/stampcrush/backend/entity/visithistory/VisitHistories.java
@@ -17,6 +17,9 @@ public class VisitHistories {
     }
 
     public LocalDateTime getFirstVisitDate() {
+        if (visitHistories.isEmpty()) {
+            return LocalDateTime.now();
+        }
         VisitHistory firstVisit = visitHistories.stream()
                 .min(Comparator.comparing(BaseDate::getCreatedAt))
                 .get();


### PR DESCRIPTION
## 주요 변경사항

- 카페에 스탬프가 없는 쿠폰을 가지고 있는 고객이 존재하면 사장이 고객 목록을 조회해올때 에러가 발생합니다
- 임시 고객일때 스탬프가 없는 쿠폰을 가지게 되는 경우가 생깁니다
- 스탬프가 찍힐때 방문 이력 테이블에 이력이 찍히게 되기 때문에 방문 이력 테이블에서 카페와 고객을 기준으로 조회해왔을때 빈 배열이 반환될때 에러가 나게해놨는데 에러 발생하는거 제거해놨습니다 (임시방편)


## 리뷰어에게...

- 현재는 스탬프가 없는 쿠폰을 가지고 있는 고객은 방문횟수가 0번, 첫 방문일이 현재 시간으로 반환되게끔 수정했습니다

## 관련 이슈

closes

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [x] `milestone` 설정
