### PR TITLE
[BE] feat: Coupon 즐겨찾기에 따라 정렬

### DIFF
--- a/backend/src/main/java/com/stampcrush/backend/application/visitor/coupon/VisitorCouponFindService.java
+++ b/backend/src/main/java/com/stampcrush/backend/application/visitor/coupon/VisitorCouponFindService.java
@@ -30,7 +30,7 @@ public class VisitorCouponFindService {
 
     public List<CustomerCouponFindResultDto> findOneCouponForOneCafe(Long customerId) {
         Customer customer = findExistingCustomer(customerId);
-        List<Coupon> coupons = couponRepository.findByCustomerAndStatus(customer, CouponStatus.ACCUMULATING);
+        List<Coupon> coupons = couponRepository.findFilteredAndSortedCoupons(customer, CouponStatus.ACCUMULATING);
 
         return coupons.stream()
                 .map(coupon -> formatToDto(customer, coupon))

--- a/backend/src/main/java/com/stampcrush/backend/repository/coupon/CouponRepository.java
+++ b/backend/src/main/java/com/stampcrush/backend/repository/coupon/CouponRepository.java
@@ -18,7 +18,7 @@ public interface CouponRepository extends JpaRepository<Coupon, Long> {
 
     List<Coupon> findByCafeAndCustomerAndStatus(@Param("cafe") Cafe cafe, @Param("customer") Customer customer, @Param("status") CouponStatus status);
 
-    @Query("SELECT c FROM Coupon c LEFT JOIN Favorites f ON c.cafe.id = f.cafe.id WHERE c.customer = :customer AND c.status = :status ORDER BY f.isFavorites ASC, c.expiredDate ASC")
+    @Query("SELECT c FROM Coupon c LEFT JOIN Favorites f ON c.cafe.id = f.cafe.id WHERE c.customer = :customer AND c.status = :status ORDER BY f.isFavorites DESC, c.expiredDate ASC")
     List<Coupon> findFilteredAndSortedCoupons(@Param("customer") Customer customer, @Param("status") CouponStatus status);
 
     Optional<Coupon> findByIdAndCustomerId(Long id, Long customerId);

--- a/backend/src/main/java/com/stampcrush/backend/repository/coupon/CouponRepository.java
+++ b/backend/src/main/java/com/stampcrush/backend/repository/coupon/CouponRepository.java
@@ -18,7 +18,8 @@ public interface CouponRepository extends JpaRepository<Coupon, Long> {
 
     List<Coupon> findByCafeAndCustomerAndStatus(@Param("cafe") Cafe cafe, @Param("customer") Customer customer, @Param("status") CouponStatus status);
 
-    List<Coupon> findByCustomerAndStatus(@Param("customer") Customer customer, @Param("status") CouponStatus status);
+    @Query("SELECT c FROM Coupon c LEFT JOIN Favorites f ON c.cafe.id = f.cafe.id WHERE c.customer = :customer AND c.status = :status ORDER BY f.isFavorites ASC, c.expiredDate ASC")
+    List<Coupon> findFilteredAndSortedCoupons(@Param("customer") Customer customer, @Param("status") CouponStatus status);
 
     Optional<Coupon> findByIdAndCustomerId(Long id, Long customerId);
 }

--- a/backend/src/test/java/com/stampcrush/backend/application/visitor/coupon/VisitorCouponFindServiceTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/application/visitor/coupon/VisitorCouponFindServiceTest.java
@@ -62,7 +62,7 @@ class VisitorCouponFindServiceTest {
         when(customerRepository.findById(customerId))
                 .thenReturn(Optional.of(customer));
 
-        when(couponRepository.findByCustomerAndStatus(customer, CouponStatus.ACCUMULATING))
+        when(couponRepository.findFilteredAndSortedCoupons(customer, CouponStatus.ACCUMULATING))
                 .thenReturn(new ArrayList<>());
 
         assertThat(visitorCouponFindService.findOneCouponForOneCafe(customerId)).isEmpty();
@@ -77,7 +77,7 @@ class VisitorCouponFindServiceTest {
         when(customerRepository.findById(customerId))
                 .thenReturn(Optional.of(customer));
 
-        when(couponRepository.findByCustomerAndStatus(customer, CouponStatus.ACCUMULATING))
+        when(couponRepository.findFilteredAndSortedCoupons(customer, CouponStatus.ACCUMULATING))
                 .thenReturn(List.of(gitchanCoupon));
 
         when(visitorFavoritesFindService.findIsFavorites(gitchanCoupon.getCafe(), customer))

--- a/backend/src/test/java/com/stampcrush/backend/repository/coupon/CouponRepositoryTest2.java
+++ b/backend/src/test/java/com/stampcrush/backend/repository/coupon/CouponRepositoryTest2.java
@@ -162,7 +162,7 @@ class CouponRepositoryTest2 {
         Coupon jenaCafeCoupon = saveCoupon(jenaCafe, savedCustomer, couponDesignRepository.save(CouponDesignFixture.COUPON_DESIGN_2), couponPolicyRepository.save(CouponPolicyFixture.COUPON_POLICY_2));
 
         // when
-        List<Coupon> findCoupon = couponRepository.findByCustomerAndStatus(savedCustomer, CouponStatus.ACCUMULATING);
+        List<Coupon> findCoupon = couponRepository.findFilteredAndSortedCoupons(savedCustomer, CouponStatus.ACCUMULATING);
 
         // then
         assertThat(findCoupon).containsExactlyInAnyOrder(gitchanCafeCoupon, jenaCafeCoupon);
@@ -183,7 +183,7 @@ class CouponRepositoryTest2 {
         changeCafeCouponStatusToRewarded(gitchanCafeCoupon, gitchanCafeCouponPolicy.getMaxStampCount());
 
         // when
-        List<Coupon> findCoupon = couponRepository.findByCustomerAndStatus(savedCustomer, CouponStatus.ACCUMULATING);
+        List<Coupon> findCoupon = couponRepository.findFilteredAndSortedCoupons(savedCustomer, CouponStatus.ACCUMULATING);
 
         // then
         assertThat(findCoupon).containsOnly(jenaCafeCoupon);


### PR DESCRIPTION
## 주요 변경사항

- 프론트에서 현재 정렬 로직이 없어서 백엔드에서 정렬해서 보내주겠습니다 
- 즐겨찾기 해제된게 앞으로 오도록 정렬해달라고 해서 그렇게 했습니당

## 리뷰어에게...

## 관련 이슈

closes #570 

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [x] `milestone` 설정
