### PR TITLE
[BE] feat: 사장이 고객의 쿠폰 조회 시 쿠폰 발급 당시 이미지 조회

### DIFF
--- a/backend/src/main/java/com/stampcrush/backend/api/manager/cafe/ManagerCafeCouponSettingFindApiController.java
+++ b/backend/src/main/java/com/stampcrush/backend/api/manager/cafe/ManagerCafeCouponSettingFindApiController.java
@@ -8,10 +8,7 @@ import com.stampcrush.backend.config.resolver.OwnerAuth;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
 @RestController
@@ -20,12 +17,13 @@ public class ManagerCafeCouponSettingFindApiController {
 
     private final ManagerCafeCouponSettingFindService managerCafeCouponSettingFindService;
 
-    @GetMapping
-    public ResponseEntity<CafeCouponSettingFindResponse> findCafeCouponSetting(
+    @GetMapping("/{couponId}")
+    public ResponseEntity<CafeCouponSettingFindResponse> findCouponSetting(
             OwnerAuth owner,
-            @RequestParam("cafe-id") Long cafeId
+            @RequestParam("cafe-id") Long cafeId,
+            @PathVariable("couponId") Long couponId
     ) {
-        CafeCouponSettingFindResultDto cafeCouponSetting = managerCafeCouponSettingFindService.findCafeCouponSetting(cafeId);
+        CafeCouponSettingFindResultDto cafeCouponSetting = managerCafeCouponSettingFindService.findCouponSetting(cafeId, couponId);
         CafeCouponSettingFindResponse response = new CafeCouponSettingFindResponse(
                 cafeCouponSetting.getFrontImageUrl(),
                 cafeCouponSetting.getBackImageUrl(),
@@ -37,4 +35,25 @@ public class ManagerCafeCouponSettingFindApiController {
                                 stamp.getYCoordinate())).toList());
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
+
+    @GetMapping
+    public ResponseEntity<CafeCouponSettingFindResponse> findCafeCouponSetting(
+            OwnerAuth owner,
+            @RequestParam("cafe-id") Long cafeId,
+            @PathVariable("couponId") Long couponId
+    ) {
+        CafeCouponSettingFindResultDto cafeCouponSetting = managerCafeCouponSettingFindService.findCouponSetting(cafeId, couponId);
+        CafeCouponSettingFindResponse response = new CafeCouponSettingFindResponse(
+                cafeCouponSetting.getFrontImageUrl(),
+                cafeCouponSetting.getBackImageUrl(),
+                cafeCouponSetting.getStampImageUrl(),
+                cafeCouponSetting.getCoordinates().stream()
+                        .map(stamp -> new CafeCouponCoordinateFindResponse(
+                                stamp.getOrder(),
+                                stamp.getXCoordinate(),
+                                stamp.getYCoordinate())).toList());
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+
 }

--- a/backend/src/main/java/com/stampcrush/backend/api/manager/cafe/ManagerCafeCouponSettingFindApiController.java
+++ b/backend/src/main/java/com/stampcrush/backend/api/manager/cafe/ManagerCafeCouponSettingFindApiController.java
@@ -8,7 +8,12 @@ import com.stampcrush.backend.config.resolver.OwnerAuth;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
 
 @RequiredArgsConstructor
 @RestController

--- a/backend/src/main/java/com/stampcrush/backend/application/manager/cafe/ManagerCafeCouponSettingFindService.java
+++ b/backend/src/main/java/com/stampcrush/backend/application/manager/cafe/ManagerCafeCouponSettingFindService.java
@@ -4,20 +4,27 @@ import com.stampcrush.backend.application.manager.cafe.dto.CafeCouponCoordinateF
 import com.stampcrush.backend.application.manager.cafe.dto.CafeCouponSettingFindResultDto;
 import com.stampcrush.backend.entity.cafe.Cafe;
 import com.stampcrush.backend.entity.cafe.CafeCouponDesign;
+import com.stampcrush.backend.entity.coupon.Coupon;
+import com.stampcrush.backend.entity.coupon.CouponDesign;
 import com.stampcrush.backend.exception.CafeCouponSettingNotFoundException;
 import com.stampcrush.backend.exception.CafeNotFoundException;
+import com.stampcrush.backend.exception.CouponNotFoundException;
 import com.stampcrush.backend.repository.cafe.CafeCouponDesignRepository;
 import com.stampcrush.backend.repository.cafe.CafeRepository;
+import com.stampcrush.backend.repository.coupon.CouponRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
+@Slf4j
 @Service
 public class ManagerCafeCouponSettingFindService {
 
     private final CafeRepository cafeRepository;
+    private final CouponRepository couponRepository;
     private final CafeCouponDesignRepository cafeCouponDesignRepository;
 
     public CafeCouponSettingFindResultDto findCafeCouponSetting(Long cafeId) {
@@ -34,5 +41,14 @@ public class ManagerCafeCouponSettingFindService {
                                 stamp.getStampOrder(),
                                 stamp.getXCoordinate(),
                                 stamp.getYCoordinate())).toList());
+    }
+
+    public CafeCouponSettingFindResultDto findCouponSetting(Long cafeId, Long couponId) {
+        Cafe cafe = cafeRepository.findById(cafeId)
+                .orElseThrow(() -> new CafeNotFoundException("카페를 찾지 못했습니다."));
+        Coupon coupon = couponRepository.findById(couponId)
+                .orElseThrow(() -> new CouponNotFoundException("couponId: " + couponId + " 쿠폰을 찾지 못했습니다."));
+        CouponDesign couponDesign = coupon.getCouponDesign();
+        return CafeCouponSettingFindResultDto.from(couponDesign);
     }
 }

--- a/backend/src/main/java/com/stampcrush/backend/application/manager/cafe/dto/CafeCouponSettingFindResultDto.java
+++ b/backend/src/main/java/com/stampcrush/backend/application/manager/cafe/dto/CafeCouponSettingFindResultDto.java
@@ -1,5 +1,6 @@
 package com.stampcrush.backend.application.manager.cafe.dto;
 
+import com.stampcrush.backend.entity.coupon.CouponDesign;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -13,4 +14,17 @@ public class CafeCouponSettingFindResultDto {
     private final String backImageUrl;
     private final String stampImageUrl;
     private final List<CafeCouponCoordinateFindResultDto> coordinates;
+
+    public static CafeCouponSettingFindResultDto from(CouponDesign couponDesign) {
+        return new CafeCouponSettingFindResultDto(
+                couponDesign.getFrontImageUrl(),
+                couponDesign.getBackImageUrl(),
+                couponDesign.getStampImageUrl(),
+                couponDesign.getCouponStampCoordinates().stream()
+                        .map(stamp -> new CafeCouponCoordinateFindResultDto(
+                                stamp.getStampOrder(),
+                                stamp.getXCoordinate(),
+                                stamp.getYCoordinate())).toList()
+        );
+    }
 }

--- a/backend/src/test/java/com/stampcrush/backend/api/manager/cafe/ManagerCafeCouponSettingFindApiControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/manager/cafe/ManagerCafeCouponSettingFindApiControllerTest.java
@@ -14,6 +14,7 @@ import org.springframework.context.annotation.FilterType;
 import java.util.List;
 
 import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -43,11 +44,11 @@ public class ManagerCafeCouponSettingFindApiControllerTest extends ControllerSli
                 )
         );
 
-        given(cafeCouponSettingFindService.findCafeCouponSetting(1L))
+        given(cafeCouponSettingFindService.findCouponSetting(anyLong(), anyLong()))
                 .willReturn(resultDto);
 
         // when, then
-        mockMvc.perform(get("/api/admin/coupon-setting")
+        mockMvc.perform(get("/api/admin/coupon-setting/{couponId}", 1L)
                         .param("cafe-id", "1"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("frontImageUrl").value(resultDto.getFrontImageUrl()))

--- a/backend/src/test/java/com/stampcrush/backend/application/manager/cafe/ManagerCafeCouponSettingFindServiceTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/application/manager/cafe/ManagerCafeCouponSettingFindServiceTest.java
@@ -1,10 +1,10 @@
 package com.stampcrush.backend.application.manager.cafe;
 
 import com.stampcrush.backend.application.ServiceSliceTest;
-import com.stampcrush.backend.exception.CafeCouponSettingNotFoundException;
 import com.stampcrush.backend.exception.CafeNotFoundException;
-import com.stampcrush.backend.repository.cafe.CafeCouponDesignRepository;
+import com.stampcrush.backend.exception.CouponNotFoundException;
 import com.stampcrush.backend.repository.cafe.CafeRepository;
+import com.stampcrush.backend.repository.coupon.CouponRepository;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -26,7 +26,7 @@ public class ManagerCafeCouponSettingFindServiceTest {
     private CafeRepository cafeRepository;
 
     @Mock
-    private CafeCouponDesignRepository cafeCouponDesignRepository;
+    private CouponRepository couponRepository;
 
     @Test
     void 쿠폰_세팅을_조회할_때_카페_정보가_존재하지_않으면_예외가_발생한다() {
@@ -37,7 +37,7 @@ public class ManagerCafeCouponSettingFindServiceTest {
                 .thenReturn(Optional.empty());
 
         // when, then
-        assertThatThrownBy(() -> managerCafeCouponSettingFindService.findCafeCouponSetting(cafeId))
+        assertThatThrownBy(() -> managerCafeCouponSettingFindService.findCouponSetting(cafeId, 1L))
                 .isInstanceOf(CafeNotFoundException.class);
     }
 
@@ -48,10 +48,10 @@ public class ManagerCafeCouponSettingFindServiceTest {
 
         when(cafeRepository.findById(cafeId))
                 .thenReturn(Optional.of(GITCHAN_CAFE));
-        when(cafeCouponDesignRepository.findByCafe(any()))
+        when(couponRepository.findById(any()))
                 .thenReturn(Optional.empty());
         // when, then
-        assertThatThrownBy(() -> managerCafeCouponSettingFindService.findCafeCouponSetting(cafeId))
-                .isInstanceOf(CafeCouponSettingNotFoundException.class);
+        assertThatThrownBy(() -> managerCafeCouponSettingFindService.findCouponSetting(cafeId, 1L))
+                .isInstanceOf(CouponNotFoundException.class);
     }
 }


### PR DESCRIPTION
## 주요 변경사항

- 기존 CafeCoupon조회였는데, Coupon조회 후 Coupon의 CouponDesign에서 이미지 조회하도록 수정했습니다.

## 리뷰어에게...

## 관련 이슈

closes #567 

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [x] `milestone` 설정
