### PR TITLE
[FE] 커스텀 스탬프 창의 사이즈가 변할 때 쿠폰 위에 따라다니지 않는 문제를 해결한다.

### DIFF
--- a/frontend/src/components/Modal/style.tsx
+++ b/frontend/src/components/Modal/style.tsx
@@ -18,7 +18,7 @@ export const BaseModal = styled.div`
 
   top: 50%;
   left: 50%;
-  width: 60vw;
+  width: fit-content;
   height: auto;
 
   padding: 35px;
@@ -29,10 +29,6 @@ export const BaseModal = styled.div`
   background-color: ${({ theme }) => theme.colors.white};
 
   transform: translate(-50%, -50%);
-
-  @media screen and (min-width: 768px) and (max-width: 1024px) {
-    width: 70vw;
-  }
 `;
 
 export const CloseButton = styled.button`

--- a/frontend/src/pages/CouponList/FlippedCoupon/style.tsx
+++ b/frontend/src/pages/CouponList/FlippedCoupon/style.tsx
@@ -46,11 +46,11 @@ export const BackImage = styled(CouponImage)`
 `;
 
 export const StampImage = styled.img<{ $x: number; $y: number }>`
-  width: 40px;
-  height: 40px;
+  width: 25px;
+  height: 25px;
   position: absolute;
-  top: ${({ $y }) => `${$y - 20}px`};
-  right: ${({ $x }) => `${$x - 20}px`};
+  top: ${({ $y }) => `${$y - 12.5}px`};
+  right: ${({ $x }) => `${$x - 12.5}px`};
   object-fit: cover;
   backface-visibility: hidden;
   transform-style: preserve-3d;


### PR DESCRIPTION
## 주요 변경사항

- 해당 문제는 `top`, `left`가 고정된 스탬프와 너비가 `vw`단위인 모달 `width`의 상대, 절대적 좌표 문제임을 인식하였습니다.
- 해당 문제를 해결하기 위해 `width`를 `fit-content`로 변경하여 해당 문제를 해결하였습니다.
- 또한 위 문제와 같이 제기되었던 FlippedCoupon에서의 스탬프 이미지 사이즈를 비율에 맞게 조정하여 사용자가 기대하는 쿠폰의 모습을 띄도록 하였습니다.

## 리뷰어에게...
1. 윈도우 리사이즈 이후에도 스탬프의 위치가 변경되지 않는 모습

<img width="566" alt="스크린샷 2023-08-24 오후 3 44 54" src="https://github.com/woowacourse-teams/2023-stamp-crush/assets/90092440/ca48ff2c-8720-4340-b446-79f9b0edc34a">

<br/>
<br/>

2. 비율에 맞게 스탬프의 사이즈를 조정함으로써 사용자가 기대하는 쿠폰의 모습을 보여줌

<img width="569" alt="스크린샷 2023-08-24 오후 3 44 24" src="https://github.com/woowacourse-teams/2023-stamp-crush/assets/90092440/245bafd9-ec9c-4dd8-a1c0-b992242147ba">

## 관련 이슈

closes #566 

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [x] `milestone` 설정
