### PR TITLE
feat: 4차 데모데이때 추가된 API 에 대한 문서화 테스트를 작성한다

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -82,7 +82,6 @@ tasks.withType(GenerateSwaggerUI) {
     copy {
         from "build/resources/main/static/docs"
         into "src/main/resources/static/docs/"
-
     }
 }
 

--- a/backend/src/main/java/com/stampcrush/backend/api/manager/cafe/ManagerCafeCouponSettingFindApiController.java
+++ b/backend/src/main/java/com/stampcrush/backend/api/manager/cafe/ManagerCafeCouponSettingFindApiController.java
@@ -58,6 +58,4 @@ public class ManagerCafeCouponSettingFindApiController {
                                 stamp.getYCoordinate())).toList());
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
-
-
 }

--- a/backend/src/main/java/com/stampcrush/backend/api/visitor/profile/VisitorProfilesCommandApiController.java
+++ b/backend/src/main/java/com/stampcrush/backend/api/visitor/profile/VisitorProfilesCommandApiController.java
@@ -23,7 +23,6 @@ public class VisitorProfilesCommandApiController {
             CustomerAuth customer,
             @Valid @RequestBody VisitorProfilesPhoneNumberUpdateRequest request
     ) {
-        System.out.println("request.getPhoneNumber() = " + request.getPhoneNumber());
         visitorProfilesCommandService.registerPhoneNumber(customer.getId(), request.getPhoneNumber());
         return ResponseEntity.ok().build();
     }

--- a/backend/src/main/java/com/stampcrush/backend/config/RequestLoggingFilter.java
+++ b/backend/src/main/java/com/stampcrush/backend/config/RequestLoggingFilter.java
@@ -15,7 +15,7 @@ import java.io.IOException;
 public class RequestLoggingFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
-        log.info(request.getRequestURI());
+        log.info("method: " + request.getMethod() + ", url: " + request.getRequestURI());
         if (request.getHeader("authorization") != null) {
             log.info("auth info: " + request.getHeader("authorization"));
         }

--- a/backend/src/test/java/com/stampcrush/backend/api/docs/DocsControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/docs/DocsControllerTest.java
@@ -3,6 +3,7 @@ package com.stampcrush.backend.api.docs;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.stampcrush.backend.api.manager.cafe.ManagerCafeCommandApiController;
 import com.stampcrush.backend.api.manager.cafe.ManagerCafeCouponSettingCommandApiController;
+import com.stampcrush.backend.api.manager.cafe.ManagerCafeCouponSettingFindApiController;
 import com.stampcrush.backend.api.manager.cafe.ManagerCafeFindApiController;
 import com.stampcrush.backend.api.manager.coupon.ManagerCouponCommandApiController;
 import com.stampcrush.backend.api.manager.coupon.ManagerCouponFindApiController;
@@ -21,6 +22,7 @@ import com.stampcrush.backend.api.visitor.reward.VisitorRewardsFindController;
 import com.stampcrush.backend.api.visitor.visithistory.VisitorVisitHistoryFindApiController;
 import com.stampcrush.backend.application.manager.cafe.ManagerCafeCommandService;
 import com.stampcrush.backend.application.manager.cafe.ManagerCafeCouponSettingCommandService;
+import com.stampcrush.backend.application.manager.cafe.ManagerCafeCouponSettingFindService;
 import com.stampcrush.backend.application.manager.cafe.ManagerCafeFindService;
 import com.stampcrush.backend.application.manager.coupon.ManagerCouponCommandService;
 import com.stampcrush.backend.application.manager.coupon.ManagerCouponFindService;
@@ -85,7 +87,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
         VisitorRewardsFindController.class,
         VisitorVisitHistoryFindApiController.class,
         VisitorProfilesCommandApiController.class,
-        VisitorProfilesFindApiController.class
+        VisitorProfilesFindApiController.class,
+        ManagerCafeCouponSettingFindApiController.class
 })
 @ExtendWith({RestDocumentationExtension.class})
 public abstract class DocsControllerTest {
@@ -164,6 +167,9 @@ public abstract class DocsControllerTest {
 
     @MockBean
     protected VisitorProfilesFindService visitorProfilesFindService;
+
+    @MockBean
+    protected ManagerCafeCouponSettingFindService managerCafeCouponSettingFindService;
 
     @MockBean
     public AuthTokensGenerator authTokensGenerator;

--- a/backend/src/test/java/com/stampcrush/backend/api/docs/DocsControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/docs/DocsControllerTest.java
@@ -15,6 +15,7 @@ import com.stampcrush.backend.api.visitor.cafe.VisitorCafeFindApiController;
 import com.stampcrush.backend.api.visitor.coupon.VisitorCouponCommandApiController;
 import com.stampcrush.backend.api.visitor.coupon.VisitorCouponFindApiController;
 import com.stampcrush.backend.api.visitor.favorites.VisitorFavoritesCommandApiController;
+import com.stampcrush.backend.api.visitor.profile.VisitorProfilesCommandApiController;
 import com.stampcrush.backend.api.visitor.reward.VisitorRewardsFindController;
 import com.stampcrush.backend.api.visitor.visithistory.VisitorVisitHistoryFindApiController;
 import com.stampcrush.backend.application.manager.cafe.ManagerCafeCommandService;
@@ -31,6 +32,7 @@ import com.stampcrush.backend.application.visitor.cafe.VisitorCafeFindService;
 import com.stampcrush.backend.application.visitor.coupon.VisitorCouponCommandService;
 import com.stampcrush.backend.application.visitor.coupon.VisitorCouponFindService;
 import com.stampcrush.backend.application.visitor.favorites.VisitorFavoritesCommandService;
+import com.stampcrush.backend.application.visitor.profile.VisitorProfilesCommandService;
 import com.stampcrush.backend.application.visitor.reward.VisitorRewardsFindService;
 import com.stampcrush.backend.application.visitor.visithistory.VisitorVisitHistoryFindService;
 import com.stampcrush.backend.auth.application.util.AuthTokensGenerator;
@@ -79,7 +81,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
         ManagerRewardFindApiController.class,
         VisitorCouponCommandApiController.class,
         VisitorRewardsFindController.class,
-        VisitorVisitHistoryFindApiController.class
+        VisitorVisitHistoryFindApiController.class,
+        VisitorProfilesCommandApiController.class
 })
 @ExtendWith({RestDocumentationExtension.class})
 public abstract class DocsControllerTest {
@@ -152,6 +155,9 @@ public abstract class DocsControllerTest {
 
     @MockBean
     protected VisitorVisitHistoryFindService visitorVisitHistoryFindService;
+
+    @MockBean
+    protected VisitorProfilesCommandService visitorProfilesCommandService;
 
     @MockBean
     public AuthTokensGenerator authTokensGenerator;

--- a/backend/src/test/java/com/stampcrush/backend/api/docs/DocsControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/docs/DocsControllerTest.java
@@ -9,6 +9,7 @@ import com.stampcrush.backend.api.manager.coupon.ManagerCouponCommandApiControll
 import com.stampcrush.backend.api.manager.coupon.ManagerCouponFindApiController;
 import com.stampcrush.backend.api.manager.customer.ManagerCustomerCommandApiController;
 import com.stampcrush.backend.api.manager.customer.ManagerCustomerFindApiController;
+import com.stampcrush.backend.api.manager.image.ManagerImageCommandApiController;
 import com.stampcrush.backend.api.manager.reward.ManagerRewardCommandApiController;
 import com.stampcrush.backend.api.manager.reward.ManagerRewardFindApiController;
 import com.stampcrush.backend.api.manager.sample.ManagerSampleCouponFindApiController;
@@ -28,6 +29,7 @@ import com.stampcrush.backend.application.manager.coupon.ManagerCouponCommandSer
 import com.stampcrush.backend.application.manager.coupon.ManagerCouponFindService;
 import com.stampcrush.backend.application.manager.customer.ManagerCustomerCommandService;
 import com.stampcrush.backend.application.manager.customer.ManagerCustomerFindService;
+import com.stampcrush.backend.application.manager.image.ManagerImageCommandService;
 import com.stampcrush.backend.application.manager.reward.ManagerRewardCommandService;
 import com.stampcrush.backend.application.manager.reward.ManagerRewardFindService;
 import com.stampcrush.backend.application.manager.sample.ManagerSampleCouponFindService;
@@ -88,7 +90,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
         VisitorVisitHistoryFindApiController.class,
         VisitorProfilesCommandApiController.class,
         VisitorProfilesFindApiController.class,
-        ManagerCafeCouponSettingFindApiController.class
+        ManagerCafeCouponSettingFindApiController.class,
+        ManagerImageCommandApiController.class
 })
 @ExtendWith({RestDocumentationExtension.class})
 public abstract class DocsControllerTest {
@@ -170,6 +173,9 @@ public abstract class DocsControllerTest {
 
     @MockBean
     protected ManagerCafeCouponSettingFindService managerCafeCouponSettingFindService;
+
+    @MockBean
+    protected ManagerImageCommandService managerImageCommandService;
 
     @MockBean
     public AuthTokensGenerator authTokensGenerator;

--- a/backend/src/test/java/com/stampcrush/backend/api/docs/DocsControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/docs/DocsControllerTest.java
@@ -16,6 +16,7 @@ import com.stampcrush.backend.api.visitor.coupon.VisitorCouponCommandApiControll
 import com.stampcrush.backend.api.visitor.coupon.VisitorCouponFindApiController;
 import com.stampcrush.backend.api.visitor.favorites.VisitorFavoritesCommandApiController;
 import com.stampcrush.backend.api.visitor.profile.VisitorProfilesCommandApiController;
+import com.stampcrush.backend.api.visitor.profile.VisitorProfilesFindApiController;
 import com.stampcrush.backend.api.visitor.reward.VisitorRewardsFindController;
 import com.stampcrush.backend.api.visitor.visithistory.VisitorVisitHistoryFindApiController;
 import com.stampcrush.backend.application.manager.cafe.ManagerCafeCommandService;
@@ -33,6 +34,7 @@ import com.stampcrush.backend.application.visitor.coupon.VisitorCouponCommandSer
 import com.stampcrush.backend.application.visitor.coupon.VisitorCouponFindService;
 import com.stampcrush.backend.application.visitor.favorites.VisitorFavoritesCommandService;
 import com.stampcrush.backend.application.visitor.profile.VisitorProfilesCommandService;
+import com.stampcrush.backend.application.visitor.profile.VisitorProfilesFindService;
 import com.stampcrush.backend.application.visitor.reward.VisitorRewardsFindService;
 import com.stampcrush.backend.application.visitor.visithistory.VisitorVisitHistoryFindService;
 import com.stampcrush.backend.auth.application.util.AuthTokensGenerator;
@@ -82,7 +84,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
         VisitorCouponCommandApiController.class,
         VisitorRewardsFindController.class,
         VisitorVisitHistoryFindApiController.class,
-        VisitorProfilesCommandApiController.class
+        VisitorProfilesCommandApiController.class,
+        VisitorProfilesFindApiController.class
 })
 @ExtendWith({RestDocumentationExtension.class})
 public abstract class DocsControllerTest {
@@ -158,6 +161,9 @@ public abstract class DocsControllerTest {
 
     @MockBean
     protected VisitorProfilesCommandService visitorProfilesCommandService;
+
+    @MockBean
+    protected VisitorProfilesFindService visitorProfilesFindService;
 
     @MockBean
     public AuthTokensGenerator authTokensGenerator;

--- a/backend/src/test/java/com/stampcrush/backend/api/docs/DocsControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/docs/DocsControllerTest.java
@@ -41,6 +41,9 @@ import com.stampcrush.backend.application.visitor.profile.VisitorProfilesCommand
 import com.stampcrush.backend.application.visitor.profile.VisitorProfilesFindService;
 import com.stampcrush.backend.application.visitor.reward.VisitorRewardsFindService;
 import com.stampcrush.backend.application.visitor.visithistory.VisitorVisitHistoryFindService;
+import com.stampcrush.backend.auth.api.ManagerOAuthController;
+import com.stampcrush.backend.auth.application.manager.ManagerOAuthLoginService;
+import com.stampcrush.backend.auth.application.manager.ManagerOAuthService;
 import com.stampcrush.backend.auth.application.util.AuthTokensGenerator;
 import com.stampcrush.backend.common.KorNamingConverter;
 import com.stampcrush.backend.entity.user.Owner;
@@ -91,7 +94,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
         VisitorProfilesCommandApiController.class,
         VisitorProfilesFindApiController.class,
         ManagerCafeCouponSettingFindApiController.class,
-        ManagerImageCommandApiController.class
+        ManagerImageCommandApiController.class,
+        ManagerOAuthController.class
 })
 @ExtendWith({RestDocumentationExtension.class})
 public abstract class DocsControllerTest {
@@ -176,6 +180,12 @@ public abstract class DocsControllerTest {
 
     @MockBean
     protected ManagerImageCommandService managerImageCommandService;
+
+    @MockBean
+    protected ManagerOAuthService managerOAuthService;
+
+    @MockBean
+    protected ManagerOAuthLoginService managerOAuthLoginService;
 
     @MockBean
     public AuthTokensGenerator authTokensGenerator;

--- a/backend/src/test/java/com/stampcrush/backend/api/docs/auth/ManagerOAuthApiDocsControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/docs/auth/ManagerOAuthApiDocsControllerTest.java
@@ -1,0 +1,43 @@
+package com.stampcrush.backend.api.docs.auth;
+
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.epages.restdocs.apispec.Schema;
+import com.stampcrush.backend.api.docs.DocsControllerTest;
+import com.stampcrush.backend.auth.api.response.AuthTokensResponse;
+import com.stampcrush.backend.auth.application.util.KakaoLoginParams;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
+import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+public class ManagerOAuthApiDocsControllerTest extends DocsControllerTest {
+
+    // TODO: 현재 ManagerOAuthApiController 가 테스트 프로파일에서 로딩되지 않게 설정해둬서 Disable. TestConfig 분리 후 enable 필요.
+    @Test
+    @Disabled
+    void 로그인_요청() throws Exception {
+        // given
+        when(managerOAuthService.findLoginRedirectUri()).thenReturn("redirectUrl");
+
+        // when, then
+        mockMvc.perform(RestDocumentationRequestBuilders.get("/api/admin/login/kakao"))
+                .andDo(document("auth/manage/login",
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint()),
+                                resource(
+                                        ResourceSnippetParameters.builder()
+                                                .tag("사장 모드")
+                                                .description("로그인 요청")
+                                                .build()
+                                )
+                        )
+                )
+                .andExpect(status().isFound());
+    }
+}

--- a/backend/src/test/java/com/stampcrush/backend/api/docs/manager/cafe/ManagerCafeCouponSettingFindApiDocsControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/docs/manager/cafe/ManagerCafeCouponSettingFindApiDocsControllerTest.java
@@ -1,0 +1,115 @@
+package com.stampcrush.backend.api.docs.manager.cafe;
+
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.epages.restdocs.apispec.Schema;
+import com.stampcrush.backend.api.docs.DocsControllerTest;
+import com.stampcrush.backend.application.manager.cafe.dto.CafeCouponCoordinateFindResultDto;
+import com.stampcrush.backend.application.manager.cafe.dto.CafeCouponSettingFindResultDto;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
+import static com.epages.restdocs.apispec.ResourceDocumentation.parameterWithName;
+import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+public class ManagerCafeCouponSettingFindApiDocsControllerTest extends DocsControllerTest {
+
+    @Test
+    void 현재_카페의_쿠폰_디자인_정책_조회() throws Exception {
+        // given
+        Long CAFE_ID = 1L;
+        when(ownerRepository.findByLoginId(OWNER.getLoginId())).thenReturn(Optional.of(OWNER));
+        when(managerCafeCouponSettingFindService.findCafeCouponSetting(CAFE_ID)).thenReturn(
+                new CafeCouponSettingFindResultDto("frontImageUrl", "backImageUrl",
+                        "stampImageUrl", List.of(
+                        new CafeCouponCoordinateFindResultDto(1, 1, 1),
+                        new CafeCouponCoordinateFindResultDto(2, 2, 2),
+                        new CafeCouponCoordinateFindResultDto(3, 3, 3),
+                        new CafeCouponCoordinateFindResultDto(4, 4, 4),
+                        new CafeCouponCoordinateFindResultDto(5, 5, 5))
+                ));
+
+        // when, then
+        mockMvc.perform(RestDocumentationRequestBuilders.get("/api/admin/coupon-setting?cafe-id=" + CAFE_ID)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header(HttpHeaders.AUTHORIZATION, OWNER_BASIC_HEADER))
+                .andDo(document("manager/cafe/find-current-cafe-coupon-design",
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint()),
+                                resource(
+                                        ResourceSnippetParameters.builder()
+                                                .tag("사장 모드")
+                                                .description("카페의 현재 쿠폰 디자인 조회")
+                                                .requestHeaders(headerWithName("Authorization").description("임시(Basic)"))
+                                                .queryParameters(parameterWithName("cafe-id").description("카페 Id"))
+                                                .responseFields(
+                                                        fieldWithPath("frontImageUrl").description("프론트 이미지 URL"),
+                                                        fieldWithPath("backImageUrl").description("백 이미지 URL"),
+                                                        fieldWithPath("stampImageUrl").description("스탬프 이미지 URL"),
+                                                        fieldWithPath("coordinates[].order").description("스탬프 좌표 순서"),
+                                                        fieldWithPath("coordinates[].xCoordinate").description("스탬프 x 좌표"),
+                                                        fieldWithPath("coordinates[].yCoordinate").description("스탬프 y 좌표")
+                                                )
+                                                .responseSchema(Schema.schema("CafeCouponSettingFindResponse"))
+                                                .build()
+                                )
+                        )
+                )
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void 쿠폰이_발급된_당시의_쿠폰_디자인_정책_조회() throws Exception {
+        // given
+        Long CAFE_ID = 1L;
+        Long COUPON_ID = 1L;
+        when(ownerRepository.findByLoginId(OWNER.getLoginId())).thenReturn(Optional.of(OWNER));
+        when(managerCafeCouponSettingFindService.findCouponSetting(CAFE_ID, COUPON_ID)).thenReturn(
+                new CafeCouponSettingFindResultDto("frontImageUrl", "backImageUrl",
+                        "stampImageUrl", List.of(
+                        new CafeCouponCoordinateFindResultDto(1, 1, 1),
+                        new CafeCouponCoordinateFindResultDto(2, 2, 2),
+                        new CafeCouponCoordinateFindResultDto(3, 3, 3),
+                        new CafeCouponCoordinateFindResultDto(4, 4, 4),
+                        new CafeCouponCoordinateFindResultDto(5, 5, 5))
+                ));
+
+        // when, then
+        mockMvc.perform(RestDocumentationRequestBuilders.get("/api/admin/coupon-setting/{couponId}?cafe-id=" + CAFE_ID, COUPON_ID)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header(HttpHeaders.AUTHORIZATION, OWNER_BASIC_HEADER))
+                .andDo(document("manager/cafe/find-coupon-design-when-coupon-issued",
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint()),
+                                resource(
+                                        ResourceSnippetParameters.builder()
+                                                .tag("사장 모드")
+                                                .description("쿠폰이 발급될때의 쿠폰 디자인 조회")
+                                                .requestHeaders(headerWithName("Authorization").description("임시(Basic)"))
+                                                .queryParameters(parameterWithName("cafe-id").description("카페 Id"))
+                                                .responseFields(
+                                                        fieldWithPath("frontImageUrl").description("프론트 이미지 URL"),
+                                                        fieldWithPath("backImageUrl").description("백 이미지 URL"),
+                                                        fieldWithPath("stampImageUrl").description("스탬프 이미지 URL"),
+                                                        fieldWithPath("coordinates[].order").description("스탬프 좌표 순서"),
+                                                        fieldWithPath("coordinates[].xCoordinate").description("스탬프 x 좌표"),
+                                                        fieldWithPath("coordinates[].yCoordinate").description("스탬프 y 좌표")
+                                                )
+                                                .responseSchema(Schema.schema("CafeCouponSettingFindResponse"))
+                                                .build()
+                                )
+                        )
+                )
+                .andExpect(status().isOk());
+    }
+}

--- a/backend/src/test/java/com/stampcrush/backend/api/docs/manager/image/ManagerImageCommandApiDocsControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/docs/manager/image/ManagerImageCommandApiDocsControllerTest.java
@@ -1,0 +1,49 @@
+package com.stampcrush.backend.api.docs.manager.image;
+
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.epages.restdocs.apispec.Schema;
+import com.stampcrush.backend.api.docs.DocsControllerTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
+import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+public class ManagerImageCommandApiDocsControllerTest extends DocsControllerTest {
+
+    @Test
+    void 이미지_업로드() throws Exception {
+        // given
+        MockMultipartFile multipartFile = new MockMultipartFile(
+                "image", "image.jpg", MediaType.IMAGE_JPEG.toString(), "image data".getBytes()
+        );
+        when(managerImageCommandService.uploadImageAndReturnUrl(multipartFile)).thenReturn("imageUrl");
+
+        // when, then
+        mockMvc.perform(RestDocumentationRequestBuilders.multipart("/api/admin/images")
+                        .file(multipartFile)
+                )
+                .andDo(document("manager/image/upload",
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint()),
+                                resource(
+                                        ResourceSnippetParameters.builder()
+                                                .tag("사장 모드")
+                                                .description("이미지 업로드")
+                                                .responseFields(
+                                                        fieldWithPath("imageUrl").description("업로드한 이미지의 Url")
+                                                )
+                                                .responseSchema(Schema.schema("ImageUrlResponse"))
+                                                .build()
+                                )
+                        )
+                )
+                .andExpect(status().isOk());
+    }
+}

--- a/backend/src/test/java/com/stampcrush/backend/api/docs/visitor/profile/VisitorProfilesCommandApiDocsControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/docs/visitor/profile/VisitorProfilesCommandApiDocsControllerTest.java
@@ -1,0 +1,52 @@
+package com.stampcrush.backend.api.docs.visitor.profile;
+
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.epages.restdocs.apispec.Schema;
+import com.stampcrush.backend.api.docs.DocsControllerTest;
+import com.stampcrush.backend.api.visitor.profile.request.VisitorProfilesPhoneNumberUpdateRequest;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+
+import java.util.Optional;
+
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
+import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+public class VisitorProfilesCommandApiDocsControllerTest extends DocsControllerTest {
+
+    @Test
+    void 고객이_전화번호_등록() throws Exception {
+        // given
+        when(customerRepository.findByLoginId(CUSTOMER.getLoginId())).thenReturn(Optional.of(CUSTOMER));
+        VisitorProfilesPhoneNumberUpdateRequest request = new VisitorProfilesPhoneNumberUpdateRequest("01012345678");
+
+        // when, then
+        mockMvc.perform(
+                        RestDocumentationRequestBuilders.post("/api/profiles/phone-number")
+                                .content(objectMapper.writeValueAsString(request))
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .header(HttpHeaders.AUTHORIZATION, CUSTOMER_BASIC_HEADER))
+                .andDo(document("visitor/profiles/post-phonenumber",
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint()),
+                                resource(
+                                        ResourceSnippetParameters.builder()
+                                                .tag("고객 모드")
+                                                .description("고객이 전화번호 등록")
+                                                .requestHeaders(headerWithName("Authorization").description("임시(Basic)"))
+                                                .requestFields(fieldWithPath("phoneNumber").description("고객이 등록할 전화번호"))
+                                                .requestSchema(Schema.schema("VisitorProfilesPhoneNumberUpdateRequest"))
+                                                .build()
+                                )
+                        )
+                )
+                .andExpect(status().isOk());
+    }
+}

--- a/backend/src/test/java/com/stampcrush/backend/api/docs/visitor/profile/VisitorProfilesFindApiDocsControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/docs/visitor/profile/VisitorProfilesFindApiDocsControllerTest.java
@@ -1,0 +1,60 @@
+package com.stampcrush.backend.api.docs.visitor.profile;
+
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.epages.restdocs.apispec.Schema;
+import com.stampcrush.backend.api.docs.DocsControllerTest;
+import com.stampcrush.backend.application.visitor.profile.dto.VisitorProfileFindResultDto;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+
+import java.util.Optional;
+
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
+import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+public class VisitorProfilesFindApiDocsControllerTest extends DocsControllerTest {
+
+    @Test
+    void 고객의_프로필_조회() throws Exception {
+        // given
+        when(customerRepository.findByLoginId(CUSTOMER.getLoginId())).thenReturn(Optional.of(CUSTOMER));
+        when(visitorProfilesFindService.findVisitorProfile(CUSTOMER.getId()))
+                .thenReturn(
+                        new VisitorProfileFindResultDto(CUSTOMER.getId(), "jena", "01012345678",
+                                "yenawee@gmail.com")
+                );
+
+        // when, then
+        mockMvc.perform(
+                        RestDocumentationRequestBuilders.get("/api/profiles")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .header(HttpHeaders.AUTHORIZATION, CUSTOMER_BASIC_HEADER))
+                .andDo(document("visitor/profiles/find-profiles",
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint()),
+                                resource(
+                                        ResourceSnippetParameters.builder()
+                                                .tag("고객 모드")
+                                                .description("고객 프로필 조회")
+                                                .requestHeaders(headerWithName("Authorization").description("임시(Basic)"))
+                                                .responseFields(
+                                                        fieldWithPath("profile.id").description("고객 ID"),
+                                                        fieldWithPath("profile.nickname").description("고객 닉네임"),
+                                                        fieldWithPath("profile.phoneNumber").description("고객 전화번호"),
+                                                        fieldWithPath("profile.email").description("고객 이메일")
+                                                )
+                                                .requestSchema(Schema.schema("VisitorProfilesFindResponse"))
+                                                .build()
+                                )
+                        )
+                )
+                .andExpect(status().isOk());
+    }
+}


### PR DESCRIPTION
## 주요 변경사항

- 고객 모드 프로필 조회
- 고객 모드 핸드폰 번호 등록
- 현재 카페의 카페 쿠폰 디자인 세팅 정보 불러오는 API
- 사장이 고객의 쿠폰 조회시 쿠폰 발급 당시 이미지 조회
- 이미지 업로드
- 회원가입 (이건 AuthController Test profile 분리해야 해서 disable)

## 리뷰어에게...

## 관련 이슈

closes #526 

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [x] `milestone` 설정
