### PR TITLE
[BE] feat: 고객모드의 전화번호로 고객 조회 API

### DIFF
--- a/backend/src/main/java/com/stampcrush/backend/api/visitor/profile/VisitorProfilesFindApiController.java
+++ b/backend/src/main/java/com/stampcrush/backend/api/visitor/profile/VisitorProfilesFindApiController.java
@@ -1,13 +1,16 @@
 package com.stampcrush.backend.api.visitor.profile;
 
+import com.stampcrush.backend.api.visitor.profile.response.VisitorProfilesFindByPhoneNumberResponse;
 import com.stampcrush.backend.api.visitor.profile.response.VisitorProfilesFindResponse;
 import com.stampcrush.backend.application.visitor.profile.VisitorProfilesFindService;
+import com.stampcrush.backend.application.visitor.profile.dto.VisitorProfileFindByPhoneNumberResultDto;
 import com.stampcrush.backend.application.visitor.profile.dto.VisitorProfileFindResultDto;
 import com.stampcrush.backend.config.resolver.CustomerAuth;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
@@ -22,5 +25,15 @@ public class VisitorProfilesFindApiController {
         VisitorProfileFindResultDto dto = visitorProfilesFindService.findVisitorProfile(customer.getId());
 
         return ResponseEntity.ok().body(VisitorProfilesFindResponse.from(dto));
+    }
+
+    @GetMapping("/search")
+    public ResponseEntity<VisitorProfilesFindByPhoneNumberResponse> findProfilesByPhoneNumber(
+            CustomerAuth customer,
+            @RequestParam("phone-number") String phoneNumber
+    ) {
+        VisitorProfileFindByPhoneNumberResultDto dto = visitorProfilesFindService.findCustomerProfileByNumber(phoneNumber);
+
+        return ResponseEntity.ok().body(VisitorProfilesFindByPhoneNumberResponse.from(dto));
     }
 }

--- a/backend/src/main/java/com/stampcrush/backend/api/visitor/profile/response/VisitorProfilesFindByPhoneNumberResponse.java
+++ b/backend/src/main/java/com/stampcrush/backend/api/visitor/profile/response/VisitorProfilesFindByPhoneNumberResponse.java
@@ -1,6 +1,6 @@
 package com.stampcrush.backend.api.visitor.profile.response;
 
-import com.stampcrush.backend.application.visitor.profile.dto.VisitorProfileFindByPhoneNumberResulteDto;
+import com.stampcrush.backend.application.visitor.profile.dto.VisitorProfileFindByPhoneNumberResultDto;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -12,7 +12,7 @@ public class VisitorProfilesFindByPhoneNumberResponse {
 
     private final List<VisitorProfileFindByPhoneNumberResponse> customers;
 
-    public static VisitorProfilesFindByPhoneNumberResponse from(VisitorProfileFindByPhoneNumberResulteDto dto) {
+    public static VisitorProfilesFindByPhoneNumberResponse from(VisitorProfileFindByPhoneNumberResultDto dto) {
         if (dto == null) {
             return new VisitorProfilesFindByPhoneNumberResponse(List.of());
         }
@@ -30,7 +30,7 @@ public class VisitorProfilesFindByPhoneNumberResponse {
         private final String phoneNumber;
         private final String registerType;
 
-        public static VisitorProfileFindByPhoneNumberResponse from(VisitorProfileFindByPhoneNumberResulteDto dto) {
+        public static VisitorProfileFindByPhoneNumberResponse from(VisitorProfileFindByPhoneNumberResultDto dto) {
             return new VisitorProfileFindByPhoneNumberResponse(
                     dto.getId(),
                     dto.getNickname(),

--- a/backend/src/main/java/com/stampcrush/backend/api/visitor/profile/response/VisitorProfilesFindByPhoneNumberResponse.java
+++ b/backend/src/main/java/com/stampcrush/backend/api/visitor/profile/response/VisitorProfilesFindByPhoneNumberResponse.java
@@ -1,0 +1,42 @@
+package com.stampcrush.backend.api.visitor.profile.response;
+
+import com.stampcrush.backend.application.visitor.profile.dto.VisitorProfileFindByPhoneNumberResulteDto;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@RequiredArgsConstructor
+public class VisitorProfilesFindByPhoneNumberResponse {
+
+    private final List<VisitorProfileFindByPhoneNumberResponse> customers;
+
+    public static VisitorProfilesFindByPhoneNumberResponse from(VisitorProfileFindByPhoneNumberResulteDto dto) {
+        if (dto == null) {
+            return new VisitorProfilesFindByPhoneNumberResponse(List.of());
+        }
+        return new VisitorProfilesFindByPhoneNumberResponse(
+                List.of(VisitorProfileFindByPhoneNumberResponse.from(dto))
+        );
+    }
+
+    @Getter
+    @RequiredArgsConstructor
+    private static class VisitorProfileFindByPhoneNumberResponse {
+
+        private final Long id;
+        private final String nickname;
+        private final String phoneNumber;
+        private final String registerType;
+
+        public static VisitorProfileFindByPhoneNumberResponse from(VisitorProfileFindByPhoneNumberResulteDto dto) {
+            return new VisitorProfileFindByPhoneNumberResponse(
+                    dto.getId(),
+                    dto.getNickname(),
+                    dto.getPhoneNumber(),
+                    dto.getRegisterType()
+            );
+        }
+    }
+}

--- a/backend/src/main/java/com/stampcrush/backend/application/visitor/profile/VisitorProfilesCommandService.java
+++ b/backend/src/main/java/com/stampcrush/backend/application/visitor/profile/VisitorProfilesCommandService.java
@@ -1,14 +1,14 @@
 package com.stampcrush.backend.application.visitor.profile;
 
 import com.stampcrush.backend.entity.user.Customer;
-import com.stampcrush.backend.exception.CustomerBadRequestException;
+import com.stampcrush.backend.exception.BadRequestException;
 import com.stampcrush.backend.exception.CustomerNotFoundException;
 import com.stampcrush.backend.repository.user.CustomerRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Optional;
 
 @RequiredArgsConstructor
@@ -19,11 +19,15 @@ public class VisitorProfilesCommandService {
     private final CustomerRepository customerRepository;
 
     public void registerPhoneNumber(Long customerId, String phoneNumber) {
-        try {
-            Customer customer = findExistingCustomer(customerId);
-            customer.registerPhoneNumber(phoneNumber);
-        } catch (DataIntegrityViolationException exception) {
-            throw new CustomerBadRequestException("이미 등록된 전화번호입니다.", exception);
+        validateDuplicatePhoneNumber(phoneNumber);
+        Customer customer = findExistingCustomer(customerId);
+        customer.registerPhoneNumber(phoneNumber);
+    }
+
+    private void validateDuplicatePhoneNumber(String phoneNumber) {
+        List<Customer> findCustomer = customerRepository.findByPhoneNumber(phoneNumber);
+        if (!findCustomer.isEmpty()) {
+            throw new BadRequestException("해당 전화번호 " + phoneNumber + "는 이미 존재하는 회원과 중복임!");
         }
     }
 

--- a/backend/src/main/java/com/stampcrush/backend/application/visitor/profile/VisitorProfilesFindService.java
+++ b/backend/src/main/java/com/stampcrush/backend/application/visitor/profile/VisitorProfilesFindService.java
@@ -1,5 +1,6 @@
 package com.stampcrush.backend.application.visitor.profile;
 
+import com.stampcrush.backend.application.visitor.profile.dto.VisitorProfileFindByPhoneNumberResultDto;
 import com.stampcrush.backend.application.visitor.profile.dto.VisitorProfileFindResultDto;
 import com.stampcrush.backend.entity.user.RegisterCustomer;
 import com.stampcrush.backend.exception.CustomerNotFoundException;
@@ -20,5 +21,9 @@ public class VisitorProfilesFindService {
                 .orElseThrow(() -> new CustomerNotFoundException("고객을 찾을 수 없습니다"));
 
         return new VisitorProfileFindResultDto(customer.getId(), customer.getNickname(), customer.getPhoneNumber(), customer.getEmail());
+    }
+
+    public VisitorProfileFindByPhoneNumberResultDto findCustomerProfileByNumber(String phoneNumber) {
+        return null;
     }
 }

--- a/backend/src/main/java/com/stampcrush/backend/application/visitor/profile/VisitorProfilesFindService.java
+++ b/backend/src/main/java/com/stampcrush/backend/application/visitor/profile/VisitorProfilesFindService.java
@@ -2,18 +2,24 @@ package com.stampcrush.backend.application.visitor.profile;
 
 import com.stampcrush.backend.application.visitor.profile.dto.VisitorProfileFindByPhoneNumberResultDto;
 import com.stampcrush.backend.application.visitor.profile.dto.VisitorProfileFindResultDto;
+import com.stampcrush.backend.entity.user.Customer;
 import com.stampcrush.backend.entity.user.RegisterCustomer;
 import com.stampcrush.backend.exception.CustomerNotFoundException;
+import com.stampcrush.backend.exception.StampCrushException;
+import com.stampcrush.backend.repository.user.CustomerRepository;
 import com.stampcrush.backend.repository.user.RegisterCustomerRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 @Service
 public class VisitorProfilesFindService {
 
+    private final CustomerRepository customerRepository;
     private final RegisterCustomerRepository registerCustomerRepository;
 
     public VisitorProfileFindResultDto findVisitorProfile(Long customerId) {
@@ -24,6 +30,19 @@ public class VisitorProfilesFindService {
     }
 
     public VisitorProfileFindByPhoneNumberResultDto findCustomerProfileByNumber(String phoneNumber) {
-        return null;
+        Customer customer = findCustomerWithSamePhoneNumber(phoneNumber);
+        return VisitorProfileFindByPhoneNumberResultDto.from(customer);
+    }
+
+    private Customer findCustomerWithSamePhoneNumber(String phoneNumber) {
+        List<Customer> customers = customerRepository.findByPhoneNumber(phoneNumber);
+        if (customers.isEmpty()) {
+            return null;
+        }
+        if (customers.size() > 1) {
+            throw new StampCrushException("🚨 전화번호 " + phoneNumber + "에 대해서 중복되는 사용자가 이미 2명 이상 존재합니다.");
+        }
+
+        return customers.get(0);
     }
 }

--- a/backend/src/main/java/com/stampcrush/backend/application/visitor/profile/dto/VisitorProfileFindByPhoneNumberResultDto.java
+++ b/backend/src/main/java/com/stampcrush/backend/application/visitor/profile/dto/VisitorProfileFindByPhoneNumberResultDto.java
@@ -14,6 +14,10 @@ public class VisitorProfileFindByPhoneNumberResultDto {
     private final String registerType;
 
     public static VisitorProfileFindByPhoneNumberResultDto from(Customer customer) {
+        if (customer == null) {
+            return null;
+        }
+
         return new VisitorProfileFindByPhoneNumberResultDto(
                 customer.getId(),
                 customer.getNickname(),

--- a/backend/src/main/java/com/stampcrush/backend/application/visitor/profile/dto/VisitorProfileFindByPhoneNumberResultDto.java
+++ b/backend/src/main/java/com/stampcrush/backend/application/visitor/profile/dto/VisitorProfileFindByPhoneNumberResultDto.java
@@ -1,0 +1,31 @@
+package com.stampcrush.backend.application.visitor.profile.dto;
+
+import com.stampcrush.backend.entity.user.Customer;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class VisitorProfileFindByPhoneNumberResultDto {
+
+    private final Long id;
+    private final String nickname;
+    private final String phoneNumber;
+    private final String registerType;
+
+    public static VisitorProfileFindByPhoneNumberResultDto from(Customer customer) {
+        return new VisitorProfileFindByPhoneNumberResultDto(
+                customer.getId(),
+                customer.getNickname(),
+                customer.getPhoneNumber(),
+                getRegisterType(customer)
+        );
+    }
+
+    private static String getRegisterType(Customer customer) {
+        if (customer.isRegistered()) {
+            return "register";
+        }
+        return "temporary";
+    }
+}

--- a/backend/src/test/java/com/stampcrush/backend/api/visitor/profile/VisitorProfilesFindApiControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/visitor/profile/VisitorProfilesFindApiControllerTest.java
@@ -1,0 +1,55 @@
+package com.stampcrush.backend.api.visitor.profile;
+
+import com.stampcrush.backend.api.ControllerSliceTest;
+import com.stampcrush.backend.application.visitor.profile.VisitorProfilesFindService;
+import com.stampcrush.backend.application.visitor.profile.dto.VisitorProfileFindByPhoneNumberResultDto;
+import com.stampcrush.backend.config.WebMvcConfig;
+import com.stampcrush.backend.entity.user.Customer;
+import com.stampcrush.backend.fixture.CustomerFixture;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(
+        value = VisitorProfilesFindApiController.class,
+        excludeFilters =
+        @ComponentScan.Filter(
+                type = FilterType.ASSIGNABLE_TYPE,
+                classes = WebMvcConfig.class
+        )
+)
+class VisitorProfilesFindApiControllerTest extends ControllerSliceTest {
+
+    @MockBean
+    private VisitorProfilesFindService visitorProfilesFindService;
+
+    @Test
+    void 전화번호로_고객을_조회한다() throws Exception {
+        Customer customer = CustomerFixture.TEMPORARY_CUSTOMER_1;
+
+        when(visitorProfilesFindService.findCustomerProfileByNumber(anyString()))
+                .thenReturn(
+                        VisitorProfileFindByPhoneNumberResultDto.from(customer)
+                );
+
+        mockMvc.perform(
+                        get("/api/profiles/search")
+                                .param("phone-number", "01038626099")
+                                .contentType(APPLICATION_JSON)
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("customers[0].id").value(customer.getId()))
+                .andExpect(jsonPath("customers[0].nickname").value(customer.getNickname()))
+                .andExpect(jsonPath("customers[0].phoneNumber").value(customer.getPhoneNumber()))
+                .andExpect(jsonPath("customers[0].registerType").value("temporary"));
+    }
+}

--- a/backend/src/test/java/com/stampcrush/backend/api/visitor/profile/response/VisitorProfilesFindByPhoneNumberResponseTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/visitor/profile/response/VisitorProfilesFindByPhoneNumberResponseTest.java
@@ -1,0 +1,20 @@
+package com.stampcrush.backend.api.visitor.profile.response;
+
+import com.stampcrush.backend.application.visitor.profile.dto.VisitorProfileFindByPhoneNumberResulteDto;
+import com.stampcrush.backend.entity.user.Customer;
+import com.stampcrush.backend.fixture.CustomerFixture;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class VisitorProfilesFindByPhoneNumberResponseTest {
+
+    @Test
+    void 응답_생성_테스트() {
+        Customer customer = CustomerFixture.REGISTER_CUSTOMER_GITCHAN;
+        VisitorProfileFindByPhoneNumberResulteDto dto = VisitorProfileFindByPhoneNumberResulteDto.from(customer);
+        VisitorProfilesFindByPhoneNumberResponse response = VisitorProfilesFindByPhoneNumberResponse.from(dto);
+
+        assertThat(response.getCustomers()).isNotEmpty();
+    }
+}

--- a/backend/src/test/java/com/stampcrush/backend/api/visitor/profile/response/VisitorProfilesFindByPhoneNumberResponseTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/visitor/profile/response/VisitorProfilesFindByPhoneNumberResponseTest.java
@@ -1,6 +1,6 @@
 package com.stampcrush.backend.api.visitor.profile.response;
 
-import com.stampcrush.backend.application.visitor.profile.dto.VisitorProfileFindByPhoneNumberResulteDto;
+import com.stampcrush.backend.application.visitor.profile.dto.VisitorProfileFindByPhoneNumberResultDto;
 import com.stampcrush.backend.entity.user.Customer;
 import com.stampcrush.backend.fixture.CustomerFixture;
 import org.junit.jupiter.api.Test;
@@ -12,7 +12,7 @@ class VisitorProfilesFindByPhoneNumberResponseTest {
     @Test
     void 응답_생성_테스트() {
         Customer customer = CustomerFixture.REGISTER_CUSTOMER_GITCHAN;
-        VisitorProfileFindByPhoneNumberResulteDto dto = VisitorProfileFindByPhoneNumberResulteDto.from(customer);
+        VisitorProfileFindByPhoneNumberResultDto dto = VisitorProfileFindByPhoneNumberResultDto.from(customer);
         VisitorProfilesFindByPhoneNumberResponse response = VisitorProfilesFindByPhoneNumberResponse.from(dto);
 
         assertThat(response.getCustomers()).isNotEmpty();

--- a/backend/src/test/java/com/stampcrush/backend/application/visitor/profile/VisitorProfilesCommandServiceTest2.java
+++ b/backend/src/test/java/com/stampcrush/backend/application/visitor/profile/VisitorProfilesCommandServiceTest2.java
@@ -29,7 +29,7 @@ class VisitorProfilesCommandServiceTest2 {
                 .build()
         );
 
-        String phoneNumber = "01012345678";
+        String phoneNumber = "01098765432";
         visitorProfilesCommandService.registerPhoneNumber(gitchan.getId(), phoneNumber);
 
         Customer findGitchan = customerRepository.findById(gitchan.getId()).get();

--- a/backend/src/test/java/com/stampcrush/backend/application/visitor/profile/VisitorProfilesFindServiceTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/application/visitor/profile/VisitorProfilesFindServiceTest.java
@@ -26,9 +26,6 @@ class VisitorProfilesFindServiceTest {
     @Mock
     private CustomerRepository customerRepository;
 
-//    @Mock
-//    private RegisterCustomerRepository registerCustomerRepository;
-
     @Test
     void 전화번호로_사용자_정상_조회() {
         RegisterCustomer customer = CustomerFixture.REGISTER_CUSTOMER_GITCHAN;

--- a/backend/src/test/java/com/stampcrush/backend/application/visitor/profile/VisitorProfilesFindServiceTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/application/visitor/profile/VisitorProfilesFindServiceTest.java
@@ -1,0 +1,62 @@
+package com.stampcrush.backend.application.visitor.profile;
+
+import com.stampcrush.backend.application.ServiceSliceTest;
+import com.stampcrush.backend.application.visitor.profile.dto.VisitorProfileFindByPhoneNumberResultDto;
+import com.stampcrush.backend.entity.user.RegisterCustomer;
+import com.stampcrush.backend.exception.StampCrushException;
+import com.stampcrush.backend.fixture.CustomerFixture;
+import com.stampcrush.backend.repository.user.CustomerRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+
+@ServiceSliceTest
+class VisitorProfilesFindServiceTest {
+
+    @InjectMocks
+    private VisitorProfilesFindService visitorProfilesFindService;
+
+    @Mock
+    private CustomerRepository customerRepository;
+
+//    @Mock
+//    private RegisterCustomerRepository registerCustomerRepository;
+
+    @Test
+    void 전화번호로_사용자_정상_조회() {
+        RegisterCustomer customer = CustomerFixture.REGISTER_CUSTOMER_GITCHAN;
+
+        given(customerRepository.findByPhoneNumber(anyString()))
+                .willReturn(List.of(customer));
+
+        assertThat(visitorProfilesFindService.findCustomerProfileByNumber("01038626099"))
+                .usingRecursiveComparison()
+                .isEqualTo(VisitorProfileFindByPhoneNumberResultDto.from(customer));
+    }
+
+    @Test
+    void 같은_전화번호의_사용자가_이미_2명_이상_존재하면_예외_발생() {
+        given(customerRepository.findByPhoneNumber(anyString()))
+                .willReturn(List.of(CustomerFixture.TEMPORARY_CUSTOMER_1, CustomerFixture.TEMPORARY_CUSTOMER_2));
+
+        Assertions.assertThatThrownBy(() -> visitorProfilesFindService.findCustomerProfileByNumber("01038626099"))
+                .isInstanceOf(StampCrushException.class);
+    }
+
+    @Test
+    void 전화번호로_사용자_조회되지_않음() {
+        given(customerRepository.findByPhoneNumber(anyString()))
+                .willReturn(List.of());
+
+        assertThat(visitorProfilesFindService.findCustomerProfileByNumber("01038626099"))
+                .usingRecursiveComparison()
+                .isEqualTo(VisitorProfileFindByPhoneNumberResultDto.from(null));
+    }
+}


### PR DESCRIPTION
## 구현 기능

- 임시 회원 데이터 연동 과정에서 필요한 API임.
- 왜 필요한지는 [디스커션](https://github.com/woowacourse-teams/2023-stamp-crush/discussions/619)에 써놨으니 꼭 꼭 꼭 확인.. 너무 힘드니 묻지 말아주세요....

- 데이터 연동 API를 만들다가 어제 큰 수정이 필요하다고 논의했고, 수정 전에 이 API는 먼저 머지하는게 좋을 것 같아서 PR 올렸습니다. 

## `전화번호로 고객 조회 API`

### Request

```http
GET /api/customers/profiles/serach?phone-number=01038626099 HTTP/1.1
Authorization: Bearer k21h3keeoiu3k2lkl12j3kdksuhxcb_120909
```

**Body**

None

### Response

**Header**

```http
HTTP/1.1 200 OK
```

**Body**

- 해당 전화번호의 임시 회원(Temporary Customer)이 존재하는 경우 => 프론트에서 연동할거냐고 물어볼 예정

```json
{
	"customers": [
		{
			"id": 300,
			"nickname": "6099",
			"phoneNumber": "01038626099",
			"registerType": "temporary"
		}
	]
}
```

- 해당 전화번호의 가입 회원(Register Customer)이 존재하는 경우 => 프론트에서 이경우에는 일단 해당 번호로 저장을 못하게 할 예정

```json
{
	"customers": [
		{
			"id": 300,
			"nickname": "6099",
			"phoneNumber": "01038626099",
			"registerType": "register"
		}
	]
}
```

- 해당 전화번호의 회원이 존재하지 않는 경우 => 전화번호 맞는지 확인 후 등록할 예정

```json
{
	"customers": []
}
```

<br/>

## 작업 내용

<br/>

close #629 

## 체크리스트

- [x] `assignee` 설정 (선택)
- [x] `labels` 설정
- [x] `milestone` 설정

<br/>

## 주의사항
