### PR TITLE
[FE] refactor: 쿠폰이 한 장일 때 쿠폰을 넘기는 애니메이션이 동작하지 않게 한다. 

### DIFF
--- a/frontend/src/pages/Customer/CouponList/index.tsx
+++ b/frontend/src/pages/Customer/CouponList/index.tsx
@@ -14,6 +14,7 @@ import CafeInfo from './CafeInfo';
 import Header from './Header';
 import { useCustomerProfile } from '../../../hooks/useCustomerProfile';
 import CustomerLoadingSpinner from '../../../components/LoadingSpinner/CustomerLoadingSpinner';
+import { isEmptyArray } from '../../../utils';
 
 const CouponList = () => {
   const navigate = useNavigate();
@@ -44,7 +45,7 @@ const CouponList = () => {
     if (localStorage.getItem('login-token') === '' || !localStorage.getItem('login-token'))
       navigate(ROUTER_PATH.login);
     if (!customerProfile?.profile.phoneNumber) navigate(ROUTER_PATH.phoneNumber);
-    if (couponData && couponData.coupons.length > 0) {
+    if (couponData && !isEmptyArray(couponData.coupons)) {
       setCurrentIndex(couponData.coupons.length - 1);
     }
   }, [couponData, customerProfile?.profile.phoneNumber]);
@@ -159,7 +160,7 @@ const CouponList = () => {
   return (
     <>
       <Header />
-      {coupons.length === 0 ? (
+      {isEmptyArray(coupons) ? (
         <InfoContainer>보유하고 있는 쿠폰이 없습니다.</InfoContainer>
       ) : (
         <>

--- a/frontend/src/pages/Customer/CouponList/index.tsx
+++ b/frontend/src/pages/Customer/CouponList/index.tsx
@@ -14,7 +14,7 @@ import CafeInfo from './CafeInfo';
 import Header from './Header';
 import { useCustomerProfile } from '../../../hooks/useCustomerProfile';
 import CustomerLoadingSpinner from '../../../components/LoadingSpinner/CustomerLoadingSpinner';
-import { isEmptyArray } from '../../../utils';
+import { isNotEmptyArray } from '../../../utils';
 
 const CouponList = () => {
   const navigate = useNavigate();
@@ -45,7 +45,7 @@ const CouponList = () => {
     if (localStorage.getItem('login-token') === '' || !localStorage.getItem('login-token'))
       navigate(ROUTER_PATH.login);
     if (!customerProfile?.profile.phoneNumber) navigate(ROUTER_PATH.phoneNumber);
-    if (couponData && !isEmptyArray(couponData.coupons)) {
+    if (couponData && isNotEmptyArray(couponData.coupons)) {
       setCurrentIndex(couponData.coupons.length - 1);
     }
   }, [couponData, customerProfile?.profile.phoneNumber]);
@@ -160,7 +160,7 @@ const CouponList = () => {
   return (
     <>
       <Header />
-      {isEmptyArray(coupons) ? (
+      {!isNotEmptyArray(coupons) ? (
         <InfoContainer>보유하고 있는 쿠폰이 없습니다.</InfoContainer>
       ) : (
         <>

--- a/frontend/src/pages/Customer/CouponList/index.tsx
+++ b/frontend/src/pages/Customer/CouponList/index.tsx
@@ -44,7 +44,7 @@ const CouponList = () => {
     if (localStorage.getItem('login-token') === '' || !localStorage.getItem('login-token'))
       navigate(ROUTER_PATH.login);
     if (!customerProfile?.profile.phoneNumber) navigate(ROUTER_PATH.phoneNumber);
-    if (couponData) {
+    if (couponData && couponData.coupons.length > 0) {
       setCurrentIndex(couponData.coupons.length - 1);
     }
   }, [couponData, customerProfile?.profile.phoneNumber]);

--- a/frontend/src/pages/Customer/CouponList/index.tsx
+++ b/frontend/src/pages/Customer/CouponList/index.tsx
@@ -18,13 +18,17 @@ import CustomerLoadingSpinner from '../../../components/LoadingSpinner/CustomerL
 const CouponList = () => {
   const navigate = useNavigate();
   const { customerProfile } = useCustomerProfile();
+
   const { isOpen, openModal, closeModal } = useModal();
+  const [alertMessage, setAlertMessage] = useState('');
+
   const [currentIndex, setCurrentIndex] = useState(0);
   const [isLast, setIsLast] = useState(false);
-  const [alertMessage, setAlertMessage] = useState('');
   const [isDetail, setIsDetail] = useState(false);
   const [isFlippedCouponShown, setIsFlippedCouponShown] = useState(false);
+
   const couponListContainerRef = useRef<HTMLDivElement>(null);
+
   const [startY, setStartY] = useState(0);
   const [endY, setEndY] = useState(0);
 
@@ -41,7 +45,7 @@ const CouponList = () => {
       navigate(ROUTER_PATH.login);
     if (!customerProfile?.profile.phoneNumber) navigate(ROUTER_PATH.phoneNumber);
     if (couponData) {
-      setCurrentIndex(couponData?.coupons.length - 1);
+      setCurrentIndex(couponData.coupons.length - 1);
     }
   }, [couponData, customerProfile?.profile.phoneNumber]);
 
@@ -78,6 +82,7 @@ const CouponList = () => {
 
   const swapCoupon = (e: TouchEvent<HTMLDivElement>) => {
     if (!couponListContainerRef.current || isDetail) return;
+    if (coupons.length === 1) return;
 
     const coupon = couponListContainerRef.current.lastElementChild;
     if (e.target !== coupon) return;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -160,3 +160,5 @@ export interface CustomerProfile {
   phoneNumber: string | null;
   email: string | null;
 }
+
+export type EmptyArray<T> = T[] & { _brand: 'no empty array' };

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -161,4 +161,4 @@ export interface CustomerProfile {
   email: string | null;
 }
 
-export type EmptyArray<T> = T[] & { _brand: 'no empty array' };
+export type NotEmptyArray<T> = T[] & { _brand: 'not empty array' };

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -1,5 +1,11 @@
 import { EXPIRE_DATE_MAX, EXPIRE_DATE_NONE, IMAGE_MAX_SIZE } from '../constants';
-import { ExpireDateOptionValue, StampCountOptionValue, DateParseOption, Time } from '../types';
+import {
+  ExpireDateOptionValue,
+  StampCountOptionValue,
+  DateParseOption,
+  Time,
+  EmptyArray,
+} from '../types';
 
 export const formatDate = (dateString: string) => {
   const dateArray = dateString.split(':');
@@ -88,4 +94,8 @@ export const getLocalStorage = <T>(key: string, defaultValue: T): T => {
     console.error(`[ERROR] ${key}값의 LocalStorage data 파싱 과정에서 오류가 발생했습니다.`);
     return defaultValue;
   }
+};
+
+export const isEmptyArray = <T>(array: T[]): array is EmptyArray<T> => {
+  return array.length === 0;
 };

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -4,7 +4,7 @@ import {
   StampCountOptionValue,
   DateParseOption,
   Time,
-  EmptyArray,
+  NotEmptyArray,
 } from '../types';
 
 export const formatDate = (dateString: string) => {
@@ -96,6 +96,6 @@ export const getLocalStorage = <T>(key: string, defaultValue: T): T => {
   }
 };
 
-export const isEmptyArray = <T>(array: T[]): array is EmptyArray<T> => {
-  return array.length === 0;
+export const isNotEmptyArray = <T>(array: T[]): array is NotEmptyArray<T> => {
+  return array.length !== 0;
 };

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -97,5 +97,5 @@ export const getLocalStorage = <T>(key: string, defaultValue: T): T => {
 };
 
 export const isNotEmptyArray = <T>(array: T[]): array is NotEmptyArray<T> => {
-  return array.length !== 0;
+  return array.length > 0;
 };


### PR DESCRIPTION
## 주요 변경사항

- 쿠폰이 한 장일 때 애니메이션을 동작하지 않게 하였습니다.
- 해당 부분 수정 중 발견한 오류를 해결하였습니다
    - 쿠폰이 한 장일 때 삭제 -> 사장모드에서 스탬프 적립 -> 렌더링 되지 않는 오류 발생
    - 원인 : `currentIndex`가 -1이 되어 발생하는 오류
    - 해결 : `useEffect` 내부 로직 중 `couponData`가 비어있어도 `setCurrentIndex`가 동작하였음. 조건을 추가하여 방지하였습니다.

## 리뷰어에게...

## 관련 이슈

closes #632 

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [x] `milestone` 설정
