### PR TITLE
[FE] refactor: 전화번호로 고객 조회 로직을 전화번호 입력페이지로 이동시킨다.

### DIFF
--- a/frontend/src/api/post.ts
+++ b/frontend/src/api/post.ts
@@ -25,7 +25,7 @@ export const postEarnStamp = async ({
   );
 };
 
-export const postRegisterUser = async ({ body }: MutateReq<RegisterUserReqBody>) => {
+export const postTemporaryCustomer = async ({ body }: MutateReq<RegisterUserReqBody>) => {
   return await api.post<RegisterUserReqBody>('/admin/temporary-customers', ownerHeader(), body);
 };
 

--- a/frontend/src/hooks/useDialPad.ts
+++ b/frontend/src/hooks/useDialPad.ts
@@ -2,6 +2,7 @@ import { PHONE_NUMBER_LENGTH, REGEX, ROUTER_PATH } from '../constants';
 import { ChangeEvent, KeyboardEvent, useRef, useState } from 'react';
 import { DialKeyType } from '../pages/Admin/EnterPhoneNumber/Dialpad';
 import { useLocation, useNavigate } from 'react-router-dom';
+import { CustomerPhoneNumber } from '../types';
 
 const addHypen = (phoneNumber: string) => {
   return phoneNumber.length === 8
@@ -28,20 +29,18 @@ const useDialPad = () => {
     setPhoneNumber((prev) => prev.substring(0, prev.length - 1));
   };
 
-  const navigateNextPage = () => {
+  const navigateNextPage = (customerState: CustomerPhoneNumber) => {
     if (phoneNumber.length !== PHONE_NUMBER_LENGTH) {
       alert('올바른 전화번호를 입력해주세요.');
       return;
     }
 
-    const replacedPhoneNumber = phoneNumber.replaceAll('-', '');
-
     if (location.pathname === ROUTER_PATH.enterStamp) {
-      navigate(ROUTER_PATH.selectCoupon, { state: { phoneNumber: replacedPhoneNumber } });
+      navigate(ROUTER_PATH.selectCoupon, { state: customerState });
     }
 
     if (location.pathname === ROUTER_PATH.enterReward) {
-      navigate(ROUTER_PATH.useReward, { state: { phoneNumber: replacedPhoneNumber } });
+      navigate(ROUTER_PATH.useReward, { state: customerState });
     }
   };
 

--- a/frontend/src/hooks/useDialPad.ts
+++ b/frontend/src/hooks/useDialPad.ts
@@ -3,6 +3,7 @@ import { ChangeEvent, KeyboardEvent, useRef, useState } from 'react';
 import { DialKeyType } from '../pages/Admin/EnterPhoneNumber/Dialpad';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { CustomerPhoneNumber } from '../types';
+import { removeHypen } from '../utils';
 
 const addHypen = (phoneNumber: string) => {
   return phoneNumber.length === 8
@@ -48,7 +49,7 @@ const useDialPad = () => {
     if (e.target.value.length > 4 && e.target.value.endsWith('-'))
       e.target.value = e.target.value.substring(0, e.target.value.length - 1);
 
-    if (!REGEX.number.test(e.target.value.replaceAll('-', ''))) return;
+    if (!REGEX.number.test(removeHypen(e.target.value))) return;
 
     setPhoneNumber(addHypen(e.target.value));
   };

--- a/frontend/src/pages/Admin/EarnStamp/SelectCoupon/index.tsx
+++ b/frontend/src/pages/Admin/EarnStamp/SelectCoupon/index.tsx
@@ -14,7 +14,7 @@ import { useMutation, useQuery } from '@tanstack/react-query';
 import { INVALID_CAFE_ID, ROUTER_PATH } from '../../../../constants';
 import { useRedirectRegisterPage } from '../../../../hooks/useRedirectRegisterPage';
 import { getCoupon, getCustomer } from '../../../../api/get';
-import { postIssueCoupon, postRegisterUser } from '../../../../api/post';
+import { postIssueCoupon, postTemporaryCustomer } from '../../../../api/post';
 import Text from '../../../../components/Text';
 import { CouponActivate } from '../../../../types';
 import { CustomerPhoneNumberRes, IssueCouponRes, IssuedCouponsRes } from '../../../../types/api';
@@ -45,7 +45,7 @@ const SelectCoupon = () => {
   });
 
   const { mutate: mutateTempCustomer } = useMutation({
-    mutationFn: postRegisterUser,
+    mutationFn: postTemporaryCustomer,
     onSuccess: () => {
       setSelectedCoupon('new');
       refetchCustomer();

--- a/frontend/src/pages/Admin/EnterPhoneNumber/Dialpad/index.tsx
+++ b/frontend/src/pages/Admin/EnterPhoneNumber/Dialpad/index.tsx
@@ -51,7 +51,7 @@ const Dialpad = () => {
 
   const { mutate: mutateTemporaryCustomer } = useMutation({
     mutationFn: postTemporaryCustomer,
-    onSuccess: () => {
+    onSuccess: async () => {
       queryClient.invalidateQueries({ queryKey: ['customer'] });
       if (customers?.customer[0]) navigateNextPage(customers.customer[0]);
     },

--- a/frontend/src/pages/Admin/EnterPhoneNumber/Dialpad/index.tsx
+++ b/frontend/src/pages/Admin/EnterPhoneNumber/Dialpad/index.tsx
@@ -1,10 +1,13 @@
 import { useMutation, useQuery } from '@tanstack/react-query';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { getCustomer } from '../../../../api/get';
 import { postTemporaryCustomer } from '../../../../api/post';
 import Alert from '../../../../components/Alert';
+import { ROUTER_PATH } from '../../../../constants';
 import useDialPad from '../../../../hooks/useDialPad';
 import useModal from '../../../../hooks/useModal';
 import { CustomerPhoneNumberRes } from '../../../../types/api';
+import { removeHypen } from '../../../../utils';
 import { BaseInput, Container, KeyContainer, Pad } from './style';
 
 const DIAL_KEYS = ['1', '2', '3', '4', '5', '6', '7', '8', '9', '←', '0', '입력'] as const;
@@ -12,6 +15,8 @@ const DIAL_KEYS = ['1', '2', '3', '4', '5', '6', '7', '8', '9', '←', '0', '입
 export type DialKeyType = (typeof DIAL_KEYS)[number];
 
 const Dialpad = () => {
+  const location = useLocation();
+  const navigate = useNavigate();
   const { isOpen, openModal, closeModal } = useModal();
   const {
     isDone,
@@ -29,7 +34,7 @@ const Dialpad = () => {
     status: customerStatus,
     refetch: refetchCustomers,
   } = useQuery<CustomerPhoneNumberRes>(['customer', phoneNumber], {
-    queryFn: () => getCustomer({ params: { phoneNumber: phoneNumber.replaceAll('-', '') } }),
+    queryFn: () => getCustomer({ params: { phoneNumber: removeHypen(phoneNumber) } }),
     onSuccess: (data) => {
       if (data.customer.length === 0) {
         openModal();
@@ -41,7 +46,7 @@ const Dialpad = () => {
   });
 
   const requestTemporaryCustomer = () => {
-    mutateTemporaryCustomer({ body: { phoneNumber: phoneNumber.replaceAll('-', '') } });
+    mutateTemporaryCustomer({ body: { phoneNumber: removeHypen(phoneNumber) } });
   };
 
   const { mutate: mutateTemporaryCustomer } = useMutation({
@@ -62,17 +67,32 @@ const Dialpad = () => {
     setIsDone(false);
   };
 
+  const navigateCustomerListPage = () => {
+    closeModal();
+    navigate(ROUTER_PATH.customerList);
+  };
+
   return (
     <Container>
-      {isOpen && (
-        <Alert
-          text={phoneNumber + '님, 첫 스탬프 적립이 맞으신가요?'}
-          rightOption={'네'}
-          leftOption={'다시 입력'}
-          onClickRight={requestTemporaryCustomer}
-          onClickLeft={retryPhoneNumber}
-        />
-      )}
+      {location.pathname === ROUTER_PATH.enterStamp
+        ? isOpen && (
+            <Alert
+              text={phoneNumber + '님, 첫 스탬프 적립이 맞으신가요?'}
+              rightOption={'네'}
+              leftOption={'다시 입력'}
+              onClickRight={requestTemporaryCustomer}
+              onClickLeft={retryPhoneNumber}
+            />
+          )
+        : isOpen && (
+            <Alert
+              text={phoneNumber + '님은 \n스탬프크러쉬 회원이 아니에요 🥲'}
+              rightOption={'네'}
+              leftOption={'다시 입력'}
+              onClickRight={navigateCustomerListPage}
+              onClickLeft={retryPhoneNumber}
+            />
+          )}
       <BaseInput
         id="phoneNumber"
         value={phoneNumber}

--- a/frontend/src/pages/Admin/EnterPhoneNumber/Dialpad/index.tsx
+++ b/frontend/src/pages/Admin/EnterPhoneNumber/Dialpad/index.tsx
@@ -51,7 +51,7 @@ const Dialpad = () => {
 
   const { mutate: mutateTemporaryCustomer } = useMutation({
     mutationFn: postTemporaryCustomer,
-    onSuccess: async () => {
+    onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['customer'] });
       if (customers?.customer[0]) navigateNextPage(customers.customer[0]);
     },

--- a/frontend/src/pages/Admin/RewardPage/index.tsx
+++ b/frontend/src/pages/Admin/RewardPage/index.tsx
@@ -4,44 +4,31 @@ import { RewardContainer, RewardContent, RewardItemContainer, RewardItemWrapper 
 import Text from '../../../components/Text';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { Spacing } from '../../../style/layout/common';
-import { getCustomer, getReward } from '../../../api/get';
+import { getReward } from '../../../api/get';
 import { patchReward } from '../../../api/patch';
 import { INVALID_CAFE_ID, ROUTER_PATH } from '../../../constants';
 import { Reward } from '../../../types';
-import {
-  MutateReq,
-  RewardReqBody,
-  RewardIdParams,
-  CustomerIdParams,
-  CustomerPhoneNumberRes,
-} from '../../../types/api';
+import { MutateReq, RewardReqBody, RewardIdParams, CustomerIdParams } from '../../../types/api';
 import { useRedirectRegisterPage } from '../../../hooks/useRedirectRegisterPage';
 
 const RewardPage = () => {
   const cafeId = useRedirectRegisterPage();
   const location = useLocation();
   const navigate = useNavigate();
-  const phoneNumber = location.state.phoneNumber;
 
-  const { data: customerData, status: customerStatus } = useQuery<CustomerPhoneNumberRes>(
-    ['getCustomer', phoneNumber],
-    () => getCustomer({ params: { phoneNumber } }),
-  );
-
+  // TODO: 내카페의 고객이 아닌 고객의 리워드를 조회할 경우 ErrorMessage를 띄어줌
   const { data: rewardData, status: rewardStatus } = useQuery(
-    ['getReward', customerData],
+    ['getReward'],
     () => {
-      if (!customerData) throw new Error('고객 데이터 불러오기에 실패했습니다.');
-      return getReward({ params: { customerId: customerData.customer[0].id, cafeId } });
+      return getReward({ params: { customerId: location.state.id, cafeId } });
     },
     {
-      enabled: !!customerData && cafeId !== INVALID_CAFE_ID,
+      enabled: cafeId !== INVALID_CAFE_ID,
     },
   );
 
   const { mutate: mutateReward } = useMutation({
     mutationFn: (request: MutateReq<RewardReqBody, RewardIdParams & CustomerIdParams>) => {
-      if (!customerData) throw new Error('고객 데이터 불러오기에 실패했습니다.');
       return patchReward(request);
     },
     onSuccess() {
@@ -52,11 +39,11 @@ const RewardPage = () => {
     },
   });
 
-  if (rewardStatus === 'error' || customerStatus === 'error') {
+  if (rewardStatus === 'error') {
     return <div>불러오는 중 에러가 발생했습니다. 다시 시도해주세요.</div>;
   }
 
-  if (rewardStatus === 'loading' || customerStatus === 'loading') {
+  if (rewardStatus === 'loading') {
     return <div>고객 정보 불러오는 중...</div>;
   }
 
@@ -64,7 +51,7 @@ const RewardPage = () => {
     mutateReward({
       params: {
         rewardId,
-        customerId: customerData.customer[0].id,
+        customerId: location.state.id,
       },
       body: {
         used: true,
@@ -79,7 +66,7 @@ const RewardPage = () => {
       <Text variant="pageTitle">리워드 사용</Text>
       <Spacing $size={36} />
       <RewardContainer>
-        <Text variant="pageTitle">{customerData.customer[0].nickname}고객님</Text>
+        <Text variant="pageTitle">{location.state.nickname}고객님</Text>
         <Spacing $size={72} />
         <Text variant="subTitle">보유 리워드 내역</Text>
         <Spacing $size={42} />

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -89,3 +89,5 @@ export const getLocalStorage = <T>(key: string, defaultValue: T): T => {
     return defaultValue;
   }
 };
+
+export const removeHypen = (value: string) => value.replaceAll('-', '');


### PR DESCRIPTION
## 주요 변경사항

- 전화번호 입력 페이지 `EnterPhoneNumber`에서 전화번호로 고객 조회 실패 시 alert를 띄우고(이전 pr 작업내용)
- 후에 해당 전화번호로 임시 가입 고객을 생성하여 다음 페이지 `SelectCoupon`에 state를 넘겨주는 작업을 진행하였습니다.

## 리뷰어에게...

## 관련 이슈

closes #639

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [x] `milestone` 설정
