### PR TITLE
[BE] feat: 회원 데이터 연동 API 

### DIFF
--- a/backend/src/main/java/com/stampcrush/backend/api/visitor/profile/VisitorProfilesCommandApiController.java
+++ b/backend/src/main/java/com/stampcrush/backend/api/visitor/profile/VisitorProfilesCommandApiController.java
@@ -26,4 +26,14 @@ public class VisitorProfilesCommandApiController {
         visitorProfilesCommandService.registerPhoneNumber(customer.getId(), request.getPhoneNumber());
         return ResponseEntity.ok().build();
     }
+
+    @PostMapping("/link-data")
+    public ResponseEntity<Void> linkData(
+            CustomerAuth customer,
+            @RequestBody VisitorProfilesLinkDataRequest request
+    ) {
+        VisitorProfilesLinkDataDto dto = request.toDto();
+        visitorProfilesCommandService.linkData(customer.getId(), dto);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/backend/src/main/java/com/stampcrush/backend/api/visitor/profile/VisitorProfilesLinkDataDto.java
+++ b/backend/src/main/java/com/stampcrush/backend/api/visitor/profile/VisitorProfilesLinkDataDto.java
@@ -1,0 +1,11 @@
+package com.stampcrush.backend.api.visitor.profile;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class VisitorProfilesLinkDataDto {
+
+    private final Long id;
+}

--- a/backend/src/main/java/com/stampcrush/backend/api/visitor/profile/VisitorProfilesLinkDataDto.java
+++ b/backend/src/main/java/com/stampcrush/backend/api/visitor/profile/VisitorProfilesLinkDataDto.java
@@ -7,5 +7,5 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class VisitorProfilesLinkDataDto {
 
-    private final Long id;
+    private final Long previousTemporaryCustomerId;
 }

--- a/backend/src/main/java/com/stampcrush/backend/api/visitor/profile/VisitorProfilesLinkDataRequest.java
+++ b/backend/src/main/java/com/stampcrush/backend/api/visitor/profile/VisitorProfilesLinkDataRequest.java
@@ -1,18 +1,15 @@
 package com.stampcrush.backend.api.visitor.profile;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
+@AllArgsConstructor
 public class VisitorProfilesLinkDataRequest {
 
     private Long id;
-
-    public VisitorProfilesLinkDataRequest(Long id) {
-        this.id = id;
-    }
-
-    public VisitorProfilesLinkDataRequest() {
-    }
 
     public VisitorProfilesLinkDataDto toDto() {
         return new VisitorProfilesLinkDataDto(id);

--- a/backend/src/main/java/com/stampcrush/backend/api/visitor/profile/VisitorProfilesLinkDataRequest.java
+++ b/backend/src/main/java/com/stampcrush/backend/api/visitor/profile/VisitorProfilesLinkDataRequest.java
@@ -1,0 +1,20 @@
+package com.stampcrush.backend.api.visitor.profile;
+
+import lombok.Getter;
+
+@Getter
+public class VisitorProfilesLinkDataRequest {
+
+    private Long id;
+
+    public VisitorProfilesLinkDataRequest(Long id) {
+        this.id = id;
+    }
+
+    public VisitorProfilesLinkDataRequest() {
+    }
+
+    public VisitorProfilesLinkDataDto toDto() {
+        return new VisitorProfilesLinkDataDto(id);
+    }
+}

--- a/backend/src/main/java/com/stampcrush/backend/application/visitor/profile/VisitorProfilesCommandService.java
+++ b/backend/src/main/java/com/stampcrush/backend/application/visitor/profile/VisitorProfilesCommandService.java
@@ -1,7 +1,9 @@
 package com.stampcrush.backend.application.visitor.profile;
 
 import com.stampcrush.backend.api.visitor.profile.VisitorProfilesLinkDataDto;
+import com.stampcrush.backend.auth.OAuthProvider;
 import com.stampcrush.backend.entity.user.Customer;
+import com.stampcrush.backend.entity.user.CustomerType;
 import com.stampcrush.backend.exception.BadRequestException;
 import com.stampcrush.backend.exception.CustomerNotFoundException;
 import com.stampcrush.backend.repository.user.CustomerRepository;
@@ -32,6 +34,28 @@ public class VisitorProfilesCommandService {
         }
     }
 
+    public void linkData(Long customerId, VisitorProfilesLinkDataDto dto) {
+        Customer registerCustomer = findExistingCustomer(customerId);
+        Customer temporaryCustomer = findExistingCustomer(dto.getPreviousTemporaryCustomerId());
+
+        String nickname = registerCustomer.getNickname();
+        String loginId = registerCustomer.getLoginId();
+        String encryptedPassword = registerCustomer.getEncryptedPassword();
+        String email = registerCustomer.getEmail();
+        OAuthProvider oAuthProvider = registerCustomer.getOAuthProvider();
+        Long oAuthId = registerCustomer.getOAuthId();
+
+        temporaryCustomer.setCustomerType(CustomerType.REGISTERED);
+        temporaryCustomer.setNickname(nickname);
+        temporaryCustomer.setLoginId(loginId);
+        temporaryCustomer.setEncryptedPassword(encryptedPassword);
+        temporaryCustomer.setEmail(email);
+        temporaryCustomer.setoAuthProvider(oAuthProvider);
+        temporaryCustomer.setoAuthId(oAuthId);
+
+        customerRepository.delete(registerCustomer);
+    }
+
     private Customer findExistingCustomer(Long customerId) {
         Optional<Customer> findCustomer = customerRepository.findById(customerId);
 
@@ -40,8 +64,5 @@ public class VisitorProfilesCommandService {
         }
 
         return findCustomer.get();
-    }
-
-    public void linkData(Long customerId, VisitorProfilesLinkDataDto dto) {
     }
 }

--- a/backend/src/main/java/com/stampcrush/backend/application/visitor/profile/VisitorProfilesCommandService.java
+++ b/backend/src/main/java/com/stampcrush/backend/application/visitor/profile/VisitorProfilesCommandService.java
@@ -1,5 +1,6 @@
 package com.stampcrush.backend.application.visitor.profile;
 
+import com.stampcrush.backend.api.visitor.profile.VisitorProfilesLinkDataDto;
 import com.stampcrush.backend.entity.user.Customer;
 import com.stampcrush.backend.exception.BadRequestException;
 import com.stampcrush.backend.exception.CustomerNotFoundException;
@@ -39,5 +40,8 @@ public class VisitorProfilesCommandService {
         }
 
         return findCustomer.get();
+    }
+
+    public void linkData(Long customerId, VisitorProfilesLinkDataDto dto) {
     }
 }

--- a/backend/src/main/java/com/stampcrush/backend/application/visitor/profile/VisitorProfilesCommandService.java
+++ b/backend/src/main/java/com/stampcrush/backend/application/visitor/profile/VisitorProfilesCommandService.java
@@ -3,7 +3,6 @@ package com.stampcrush.backend.application.visitor.profile;
 import com.stampcrush.backend.api.visitor.profile.VisitorProfilesLinkDataDto;
 import com.stampcrush.backend.auth.OAuthProvider;
 import com.stampcrush.backend.entity.user.Customer;
-import com.stampcrush.backend.entity.user.CustomerType;
 import com.stampcrush.backend.exception.BadRequestException;
 import com.stampcrush.backend.exception.CustomerNotFoundException;
 import com.stampcrush.backend.repository.user.CustomerRepository;
@@ -45,7 +44,7 @@ public class VisitorProfilesCommandService {
         OAuthProvider oAuthProvider = registerCustomer.getOAuthProvider();
         Long oAuthId = registerCustomer.getOAuthId();
 
-        temporaryCustomer.setCustomerType(CustomerType.REGISTERED);
+        temporaryCustomer.toRegisterCustomer();
         temporaryCustomer.setNickname(nickname);
         temporaryCustomer.setLoginId(loginId);
         temporaryCustomer.setEncryptedPassword(encryptedPassword);

--- a/backend/src/main/java/com/stampcrush/backend/auth/api/VisitorAuthController.java
+++ b/backend/src/main/java/com/stampcrush/backend/auth/api/VisitorAuthController.java
@@ -5,9 +5,9 @@ import com.stampcrush.backend.auth.application.VisitorAuthService;
 import com.stampcrush.backend.auth.request.OAuthRegisterCustomerCreateRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
 
 @RequiredArgsConstructor
 @RestController
@@ -16,16 +16,24 @@ public class VisitorAuthController {
 
     private final VisitorAuthService visitorAuthService;
 
-    @PostMapping("/test/token")
-    public ResponseEntity<AuthTokensResponse> authorizeUser(
-            OAuthRegisterCustomerCreateRequest request
+    @PostMapping("/temporary/test")
+    public ResponseEntity<Void> joinTemporaryCustomer(
+            @RequestParam("phone-number") String phoneNumber
+    ) {
+        Long id = visitorAuthService.joinTemporaryCustomer(phoneNumber);
+        return ResponseEntity.created(URI.create("/customers/" + id)).build();
+    }
+
+    @PostMapping("/register/test/token")
+    public ResponseEntity<AuthTokensResponse> joinRegisterCustomer(
+            @RequestBody OAuthRegisterCustomerCreateRequest request
     ) {
         return ResponseEntity.ok().body(
                 visitorAuthService.join(
                         request.getNickname(),
                         request.getEmail(),
-                        request.getOAuthProvider(),
-                        request.getOAuthId()
+                        request.getoAuthProvider(),
+                        request.getoAuthId()
                 )
         );
     }

--- a/backend/src/main/java/com/stampcrush/backend/auth/application/VisitorAuthService.java
+++ b/backend/src/main/java/com/stampcrush/backend/auth/application/VisitorAuthService.java
@@ -27,4 +27,12 @@ public class VisitorAuthService {
         Long customerId = savedCustomer.getId();
         return authTokensGenerator.generate(customerId);
     }
+
+    public Long joinTemporaryCustomer(String phoneNumber) {
+        Customer customer = Customer.temporaryCustomerBuilder()
+                .phoneNumber(phoneNumber)
+                .build();
+
+        return customerRepository.save(customer).getId();
+    }
 }

--- a/backend/src/main/java/com/stampcrush/backend/auth/request/OAuthRegisterCustomerCreateRequest.java
+++ b/backend/src/main/java/com/stampcrush/backend/auth/request/OAuthRegisterCustomerCreateRequest.java
@@ -1,15 +1,29 @@
 package com.stampcrush.backend.auth.request;
 
 import com.stampcrush.backend.auth.OAuthProvider;
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
-@Getter
 public class OAuthRegisterCustomerCreateRequest {
 
     private final String nickname;
     private final String email;
     private final OAuthProvider oAuthProvider;
     private final Long oAuthId;
+
+    public String getNickname() {
+        return nickname;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public OAuthProvider getoAuthProvider() {
+        return oAuthProvider;
+    }
+
+    public Long getoAuthId() {
+        return oAuthId;
+    }
 }

--- a/backend/src/main/java/com/stampcrush/backend/entity/user/Customer.java
+++ b/backend/src/main/java/com/stampcrush/backend/entity/user/Customer.java
@@ -3,11 +3,7 @@ package com.stampcrush.backend.entity.user;
 import com.stampcrush.backend.auth.OAuthProvider;
 import com.stampcrush.backend.exception.CustomerBadRequestException;
 import com.stampcrush.backend.exception.CustomerUnAuthorizationException;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -144,7 +140,7 @@ public class Customer {
         this.oAuthId = oAuthId;
     }
 
-    public void setCustomerType(CustomerType customerType) {
-        this.customerType = customerType;
+    public void toRegisterCustomer() {
+        this.customerType = REGISTERED;
     }
 }

--- a/backend/src/main/java/com/stampcrush/backend/entity/user/Customer.java
+++ b/backend/src/main/java/com/stampcrush/backend/entity/user/Customer.java
@@ -115,4 +115,36 @@ public class Customer {
             throw new CustomerUnAuthorizationException("아이디와 패스워드를 다시 확인 후 로그인해주세요.");
         }
     }
+
+    public void setNickname(String nickname) {
+        this.nickname = nickname;
+    }
+
+    public void setPhoneNumber(String phoneNumber) {
+        this.phoneNumber = phoneNumber;
+    }
+
+    public void setLoginId(String loginId) {
+        this.loginId = loginId;
+    }
+
+    public void setEncryptedPassword(String encryptedPassword) {
+        this.encryptedPassword = encryptedPassword;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public void setoAuthProvider(OAuthProvider oAuthProvider) {
+        this.oAuthProvider = oAuthProvider;
+    }
+
+    public void setoAuthId(Long oAuthId) {
+        this.oAuthId = oAuthId;
+    }
+
+    public void setCustomerType(CustomerType customerType) {
+        this.customerType = customerType;
+    }
 }

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/VisitorLinkDataAcceptanceTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/VisitorLinkDataAcceptanceTest.java
@@ -1,0 +1,57 @@
+package com.stampcrush.backend.acceptance;
+
+import com.stampcrush.backend.api.visitor.profile.VisitorProfilesLinkDataRequest;
+import com.stampcrush.backend.auth.OAuthProvider;
+import com.stampcrush.backend.auth.application.util.AuthTokensGenerator;
+import com.stampcrush.backend.auth.request.OAuthRegisterCustomerCreateRequest;
+import com.stampcrush.backend.entity.user.Customer;
+import com.stampcrush.backend.repository.user.CustomerRepository;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+
+import static com.stampcrush.backend.acceptance.step.VisitorJoinStep.임시_회원_가입_요청하고_아이디_반환;
+import static com.stampcrush.backend.acceptance.step.VisitorJoinStep.회원_가입_요청하고_액세스_토큰_반환;
+import static com.stampcrush.backend.acceptance.step.VisitorLinkDataStep.회원_데이터_연동_요청;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+public class VisitorLinkDataAcceptanceTest extends AcceptanceTest {
+
+    private static final OAuthRegisterCustomerCreateRequest O_AUTH_REGISTER_CUSTOMER_CREATE_REQUEST = new OAuthRegisterCustomerCreateRequest(
+            "깃짱",
+            "gitchan@gmail.com",
+            OAuthProvider.KAKAO,
+            1235436L
+    );
+
+    @Autowired
+    private CustomerRepository customerRepository;
+
+    @Autowired
+    private AuthTokensGenerator authTokensGenerator;
+
+    @Test
+    void 기존_임시회원의_데이터와_연동한다() {
+        Long temporaryCustomerId = 임시_회원_가입_요청하고_아이디_반환("01038626099");
+        Customer temporaryCustomer = customerRepository.findById(temporaryCustomerId).get();
+
+        OAuthRegisterCustomerCreateRequest registerCustomerCreateRequest = O_AUTH_REGISTER_CUSTOMER_CREATE_REQUEST;
+        String accessToken = 회원_가입_요청하고_액세스_토큰_반환(registerCustomerCreateRequest);
+        Long registerCustomerId = authTokensGenerator.extractMemberId(accessToken);
+
+        ExtractableResponse<Response> response = 회원_데이터_연동_요청(accessToken, new VisitorProfilesLinkDataRequest(temporaryCustomer.getId()));
+
+        Customer linkedCustomer = customerRepository.findById(temporaryCustomerId).get();
+
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
+                () -> assertThat(linkedCustomer.getNickname()).isEqualTo(registerCustomerCreateRequest.getNickname()),
+                () -> assertThat(linkedCustomer.getOAuthProvider()).isEqualTo(registerCustomerCreateRequest.getoAuthProvider()),
+                () -> assertThat(linkedCustomer.getOAuthId()).isEqualTo(registerCustomerCreateRequest.getoAuthId()),
+                () -> assertThat(customerRepository.findById(registerCustomerId)).isEmpty()
+        );
+    }
+}

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/step/VisitorJoinStep.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/step/VisitorJoinStep.java
@@ -1,12 +1,33 @@
 package com.stampcrush.backend.acceptance.step;
 
 import com.stampcrush.backend.auth.request.OAuthRegisterCustomerCreateRequest;
+import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 
 import static io.restassured.RestAssured.given;
+import static io.restassured.http.ContentType.JSON;
 
 public class VisitorJoinStep {
+
+    public static Long 임시_회원_가입_요청하고_아이디_반환(String phoneNumber) {
+        ExtractableResponse<Response> response = 임시_회원_가입_요청(phoneNumber);
+        String location = response.header("Location");
+        return Long.valueOf(location.split("/")[2]);
+    }
+
+    public static ExtractableResponse<Response> 임시_회원_가입_요청(String phoneNumber) {
+        return RestAssured.given()
+                .log().all()
+                .contentType(JSON)
+
+                .when()
+                .post("/api/login/temporary/test?phone-number=" + phoneNumber)
+
+                .then()
+                .log().all()
+                .extract();
+    }
 
     public static String 회원_가입_요청하고_액세스_토큰_반환(OAuthRegisterCustomerCreateRequest request) {
         ExtractableResponse<Response> response = 회원_가입_요청(request);
@@ -16,10 +37,11 @@ public class VisitorJoinStep {
     public static ExtractableResponse<Response> 회원_가입_요청(OAuthRegisterCustomerCreateRequest request) {
         return given()
                 .log().all()
+                .contentType(JSON)
                 .body(request)
 
                 .when()
-                .post("/api/login/test/token")
+                .post("/api/login/register/test/token")
 
                 .then()
                 .log().all()

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/step/VisitorLinkDataStep.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/step/VisitorLinkDataStep.java
@@ -1,0 +1,28 @@
+package com.stampcrush.backend.acceptance.step;
+
+import com.stampcrush.backend.api.visitor.profile.VisitorProfilesLinkDataRequest;
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+
+import static io.restassured.http.ContentType.JSON;
+
+public class VisitorLinkDataStep {
+
+    public static ExtractableResponse<Response> 회원_데이터_연동_요청(String accessToken, VisitorProfilesLinkDataRequest request) {
+        return RestAssured.given()
+                .log().all()
+                .contentType(JSON)
+                .auth().preemptive()
+                .oauth2(accessToken)
+                .body(request)
+
+                .when()
+                .post("/api/profiles/link-data")
+
+                .then()
+                .log().all()
+                .extract();
+    }
+}
+

--- a/backend/src/test/java/com/stampcrush/backend/api/visitor/profile/VisitorProfilesCommandApiControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/visitor/profile/VisitorProfilesCommandApiControllerTest.java
@@ -14,8 +14,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
 
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
@@ -63,5 +62,21 @@ class VisitorProfilesCommandApiControllerTest extends ControllerSliceTest {
                                 .contentType(APPLICATION_JSON)
                 )
                 .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void 데이터_연동에_성공하면_200_상태코드를_반환한다() throws Exception {
+        doNothing()
+                .when(visitorProfilesCommandService)
+                .linkData(eq(null), any());
+
+        VisitorProfilesLinkDataRequest request = new VisitorProfilesLinkDataRequest(1L);
+
+        mockMvc.perform(
+                        post("/api/profiles/link-data")
+                                .contentType(APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request))
+                )
+                .andExpect(status().isOk());
     }
 }


### PR DESCRIPTION
## 주요 변경사항

- 회원 데이터 연동 API 작성했습니다.
- 테스트 용도로 임시 회원가입 API도 생성했습니다. 

구체적인 플로우가 약간 어려우면, 제가 [엄청 자세히 적어놓은 블로그 글](https://engineerinsight.tistory.com/193#%E2%9C%94%20API%20%EB%AA%85%EC%84%B8-1) 있으니 참고해주세요! 

## 구현 방법

![image](https://github.com/woowacourse-teams/2023-stamp-crush/assets/107979804/a39d0c49-7ead-43ed-89df-581d3e466410)


- request dto에서 연동할 register customer id를 받음.
- JPA 자동 변경 감지 통해서 temporary customer의 nickname, ... oauth 관련 칼럼, customer type 변경함.
- 현재 로그인되어 있는 register customer 회원 삭제해버림.
    - 로컬에서는 로그인하고 access token 받는게 아직 안돼서 아직 테스트를 못해봤는데, 현재 로그인되어 있는 회원을 삭제해 버리니깐, 연동 이후에 바로 로그아웃 당할 것 같아요. 다시 로그인하면 그때부터는 연동된 customer를 찾게 될 것 같아요.
    - 이거 안된다면 조금 회의가 필요함...! 

## 리뷰어에게...

- 서비스 코드에서 뭐하는지 최대한 명확하게 하려고 메서드 분리 일부러 안했어요! 

## 관련 이슈

closes #623 

## 체크리스트

- [ ] `reviewers` 설정
- [ ] `label` 설정
- [ ] `milestone` 설정
