### PR TITLE
[BE] feat: 사장님 API 에 카페 인가에 대한 코드를 추가한다

### DIFF
--- a/backend/src/main/java/com/stampcrush/backend/api/manager/coupon/ManagerCouponCommandApiController.java
+++ b/backend/src/main/java/com/stampcrush/backend/api/manager/coupon/ManagerCouponCommandApiController.java
@@ -25,7 +25,7 @@ public class ManagerCouponCommandApiController {
             @RequestBody @Valid CouponCreateRequest request,
             @PathVariable("customerId") Long customerId
     ) {
-        Long couponId = managerCouponCommandService.createCoupon(request.getCafeId(), customerId);
+        Long couponId = managerCouponCommandService.createCoupon(owner.getId(), request.getCafeId(), customerId);
         return ResponseEntity.status(HttpStatus.CREATED).body(new CouponCreateResponse(couponId));
     }
 

--- a/backend/src/main/java/com/stampcrush/backend/api/manager/reward/ManagerRewardCommandApiController.java
+++ b/backend/src/main/java/com/stampcrush/backend/api/manager/reward/ManagerRewardCommandApiController.java
@@ -24,7 +24,7 @@ public class ManagerRewardCommandApiController {
             @RequestBody @Valid RewardUsedUpdateRequest request
     ) {
         RewardUsedUpdateDto rewardUsedUpdateDto = new RewardUsedUpdateDto(rewardId, customerId, request.getCafeId(), request.getUsed());
-        managerRewardCommandService.useReward(rewardUsedUpdateDto);
+        managerRewardCommandService.useReward(owner.getId(), rewardUsedUpdateDto);
         return ResponseEntity.ok().build();
     }
 }

--- a/backend/src/main/java/com/stampcrush/backend/api/manager/reward/response/RewardsFindResponse.java
+++ b/backend/src/main/java/com/stampcrush/backend/api/manager/reward/response/RewardsFindResponse.java
@@ -1,13 +1,16 @@
 package com.stampcrush.backend.api.manager.reward.response;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
 
 import java.util.List;
 
 @Getter
-@RequiredArgsConstructor
+@AllArgsConstructor
+@NoArgsConstructor
 public class RewardsFindResponse {
 
-    private final List<RewardFindResponse> rewards;
+    private List<RewardFindResponse> rewards;
 }

--- a/backend/src/main/java/com/stampcrush/backend/application/manager/coupon/ManagerCouponCommandService.java
+++ b/backend/src/main/java/com/stampcrush/backend/application/manager/coupon/ManagerCouponCommandService.java
@@ -14,6 +14,7 @@ import com.stampcrush.backend.entity.user.Owner;
 import com.stampcrush.backend.entity.visithistory.VisitHistory;
 import com.stampcrush.backend.exception.CafeNotFoundException;
 import com.stampcrush.backend.exception.CustomerNotFoundException;
+import com.stampcrush.backend.exception.OwnerNotFoundException;
 import com.stampcrush.backend.repository.cafe.CafeCouponDesignRepository;
 import com.stampcrush.backend.repository.cafe.CafePolicyRepository;
 import com.stampcrush.backend.repository.cafe.CafeRepository;
@@ -50,9 +51,14 @@ public class ManagerCouponCommandService {
     private record CustomerCoupons(Customer customer, List<Coupon> coupons) {
     }
 
-    public Long createCoupon(Long cafeId, Long customerId) {
-        Customer customer = findCustomerById(customerId);
+    public Long createCoupon(Long ownerId, Long cafeId, Long customerId) {
         Cafe cafe = findCafeById(cafeId);
+        Owner owner = ownerRepository.findById(ownerId)
+                .orElseThrow(() -> new OwnerNotFoundException("회원가입을 먼저 진행해주세요"));
+
+        cafe.validateOwnership(owner);
+
+        Customer customer = findCustomerById(customerId);
         CafePolicy cafePolicy = findCafePolicy(cafe);
         CafeCouponDesign cafeCouponDesign = findCafeCouponDesign(cafe);
         List<Coupon> existCoupons = couponRepository.findByCafeAndCustomerAndStatus(cafe, customer, CouponStatus.ACCUMULATING);

--- a/backend/src/main/java/com/stampcrush/backend/application/manager/reward/ManagerRewardCommandService.java
+++ b/backend/src/main/java/com/stampcrush/backend/application/manager/reward/ManagerRewardCommandService.java
@@ -4,9 +4,12 @@ import com.stampcrush.backend.application.manager.reward.dto.RewardUsedUpdateDto
 import com.stampcrush.backend.entity.cafe.Cafe;
 import com.stampcrush.backend.entity.reward.Reward;
 import com.stampcrush.backend.entity.user.Customer;
+import com.stampcrush.backend.entity.user.Owner;
+import com.stampcrush.backend.exception.OwnerNotFoundException;
 import com.stampcrush.backend.repository.cafe.CafeRepository;
 import com.stampcrush.backend.repository.reward.RewardRepository;
 import com.stampcrush.backend.repository.user.CustomerRepository;
+import com.stampcrush.backend.repository.user.OwnerRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,14 +22,20 @@ public class ManagerRewardCommandService {
     private final RewardRepository rewardRepository;
     private final CustomerRepository customerRepository;
     private final CafeRepository cafeRepository;
+    private final OwnerRepository ownerRepository;
 
-    public void useReward(RewardUsedUpdateDto rewardUsedUpdateDto) {
+    public void useReward(Long ownerId, RewardUsedUpdateDto rewardUsedUpdateDto) {
         Reward reward = rewardRepository.findById(rewardUsedUpdateDto.getRewardId())
                 .orElseThrow(IllegalArgumentException::new);
         Customer customer = customerRepository.findById(rewardUsedUpdateDto.getCustomerId())
                 .orElseThrow(IllegalArgumentException::new);
         Cafe cafe = cafeRepository.findById(rewardUsedUpdateDto.getCafeId())
                 .orElseThrow(IllegalArgumentException::new);
+        Owner owner = ownerRepository.findById(ownerId)
+                .orElseThrow(() -> new OwnerNotFoundException("회원가입을 먼저 진행해주세요"));
+
+        cafe.validateOwnership(owner);
+
         reward.useReward(customer, cafe);
     }
 }

--- a/backend/src/main/java/com/stampcrush/backend/config/WebMvcConfig.java
+++ b/backend/src/main/java/com/stampcrush/backend/config/WebMvcConfig.java
@@ -4,6 +4,7 @@ import com.stampcrush.backend.auth.application.util.AuthTokensGenerator;
 import com.stampcrush.backend.config.interceptor.BasicAuthInterceptor;
 import com.stampcrush.backend.config.resolver.CustomerArgumentResolver;
 import com.stampcrush.backend.config.resolver.OwnerArgumentResolver;
+import com.stampcrush.backend.repository.cafe.CafeRepository;
 import com.stampcrush.backend.repository.user.CustomerRepository;
 import com.stampcrush.backend.repository.user.OwnerRepository;
 import lombok.RequiredArgsConstructor;
@@ -22,6 +23,7 @@ public class WebMvcConfig implements WebMvcConfigurer {
     private final OwnerRepository ownerRepository;
     private final AuthTokensGenerator authTokensGenerator;
     private final CustomerRepository customerRepository;
+    private final CafeRepository cafeRepository;
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
@@ -38,7 +40,7 @@ public class WebMvcConfig implements WebMvcConfigurer {
 
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
-        resolvers.add(new OwnerArgumentResolver(ownerRepository, authTokensGenerator));
+        resolvers.add(new OwnerArgumentResolver(ownerRepository, cafeRepository, authTokensGenerator));
         resolvers.add(new CustomerArgumentResolver(customerRepository, authTokensGenerator));
     }
 }

--- a/backend/src/main/java/com/stampcrush/backend/config/resolver/OwnerArgumentResolver.java
+++ b/backend/src/main/java/com/stampcrush/backend/config/resolver/OwnerArgumentResolver.java
@@ -46,7 +46,6 @@ public class OwnerArgumentResolver implements HandlerMethodArgumentResolver {
             String[] credentials = getCredentials(authorization);
 
             String loginId = credentials[0];
-            // 비밀번호 암호화는 어디서 해야하는지 ..
             String encryptedPassword = credentials[1];
 
             Owner owner = ownerRepository.findByLoginId(loginId).orElseThrow(() -> new OwnerUnAuthorizationException("회원정보가 잘못되었습니다."));
@@ -56,7 +55,6 @@ public class OwnerArgumentResolver implements HandlerMethodArgumentResolver {
 
             validateOwnerShipWhenQueryString(webRequest, owner);
             validateOwnerShipWhenPathVariable(request, owner);
-
 
             return new OwnerAuth(owner.getId());
         }

--- a/backend/src/main/java/com/stampcrush/backend/config/resolver/OwnerArgumentResolver.java
+++ b/backend/src/main/java/com/stampcrush/backend/config/resolver/OwnerArgumentResolver.java
@@ -56,6 +56,8 @@ public class OwnerArgumentResolver implements HandlerMethodArgumentResolver {
             HttpServletRequest request = webRequest.getNativeRequest(HttpServletRequest.class);
 
             validateOwnerShipWhenQueryString(request, owner);
+            validateOwnerShipWhenPathVariable(request, owner);
+
 
             return new OwnerAuth(owner.getId());
         }
@@ -69,6 +71,7 @@ public class OwnerArgumentResolver implements HandlerMethodArgumentResolver {
             HttpServletRequest request = webRequest.getNativeRequest(HttpServletRequest.class);
 
             validateOwnerShipWhenQueryString(request, owner);
+            validateOwnerShipWhenPathVariable(request, owner);
 
             return new OwnerAuth(owner.getId());
         }
@@ -99,6 +102,24 @@ public class OwnerArgumentResolver implements HandlerMethodArgumentResolver {
 
                 cafe.validateOwnership(owner);
             }
+        }
+    }
+
+    private void validateOwnerShipWhenPathVariable(HttpServletRequest request, Owner owner) {
+        String requestUri = request.getRequestURI();
+
+        String[] uriParts = requestUri.split("/");
+        Long cafeId = null;
+        for (int i = 0; i < uriParts.length; i++) {
+            if ("cafes".equals(uriParts[i]) && i + 1 < uriParts.length) {
+                cafeId = Long.parseLong(uriParts[i + 1]);
+                break;
+            }
+        }
+        if (cafeId != null) {
+            Cafe cafe = cafeRepository.findById(cafeId).orElseThrow(() -> new CafeNotFoundException("카페정보가 없습니다"));
+
+            cafe.validateOwnership(owner);
         }
     }
 }

--- a/backend/src/main/java/com/stampcrush/backend/config/resolver/OwnerArgumentResolver.java
+++ b/backend/src/main/java/com/stampcrush/backend/config/resolver/OwnerArgumentResolver.java
@@ -14,12 +14,11 @@ import org.springframework.core.MethodParameter;
 import org.springframework.http.HttpHeaders;
 import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
 import javax.naming.AuthenticationException;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 @RequiredArgsConstructor
 public class OwnerArgumentResolver implements HandlerMethodArgumentResolver {
@@ -55,7 +54,7 @@ public class OwnerArgumentResolver implements HandlerMethodArgumentResolver {
 
             HttpServletRequest request = webRequest.getNativeRequest(HttpServletRequest.class);
 
-            validateOwnerShipWhenQueryString(request, owner);
+            validateOwnerShipWhenQueryString(webRequest, owner);
             validateOwnerShipWhenPathVariable(request, owner);
 
 
@@ -70,7 +69,7 @@ public class OwnerArgumentResolver implements HandlerMethodArgumentResolver {
 
             HttpServletRequest request = webRequest.getNativeRequest(HttpServletRequest.class);
 
-            validateOwnerShipWhenQueryString(request, owner);
+            validateOwnerShipWhenQueryString(webRequest, owner);
             validateOwnerShipWhenPathVariable(request, owner);
 
             return new OwnerAuth(owner.getId());
@@ -88,20 +87,14 @@ public class OwnerArgumentResolver implements HandlerMethodArgumentResolver {
         return decodedString.split(DELIMITER);
     }
 
-    private void validateOwnerShipWhenQueryString(HttpServletRequest request, Owner owner) {
-        String queryString = request.getQueryString();
+    private void validateOwnerShipWhenQueryString(WebRequest request, Owner owner) {
+        String parameter = request.getParameter("cafe-id");
 
-        if (queryString != null) {
-            Pattern pattern = Pattern.compile("cafe-id=([0-9]+)");
-            Matcher matcher = pattern.matcher(queryString);
+        if (parameter != null) {
+            Long cafeId = Long.parseLong(parameter);
 
-            if (matcher.find()) {
-                Long cafeId = Long.parseLong(matcher.group(1));
-
-                Cafe cafe = cafeRepository.findById(cafeId).orElseThrow(() -> new CafeNotFoundException("카페정보가 없습니다"));
-
-                cafe.validateOwnership(owner);
-            }
+            Cafe cafe = cafeRepository.findById(cafeId).orElseThrow(() -> new CafeNotFoundException("카페정보가 없습니다"));
+            cafe.validateOwnership(owner);
         }
     }
 

--- a/backend/src/main/java/com/stampcrush/backend/entity/cafe/Cafe.java
+++ b/backend/src/main/java/com/stampcrush/backend/entity/cafe/Cafe.java
@@ -2,6 +2,7 @@ package com.stampcrush.backend.entity.cafe;
 
 import com.stampcrush.backend.entity.baseentity.BaseDate;
 import com.stampcrush.backend.entity.user.Owner;
+import com.stampcrush.backend.exception.OwnerUnAuthorizationException;
 import jakarta.persistence.*;
 import lombok.Getter;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -90,5 +91,11 @@ public class Cafe extends BaseDate {
         this.closeTime = closeTime;
         this.telephoneNumber = telephoneNumber;
         this.cafeImageUrl = cafeImageUrl;
+    }
+
+    public void validateOwnership(Owner owner) {
+        if (!this.owner.equals(owner)) {
+            throw new OwnerUnAuthorizationException("카페에 대한 권한이 없습니다");
+        }
     }
 }

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/ManagerCafeCommandAcceptanceTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/ManagerCafeCommandAcceptanceTest.java
@@ -1,0 +1,57 @@
+package com.stampcrush.backend.acceptance;
+
+
+import com.stampcrush.backend.api.manager.cafe.request.CafeCreateRequest;
+import com.stampcrush.backend.api.manager.cafe.request.CafeUpdateRequest;
+import com.stampcrush.backend.entity.user.Owner;
+import com.stampcrush.backend.repository.user.OwnerRepository;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.LocalTime;
+
+import static com.stampcrush.backend.acceptance.step.ManagerCafeCreateStep.카페_생성_요청하고_아이디_반환;
+import static com.stampcrush.backend.acceptance.step.ManagerCafeUpdateStep.카페_정보_업데이트_요청;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+public class ManagerCafeCommandAcceptanceTest extends AcceptanceTest {
+
+    @Autowired
+    private OwnerRepository ownerRepository;
+
+    @Test
+    void 카페_사장이_자기_카페_정보_업데이트() {
+        // given
+        Owner owner = ownerRepository.save(new Owner("jena", "jenaId", "jenaPw", "01012345678"));
+        CafeCreateRequest cafeCreateRequest = new CafeCreateRequest("woowacafe", "road", "detail", "1234");
+        CafeUpdateRequest cafeUpdateRequest = new CafeUpdateRequest("hi", LocalTime.MIDNIGHT, LocalTime.NOON, "010123421253", "cafeimage");
+
+        Long cafeId = 카페_생성_요청하고_아이디_반환(owner, cafeCreateRequest);
+
+        // when
+        ExtractableResponse<Response> response = 카페_정보_업데이트_요청(owner, cafeUpdateRequest, cafeId);
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(200);
+    }
+
+    @Test
+    void 카페_사장이_자기_카페_아닌_카페_정보_업데이트하면_에러_발생() {
+        // given
+        Owner owner = ownerRepository.save(new Owner("jena", "jenaId", "jenaPw", "01012345678"));
+        Owner notOwner = ownerRepository.save(new Owner("notOwner", "id", "pw", "1234567890"));
+
+        CafeCreateRequest cafeCreateRequest = new CafeCreateRequest("woowacafe", "road", "detail", "1234");
+        CafeUpdateRequest cafeUpdateRequest = new CafeUpdateRequest("hi", LocalTime.MIDNIGHT, LocalTime.NOON, "010123421253", "cafeimage");
+
+        Long cafeId = 카페_생성_요청하고_아이디_반환(owner, cafeCreateRequest);
+
+        // when
+        ExtractableResponse<Response> response = 카페_정보_업데이트_요청(notOwner, cafeUpdateRequest, cafeId);
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(401);
+    }
+}

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/ManagerCafeCouponSettingCommandUpdateAcceptanceTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/ManagerCafeCouponSettingCommandUpdateAcceptanceTest.java
@@ -3,14 +3,12 @@ package com.stampcrush.backend.acceptance;
 import com.stampcrush.backend.entity.cafe.Cafe;
 import com.stampcrush.backend.entity.cafe.CafeCouponDesign;
 import com.stampcrush.backend.entity.cafe.CafePolicy;
-import com.stampcrush.backend.entity.cafe.CafeStampCoordinate;
-import com.stampcrush.backend.fixture.OwnerFixture;
+import com.stampcrush.backend.entity.user.Owner;
 import com.stampcrush.backend.repository.cafe.CafeCouponDesignRepository;
 import com.stampcrush.backend.repository.cafe.CafePolicyRepository;
 import com.stampcrush.backend.repository.cafe.CafeRepository;
 import com.stampcrush.backend.repository.cafe.CafeStampCoordinateRepository;
 import com.stampcrush.backend.repository.user.OwnerRepository;
-import io.restassured.http.ContentType;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import org.junit.jupiter.api.Test;
@@ -18,10 +16,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 
 import static com.stampcrush.backend.acceptance.step.ManagerCafeCouponSettingUpdateStep.CAFE_COUPON_SETTING_UPDATE_REQUEST;
+import static com.stampcrush.backend.acceptance.step.ManagerCafeCouponSettingUpdateStep.카페_쿠폰_정책_수정_요청;
 import static com.stampcrush.backend.fixture.CafeFixture.cafeOfSavedOwner;
 import static com.stampcrush.backend.fixture.CouponDesignFixture.cafeCouponDesignOfSavedCafe;
 import static com.stampcrush.backend.fixture.CouponPolicyFixture.cafePolicyOfSavedCafe;
-import static io.restassured.RestAssured.given;
+import static com.stampcrush.backend.fixture.OwnerFixture.GITCHAN;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
@@ -45,35 +44,12 @@ public class ManagerCafeCouponSettingCommandUpdateAcceptanceTest extends Accepta
     @Test
     void 카페_사장은_쿠폰_세팅에_대한_내용을_수정할_수_있다() {
         // given, when
-        Cafe savedCafe = cafeRepository.save(cafeOfSavedOwner(ownerRepository.save(OwnerFixture.GITCHAN)));
+        Cafe savedCafe = cafeRepository.save(cafeOfSavedOwner(ownerRepository.save(GITCHAN)));
 
         CafePolicy savedCafePolicy = cafePolicyRepository.save(cafePolicyOfSavedCafe(savedCafe));
         CafeCouponDesign savedCafeCouponDesign = cafeCouponDesignRepository.save(cafeCouponDesignOfSavedCafe(savedCafe));
 
-        CafeStampCoordinate savedCafeStampCoordinate1 = cafeStampCoordinateRepository.save(
-                new CafeStampCoordinate(
-                        1, 1, 1, savedCafeCouponDesign
-                )
-        );
-
-        CafeStampCoordinate savedCafeStampCoordinate2 = cafeStampCoordinateRepository.save(
-                new CafeStampCoordinate(
-                        1, 2, 1, savedCafeCouponDesign
-                )
-        );
-
-        ExtractableResponse<Response> response = given()
-                .log().all()
-                .contentType(ContentType.JSON)
-                .auth().preemptive().basic(OwnerFixture.GITCHAN.getLoginId(), OwnerFixture.GITCHAN.getEncryptedPassword())
-                .body(CAFE_COUPON_SETTING_UPDATE_REQUEST)
-
-                .when()
-                .post("/api/admin/coupon-setting?cafe-id=" + savedCafe.getId())
-
-                .then()
-                .log().all()
-                .extract();
+        ExtractableResponse<Response> response = 카페_쿠폰_정책_수정_요청(CAFE_COUPON_SETTING_UPDATE_REQUEST, GITCHAN, savedCafe.getId());
 
         // then
         assertAll(
@@ -83,5 +59,17 @@ public class ManagerCafeCouponSettingCommandUpdateAcceptanceTest extends Accepta
                 () -> assertThat(cafePolicyRepository.findById(savedCafePolicy.getId())).isEmpty(),
                 () -> assertThat(cafePolicyRepository.findByCafe(savedCafe)).isNotEmpty()
         );
+    }
+
+    @Test
+    void 카페_사장은_자신의_카페가_아니면_쿠폰_세팅에_대한_내용을_수정할_수_없다() {
+        // given, when
+        Cafe savedCafe = cafeRepository.save(cafeOfSavedOwner(ownerRepository.save(GITCHAN)));
+        Owner notOwner = ownerRepository.save(new Owner("notowner", "id", "pw", "01029347382"));
+
+        ExtractableResponse<Response> response = 카페_쿠폰_정책_수정_요청(CAFE_COUPON_SETTING_UPDATE_REQUEST, notOwner, savedCafe.getId());
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(401);
     }
 }

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/ManagerCafeCouponSettingFindAcceptanceTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/ManagerCafeCouponSettingFindAcceptanceTest.java
@@ -1,0 +1,105 @@
+package com.stampcrush.backend.acceptance;
+
+import com.stampcrush.backend.api.manager.cafe.response.CafeCouponSettingFindResponse;
+import com.stampcrush.backend.api.manager.coupon.request.CouponCreateRequest;
+import com.stampcrush.backend.entity.user.Customer;
+import com.stampcrush.backend.entity.user.Owner;
+import com.stampcrush.backend.fixture.CustomerFixture;
+import com.stampcrush.backend.fixture.OwnerFixture;
+import com.stampcrush.backend.repository.cafe.CafeRepository;
+import com.stampcrush.backend.repository.user.CustomerRepository;
+import com.stampcrush.backend.repository.user.OwnerRepository;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static com.stampcrush.backend.acceptance.step.ManagerCafeCouponSettingFindStep.카페의_현재_쿠폰_디자인_정책_조회_요청;
+import static com.stampcrush.backend.acceptance.step.ManagerCafeCouponSettingFindStep.쿠폰이_발급될때의_쿠폰_디자인_조회_요청;
+import static com.stampcrush.backend.acceptance.step.ManagerCafeCreateStep.CAFE_CREATE_REQUEST;
+import static com.stampcrush.backend.acceptance.step.ManagerCafeCreateStep.카페_생성_요청하고_아이디_반환;
+import static com.stampcrush.backend.acceptance.step.ManagerCouponCreateStep.쿠폰_생성_요청하고_아이디_반환;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+class ManagerCafeCouponSettingFindAcceptanceTest extends AcceptanceTest {
+
+    @Autowired
+    private OwnerRepository ownerRepository;
+
+    @Autowired
+    private CustomerRepository customerRepository;
+
+    @Test
+    void 카페_사장은_쿠폰이_발급되었을_때_쿠폰_디자인_조회_가능하다() {
+        // given
+        Owner owner = ownerRepository.save(OwnerFixture.JENA);
+        Customer customer = customerRepository.save(CustomerFixture.REGISTER_CUSTOMER_JENA);
+
+        Long cafeId = 카페_생성_요청하고_아이디_반환(owner, CAFE_CREATE_REQUEST);
+
+
+        CouponCreateRequest couponCreateRequest = new CouponCreateRequest(cafeId);
+        Long couponId = 쿠폰_생성_요청하고_아이디_반환(owner, couponCreateRequest, customer.getId());
+
+
+        // when
+        ExtractableResponse<Response> response = 쿠폰이_발급될때의_쿠폰_디자인_조회_요청(owner, cafeId, couponId);
+        CafeCouponSettingFindResponse cafeCouponSettingFindResponse = response.body().as(CafeCouponSettingFindResponse.class);
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(200);
+    }
+
+    @Test
+    void 내_카페에서_발급한_쿠폰이_아니면_쿠폰이_발급되었을때의_디자인_조회_불가능하다() {
+        // given
+        Owner owner = ownerRepository.save(OwnerFixture.JENA);
+        Owner notOwner = ownerRepository.save(new Owner("notowner", "id", "pw", "01012349876"));
+
+        Customer customer = customerRepository.save(CustomerFixture.REGISTER_CUSTOMER_JENA);
+
+        Long cafeId = 카페_생성_요청하고_아이디_반환(owner, CAFE_CREATE_REQUEST);
+
+
+        CouponCreateRequest couponCreateRequest = new CouponCreateRequest(cafeId);
+        Long couponId = 쿠폰_생성_요청하고_아이디_반환(owner, couponCreateRequest, customer.getId());
+
+        // when
+        ExtractableResponse<Response> response = 쿠폰이_발급될때의_쿠폰_디자인_조회_요청(notOwner, cafeId, couponId);
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(401);
+    }
+
+    @Test
+    void 카페_사장은_카페의_현재_쿠폰_디자인_정책_조회_가능하다() {
+        // given
+        Owner owner = ownerRepository.save(OwnerFixture.JENA);
+        Customer customer = customerRepository.save(CustomerFixture.REGISTER_CUSTOMER_JENA);
+
+        Long cafeId = 카페_생성_요청하고_아이디_반환(owner, CAFE_CREATE_REQUEST);
+
+        // when
+        ExtractableResponse<Response> response = 카페의_현재_쿠폰_디자인_정책_조회_요청(owner, cafeId);
+        CafeCouponSettingFindResponse cafeCouponSettingFindResponse = response.body().as(CafeCouponSettingFindResponse.class);
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(200);
+
+    }
+
+    @Test
+    void 내카페가_아닌_카페의_현재_쿠폰_디자인_정책_조회_불가능하다() {
+        // given
+        Owner owner = ownerRepository.save(OwnerFixture.JENA);
+        Owner notOwner = ownerRepository.save(new Owner("notowner", "id", "pw", "01012349876"));
+
+        Long cafeId = 카페_생성_요청하고_아이디_반환(owner, CAFE_CREATE_REQUEST);
+
+        // when
+        ExtractableResponse<Response> response = 카페의_현재_쿠폰_디자인_정책_조회_요청(notOwner, cafeId);
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(401);
+    }
+}

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/ManagerCouponCommandAcceptanceTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/ManagerCouponCommandAcceptanceTest.java
@@ -21,6 +21,7 @@ import static com.stampcrush.backend.acceptance.step.ManagerCafeCouponSettingUpd
 import static com.stampcrush.backend.acceptance.step.ManagerCafeCouponSettingUpdateStep.카페_쿠폰_정책_수정_요청;
 import static com.stampcrush.backend.acceptance.step.ManagerCafeCreateStep.CAFE_CREATE_REQUEST;
 import static com.stampcrush.backend.acceptance.step.ManagerCafeCreateStep.카페_생성_요청하고_아이디_반환;
+import static com.stampcrush.backend.acceptance.step.ManagerCouponCreateStep.쿠폰_생성_요청;
 import static com.stampcrush.backend.acceptance.step.ManagerCouponCreateStep.쿠폰_생성_요청하고_아이디_반환;
 import static com.stampcrush.backend.acceptance.step.ManagerCouponFindStep.고객의_쿠폰_조회_요청;
 import static com.stampcrush.backend.acceptance.step.ManagerCouponFindStep.고객의_쿠폰_조회하고_결과_반환;
@@ -80,6 +81,24 @@ public class ManagerCouponCommandAcceptanceTest extends AcceptanceTest {
                                 )
                         )
         );
+    }
+
+    @Test
+    void 내카페가_아닌_카페의_쿠폰을_발급할수_없다() {
+        // given
+        Owner owner = ownerRepository.save(new Owner("owner", "id1", "pw1", "01029384234"));
+        Owner notOwner = ownerRepository.save(new Owner("notowner", "id2", "pw2", "01049384234"));
+
+        Customer savedCustomer = customerRepository.save(REGISTER_CUSTOMER_YOUNGHO);
+
+        Long cafeId = 카페_생성_요청하고_아이디_반환(owner, CAFE_CREATE_REQUEST);
+        CouponCreateRequest request = new CouponCreateRequest(cafeId);
+
+        // when
+        ExtractableResponse<Response> response = 쿠폰_생성_요청(notOwner, request, savedCustomer.getId());
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(401);
     }
 
     @Test

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/ManagerCouponFindAcceptanceTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/ManagerCouponFindAcceptanceTest.java
@@ -40,8 +40,8 @@ public class ManagerCouponFindAcceptanceTest extends AcceptanceTest {
         Owner owner = ownerRepository.save(JENA);
 
         Long savedCafeId = 카페_생성_요청하고_아이디_반환(owner, CAFE_CREATE_REQUEST);
-        Customer youngho = customerRepository.save(REGISTER_CUSTOMER_YOUNGHO);
-        Customer gitchan = customerRepository.save(REGISTER_CUSTOMER_GITCHAN);
+        Customer youngho = customerRepository.save(Customer.registeredCustomerBuilder().nickname("youngho").build());
+        Customer gitchan = customerRepository.save(Customer.registeredCustomerBuilder().nickname("gitchan").build());
 
         CouponCreateRequest request = new CouponCreateRequest(savedCafeId);
 
@@ -67,5 +67,25 @@ public class ManagerCouponFindAcceptanceTest extends AcceptanceTest {
 
         // then
         assertThat(actual.getCustomers()).containsExactlyInAnyOrder(expected1, expected2);
+    }
+
+    @Test
+    void 내_카페가_아닌_고객의_고객목록_조회_불가능() {
+        // given
+        Owner owner = ownerRepository.save(JENA);
+        Owner notOwner = ownerRepository.save(new Owner("notOwner", "id", "pw", "01029384726"));
+
+        Long savedCafeId = 카페_생성_요청하고_아이디_반환(owner, CAFE_CREATE_REQUEST);
+        Customer gitchan = customerRepository.save(REGISTER_CUSTOMER_GITCHAN);
+
+        CouponCreateRequest request = new CouponCreateRequest(savedCafeId);
+
+        Long couponId2 = 쿠폰_생성_요청하고_아이디_반환(owner, request, gitchan.getId());
+
+        // when
+        ExtractableResponse<Response> response = 고객_목록_조회_요청(notOwner, savedCafeId);
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(401);
     }
 }

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/ManagerCouponFindAcceptanceTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/ManagerCouponFindAcceptanceTest.java
@@ -4,6 +4,7 @@ import com.stampcrush.backend.api.manager.coupon.request.CouponCreateRequest;
 import com.stampcrush.backend.api.manager.coupon.request.StampCreateRequest;
 import com.stampcrush.backend.api.manager.coupon.response.CafeCustomerFindResponse;
 import com.stampcrush.backend.api.manager.coupon.response.CafeCustomersFindResponse;
+import com.stampcrush.backend.api.manager.coupon.response.CustomerAccumulatingCouponFindResponse;
 import com.stampcrush.backend.entity.user.Customer;
 import com.stampcrush.backend.entity.user.Owner;
 import com.stampcrush.backend.repository.user.CustomerRepository;
@@ -15,14 +16,16 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.util.List;
 
 import static com.stampcrush.backend.acceptance.step.ManagerCafeCreateStep.CAFE_CREATE_REQUEST;
 import static com.stampcrush.backend.acceptance.step.ManagerCafeCreateStep.카페_생성_요청하고_아이디_반환;
 import static com.stampcrush.backend.acceptance.step.ManagerCouponCreateStep.쿠폰_생성_요청하고_아이디_반환;
+import static com.stampcrush.backend.acceptance.step.ManagerCouponFindStep.고객의_쿠폰_조회_요청;
+import static com.stampcrush.backend.acceptance.step.ManagerCouponFindStep.고객의_쿠폰_조회하고_결과_반환;
 import static com.stampcrush.backend.acceptance.step.ManagerCustomerFindStep.고객_목록_조회_요청;
 import static com.stampcrush.backend.acceptance.step.ManagerStampCreateStep.쿠폰에_스탬프를_적립_요청;
 import static com.stampcrush.backend.fixture.CustomerFixture.REGISTER_CUSTOMER_GITCHAN;
-import static com.stampcrush.backend.fixture.CustomerFixture.REGISTER_CUSTOMER_YOUNGHO;
 import static com.stampcrush.backend.fixture.OwnerFixture.JENA;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -84,6 +87,55 @@ public class ManagerCouponFindAcceptanceTest extends AcceptanceTest {
 
         // when
         ExtractableResponse<Response> response = 고객_목록_조회_요청(notOwner, savedCafeId);
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(401);
+    }
+
+    @Test
+    void 고객의_쿠폰을_조회한다() {
+        // given
+        Owner owner = ownerRepository.save(JENA);
+
+        Long savedCafeId = 카페_생성_요청하고_아이디_반환(owner, CAFE_CREATE_REQUEST);
+        Customer youngho = customerRepository.save(Customer.registeredCustomerBuilder().nickname("youngho").build());
+
+        CouponCreateRequest request = new CouponCreateRequest(savedCafeId);
+
+        Long couponId = 쿠폰_생성_요청하고_아이디_반환(owner, request, youngho.getId());
+
+        StampCreateRequest stampCreateRequest1 = new StampCreateRequest(7);
+        StampCreateRequest stampCreateRequest2 = new StampCreateRequest(5);
+
+        쿠폰에_스탬프를_적립_요청(owner, youngho, couponId, stampCreateRequest1);
+        쿠폰에_스탬프를_적립_요청(owner, youngho, couponId, stampCreateRequest2);
+
+        // when
+        String expireDate = LocalDate.now().plusMonths(6).format(DateTimeFormatter.ofPattern("yyyy:MM:dd"));
+        CustomerAccumulatingCouponFindResponse expected = new CustomerAccumulatingCouponFindResponse(couponId + 1, youngho.getId(), youngho.getNickname(), 2, expireDate, Boolean.FALSE, 10);
+        List<CustomerAccumulatingCouponFindResponse> response = 고객의_쿠폰_조회하고_결과_반환(owner, savedCafeId, youngho);
+
+        // then
+        assertThat(response).containsExactlyInAnyOrder(expected);
+    }
+
+    @Test
+    void 내_카페가_아닌_카페의_고객의_쿠폰은_조회_불가능() {
+        // given
+        Owner owner = ownerRepository.save(JENA);
+        Owner notOwner = ownerRepository.save(new Owner("notOwner", "id", "pw", "01029384726"));
+
+        Long savedCafeId = 카페_생성_요청하고_아이디_반환(owner, CAFE_CREATE_REQUEST);
+        Customer youngho = customerRepository.save(Customer.registeredCustomerBuilder().nickname("youngho").build());
+
+        CouponCreateRequest request = new CouponCreateRequest(savedCafeId);
+        Long couponId = 쿠폰_생성_요청하고_아이디_반환(owner, request, youngho.getId());
+
+        StampCreateRequest stampCreateRequest1 = new StampCreateRequest(7);
+        쿠폰에_스탬프를_적립_요청(owner, youngho, couponId, stampCreateRequest1);
+
+        // when
+        ExtractableResponse<Response> response = 고객의_쿠폰_조회_요청(savedCafeId, notOwner, youngho);
 
         // then
         assertThat(response.statusCode()).isEqualTo(401);

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/ManagerRewardCommandAcceptanceTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/ManagerRewardCommandAcceptanceTest.java
@@ -23,6 +23,7 @@ import static com.stampcrush.backend.acceptance.step.ManagerCafeCreateStep.카�
 import static com.stampcrush.backend.acceptance.step.ManagerCouponCreateStep.쿠폰_생성_요청하고_아이디_반환;
 import static com.stampcrush.backend.acceptance.step.ManagerRewardStep.리워드_목록_조회;
 import static com.stampcrush.backend.acceptance.step.ManagerRewardStep.리워드_사용;
+import static com.stampcrush.backend.acceptance.step.ManagerStampCreateStep.쿠폰에_스탬프를_적립_요청;
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -47,7 +48,7 @@ public class ManagerRewardCommandAcceptanceTest extends AcceptanceTest {
         CouponCreateRequest couponCreateRequest = new CouponCreateRequest(cafeId);
         Long couponId = 쿠폰_생성_요청하고_아이디_반환(owner, couponCreateRequest, customer.getId());
         StampCreateRequest stampCreateRequest = new StampCreateRequest(10);
-        스탬프_찍은_후_리워드_생성(owner, customer.getId(), couponId, stampCreateRequest);
+        쿠폰에_스탬프를_적립_요청(owner, customer, couponId, stampCreateRequest);
         ExtractableResponse<Response> response = 리워드_목록_조회(owner, cafeId, customer.getId());
         List<RewardFindResponse> rewards = response.body().as(RewardsFindResponse.class).getRewards();
         Long rewardId = rewards.get(0).getId();
@@ -75,7 +76,7 @@ public class ManagerRewardCommandAcceptanceTest extends AcceptanceTest {
         CouponCreateRequest couponCreateRequest = new CouponCreateRequest(cafeId);
         Long couponId = 쿠폰_생성_요청하고_아이디_반환(owner, couponCreateRequest, customer.getId());
         StampCreateRequest stampCreateRequest = new StampCreateRequest(10);
-        스탬프_찍은_후_리워드_생성(owner, customer.getId(), couponId, stampCreateRequest);
+        쿠폰에_스탬프를_적립_요청(owner, customer, couponId, stampCreateRequest);
         ExtractableResponse<Response> response = 리워드_목록_조회(owner, cafeId, customer.getId());
         List<RewardFindResponse> rewards = response.body().as(RewardsFindResponse.class).getRewards();
         Long rewardId = rewards.get(0).getId();
@@ -105,7 +106,7 @@ public class ManagerRewardCommandAcceptanceTest extends AcceptanceTest {
         CouponCreateRequest couponCreateRequest = new CouponCreateRequest(cafeId);
         Long couponId = 쿠폰_생성_요청하고_아이디_반환(owner, couponCreateRequest, customer.getId());
         StampCreateRequest stampCreateRequest = new StampCreateRequest(10);
-        스탬프_찍은_후_리워드_생성(owner, customer.getId(), couponId, stampCreateRequest);
+        쿠폰에_스탬프를_적립_요청(owner, customer, couponId, stampCreateRequest);
         ExtractableResponse<Response> rewardsResponse = 리워드_목록_조회(owner, cafeId, customer.getId());
         List<RewardFindResponse> rewards = rewardsResponse.body().as(RewardsFindResponse.class).getRewards();
         Long rewardId = rewards.get(0).getId();
@@ -128,7 +129,7 @@ public class ManagerRewardCommandAcceptanceTest extends AcceptanceTest {
         CouponCreateRequest couponCreateRequest = new CouponCreateRequest(cafeId);
         Long couponId = 쿠폰_생성_요청하고_아이디_반환(owner, couponCreateRequest, customer.getId());
         StampCreateRequest stampCreateRequest = new StampCreateRequest(10);
-        스탬프_찍은_후_리워드_생성(owner, customer.getId(), couponId, stampCreateRequest);
+        쿠폰에_스탬프를_적립_요청(owner, customer, couponId, stampCreateRequest);
 
         // when
         ExtractableResponse<Response> rewardsResponse = 리워드_목록_조회(owner, cafeId, customer.getId());
@@ -136,6 +137,28 @@ public class ManagerRewardCommandAcceptanceTest extends AcceptanceTest {
 
         // then
         assertThat(rewards.size()).isEqualTo(1);
+    }
+
+    @Test
+    void 자신의_카페_고객이_아니면_리워드_조회_불가능하다() {
+        // given
+        Customer customer = 가입_회원_생성_후_가입_고객_반환();
+        Owner owner = 카페_사장_생성_후_사장_반환();
+        Owner notOwner = ownerRepository.save(new Owner("notowner", "id", "pw", "01093726453"));
+
+
+        CafeCreateRequest cafeCreateRequest = new CafeCreateRequest("cafe", "잠실", "루터회관", "111111111");
+        Long cafeId = 카페_생성_요청하고_아이디_반환(owner, cafeCreateRequest);
+        CouponCreateRequest couponCreateRequest = new CouponCreateRequest(cafeId);
+        Long couponId = 쿠폰_생성_요청하고_아이디_반환(owner, couponCreateRequest, customer.getId());
+        StampCreateRequest stampCreateRequest = new StampCreateRequest(10);
+        쿠폰에_스탬프를_적립_요청(owner, customer, couponId, stampCreateRequest);
+
+        // when
+        ExtractableResponse<Response> response = 리워드_목록_조회(notOwner, cafeId, customer.getId());
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(401);
     }
 
     // TODO 회원가입, 로그인 구현 후 API CAll 로 대체
@@ -162,14 +185,5 @@ public class ManagerRewardCommandAcceptanceTest extends AcceptanceTest {
     // TODO 회원가입, 로그인 구현 후 API CAll 로 대체
     private Owner 카페_사장_생성_후_사장_반환() {
         return ownerRepository.save(new Owner("hardy", "hardyId", "1234", "01011111111"));
-    }
-
-    private void 스탬프_찍은_후_리워드_생성(Owner owner, Long customerId, Long couponId, StampCreateRequest stampCreateRequest) {
-        given()
-                .contentType(JSON)
-                .body(stampCreateRequest)
-                .auth().preemptive().basic(owner.getLoginId(), owner.getEncryptedPassword())
-                .when()
-                .post("/api/admin/customers/" + customerId + "/coupons/" + couponId + "/stamps");
     }
 }

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/ManagerRewardCommandAcceptanceTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/ManagerRewardCommandAcceptanceTest.java
@@ -5,17 +5,24 @@ import com.stampcrush.backend.api.manager.coupon.request.CouponCreateRequest;
 import com.stampcrush.backend.api.manager.coupon.request.StampCreateRequest;
 import com.stampcrush.backend.api.manager.reward.request.RewardUsedUpdateRequest;
 import com.stampcrush.backend.api.manager.reward.response.RewardFindResponse;
+import com.stampcrush.backend.api.manager.reward.response.RewardsFindResponse;
 import com.stampcrush.backend.auth.OAuthProvider;
 import com.stampcrush.backend.entity.user.Customer;
 import com.stampcrush.backend.entity.user.Owner;
 import com.stampcrush.backend.repository.user.CustomerRepository;
 import com.stampcrush.backend.repository.user.OwnerRepository;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.List;
 
+import static com.stampcrush.backend.acceptance.step.ManagerCafeCreateStep.카페_생성_요청하고_아이디_반환;
+import static com.stampcrush.backend.acceptance.step.ManagerCouponCreateStep.쿠폰_생성_요청하고_아이디_반환;
+import static com.stampcrush.backend.acceptance.step.ManagerRewardStep.리워드_목록_조회;
+import static com.stampcrush.backend.acceptance.step.ManagerRewardStep.리워드_사용;
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -36,18 +43,20 @@ public class ManagerRewardCommandAcceptanceTest extends AcceptanceTest {
         Customer customer = 가입_회원_생성_후_가입_고객_반환();
         Owner owner = 카페_사장_생성_후_사장_반환();
         CafeCreateRequest cafeCreateRequest = new CafeCreateRequest("cafe", "잠실", "루터회관", "111111111");
-        Long cafeId = 카페_생성_후_카페_아이디_반환(owner, cafeCreateRequest);
+        Long cafeId = 카페_생성_요청하고_아이디_반환(owner, cafeCreateRequest);
         CouponCreateRequest couponCreateRequest = new CouponCreateRequest(cafeId);
-        Long couponId = 쿠폰_생성_후_쿠폰_아이디_반환(owner, couponCreateRequest, customer.getId());
+        Long couponId = 쿠폰_생성_요청하고_아이디_반환(owner, couponCreateRequest, customer.getId());
         StampCreateRequest stampCreateRequest = new StampCreateRequest(10);
         스탬프_찍은_후_리워드_생성(owner, customer.getId(), couponId, stampCreateRequest);
-        List<RewardFindResponse> rewards = 리워드_목록_조회(owner, cafeId, customer.getId());
+        ExtractableResponse<Response> response = 리워드_목록_조회(owner, cafeId, customer.getId());
+        List<RewardFindResponse> rewards = response.body().as(RewardsFindResponse.class).getRewards();
         Long rewardId = rewards.get(0).getId();
 
         //when
         RewardUsedUpdateRequest request = new RewardUsedUpdateRequest(cafeId, true);
         리워드_사용(owner, request, customer.getId(), rewardId);
-        List<RewardFindResponse> restRewards = 리워드_목록_조회(owner, cafeId, customer.getId());
+        ExtractableResponse<Response> actual = 리워드_목록_조회(owner, cafeId, customer.getId());
+        List<RewardFindResponse> restRewards = actual.body().as(RewardsFindResponse.class).getRewards();
 
         // then
         SoftAssertions softAssertions = new SoftAssertions();
@@ -62,18 +71,20 @@ public class ManagerRewardCommandAcceptanceTest extends AcceptanceTest {
         Customer customer = 임시_회원_생성_후_가입_고객_반환();
         Owner owner = 카페_사장_생성_후_사장_반환();
         CafeCreateRequest cafeCreateRequest = new CafeCreateRequest("cafe", "잠실", "루터회관", "111111111");
-        Long cafeId = 카페_생성_후_카페_아이디_반환(owner, cafeCreateRequest);
+        Long cafeId = 카페_생성_요청하고_아이디_반환(owner, cafeCreateRequest);
         CouponCreateRequest couponCreateRequest = new CouponCreateRequest(cafeId);
-        Long couponId = 쿠폰_생성_후_쿠폰_아이디_반환(owner, couponCreateRequest, customer.getId());
+        Long couponId = 쿠폰_생성_요청하고_아이디_반환(owner, couponCreateRequest, customer.getId());
         StampCreateRequest stampCreateRequest = new StampCreateRequest(10);
         스탬프_찍은_후_리워드_생성(owner, customer.getId(), couponId, stampCreateRequest);
-        List<RewardFindResponse> rewards = 리워드_목록_조회(owner, cafeId, customer.getId());
+        ExtractableResponse<Response> response = 리워드_목록_조회(owner, cafeId, customer.getId());
+        List<RewardFindResponse> rewards = response.body().as(RewardsFindResponse.class).getRewards();
         Long rewardId = rewards.get(0).getId();
 
         //when
         RewardUsedUpdateRequest request = new RewardUsedUpdateRequest(cafeId, true);
         리워드_사용(owner, request, customer.getId(), rewardId);
-        List<RewardFindResponse> restRewards = 리워드_목록_조회(owner, cafeId, customer.getId());
+        ExtractableResponse<Response> actual = 리워드_목록_조회(owner, cafeId, customer.getId());
+        List<RewardFindResponse> restRewards = actual.body().as(RewardsFindResponse.class).getRewards();
 
         // then
         SoftAssertions softAssertions = new SoftAssertions();
@@ -83,19 +94,45 @@ public class ManagerRewardCommandAcceptanceTest extends AcceptanceTest {
     }
 
     @Test
+    void 카페_사장이_자신의_카페_리워드가_아니면_사용할_수_없다() {
+        // given
+        Customer customer = 가입_회원_생성_후_가입_고객_반환();
+        Owner owner = 카페_사장_생성_후_사장_반환();
+        Owner notOwner = ownerRepository.save(new Owner("notowner", "id", "pw", "01093726453"));
+
+        CafeCreateRequest cafeCreateRequest = new CafeCreateRequest("cafe", "잠실", "루터회관", "111111111");
+        Long cafeId = 카페_생성_요청하고_아이디_반환(owner, cafeCreateRequest);
+        CouponCreateRequest couponCreateRequest = new CouponCreateRequest(cafeId);
+        Long couponId = 쿠폰_생성_요청하고_아이디_반환(owner, couponCreateRequest, customer.getId());
+        StampCreateRequest stampCreateRequest = new StampCreateRequest(10);
+        스탬프_찍은_후_리워드_생성(owner, customer.getId(), couponId, stampCreateRequest);
+        ExtractableResponse<Response> rewardsResponse = 리워드_목록_조회(owner, cafeId, customer.getId());
+        List<RewardFindResponse> rewards = rewardsResponse.body().as(RewardsFindResponse.class).getRewards();
+        Long rewardId = rewards.get(0).getId();
+
+        //when
+        RewardUsedUpdateRequest request = new RewardUsedUpdateRequest(cafeId, true);
+        ExtractableResponse<Response> response = 리워드_사용(notOwner, request, customer.getId(), rewardId);
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(401);
+    }
+
+    @Test
     void 카페사장이_가입_회원의_리워드를_조회한다() {
         // given
         Customer customer = 가입_회원_생성_후_가입_고객_반환();
         Owner owner = 카페_사장_생성_후_사장_반환();
         CafeCreateRequest cafeCreateRequest = new CafeCreateRequest("cafe", "잠실", "루터회관", "111111111");
-        Long cafeId = 카페_생성_후_카페_아이디_반환(owner, cafeCreateRequest);
+        Long cafeId = 카페_생성_요청하고_아이디_반환(owner, cafeCreateRequest);
         CouponCreateRequest couponCreateRequest = new CouponCreateRequest(cafeId);
-        Long couponId = 쿠폰_생성_후_쿠폰_아이디_반환(owner, couponCreateRequest, customer.getId());
+        Long couponId = 쿠폰_생성_요청하고_아이디_반환(owner, couponCreateRequest, customer.getId());
         StampCreateRequest stampCreateRequest = new StampCreateRequest(10);
         스탬프_찍은_후_리워드_생성(owner, customer.getId(), couponId, stampCreateRequest);
 
         // when
-        List<RewardFindResponse> rewards = 리워드_목록_조회(owner, cafeId, customer.getId());
+        ExtractableResponse<Response> rewardsResponse = 리워드_목록_조회(owner, cafeId, customer.getId());
+        List<RewardFindResponse> rewards = rewardsResponse.body().as(RewardsFindResponse.class).getRewards();
 
         // then
         assertThat(rewards.size()).isEqualTo(1);
@@ -127,31 +164,6 @@ public class ManagerRewardCommandAcceptanceTest extends AcceptanceTest {
         return ownerRepository.save(new Owner("hardy", "hardyId", "1234", "01011111111"));
     }
 
-    private Long 카페_생성_후_카페_아이디_반환(Owner owner, CafeCreateRequest cafeCreateRequest) {
-        return Long.valueOf(
-                given()
-                        .contentType(JSON)
-                        .body(cafeCreateRequest)
-                        .auth().preemptive().basic(owner.getLoginId(), owner.getEncryptedPassword())
-                        .when()
-                        .post("/api/admin/cafes")
-                        .thenReturn()
-                        .header("Location")
-                        .split("/")[2]);
-    }
-
-    private Long 쿠폰_생성_후_쿠폰_아이디_반환(Owner owner, CouponCreateRequest couponCreateRequest, Long customerId) {
-        return given()
-                .contentType(JSON)
-                .body(couponCreateRequest)
-                .auth().preemptive().basic(owner.getLoginId(), owner.getEncryptedPassword())
-                .when()
-                .post("/api/admin/customers/" + customerId + "/coupons")
-                .thenReturn()
-                .jsonPath()
-                .getLong("couponId");
-    }
-
     private void 스탬프_찍은_후_리워드_생성(Owner owner, Long customerId, Long couponId, StampCreateRequest stampCreateRequest) {
         given()
                 .contentType(JSON)
@@ -159,27 +171,5 @@ public class ManagerRewardCommandAcceptanceTest extends AcceptanceTest {
                 .auth().preemptive().basic(owner.getLoginId(), owner.getEncryptedPassword())
                 .when()
                 .post("/api/admin/customers/" + customerId + "/coupons/" + couponId + "/stamps");
-    }
-
-    private List<RewardFindResponse> 리워드_목록_조회(Owner owner, Long cafeId, Long customerId) {
-        return given()
-                .queryParam("cafe-id", cafeId)
-                .queryParam("used", false)
-                .contentType(JSON)
-                .auth().preemptive().basic(owner.getLoginId(), owner.getEncryptedPassword())
-                .when()
-                .get("/api/admin/customers/" + customerId + "/rewards")
-                .thenReturn()
-                .jsonPath()
-                .getList("rewards", RewardFindResponse.class);
-    }
-
-    private void 리워드_사용(Owner owner, RewardUsedUpdateRequest rewardUsedUpdateRequest, Long customerId, Long rewardId) {
-        given()
-                .contentType(JSON)
-                .body(rewardUsedUpdateRequest)
-                .auth().preemptive().basic(owner.getLoginId(), owner.getEncryptedPassword())
-                .when()
-                .patch("/api/admin/customers/" + customerId + "/rewards/" + rewardId);
     }
 }

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/step/ManagerCafeCouponSettingFindStep.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/step/ManagerCafeCouponSettingFindStep.java
@@ -1,0 +1,41 @@
+package com.stampcrush.backend.acceptance.step;
+
+import com.stampcrush.backend.entity.user.Owner;
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+
+import static io.restassured.http.ContentType.JSON;
+
+public class ManagerCafeCouponSettingFindStep {
+
+    public static ExtractableResponse<Response> 쿠폰이_발급될때의_쿠폰_디자인_조회_요청(Owner owner, Long cafeId, Long couponId) {
+        return RestAssured.given()
+                .log().all()
+                .contentType(JSON)
+                .auth().preemptive()
+                .basic(owner.getLoginId(), owner.getEncryptedPassword())
+
+                .when()
+                .get("/api/admin/coupon-setting/" + couponId + "?cafe-id=" + cafeId)
+
+                .then()
+                .log().all()
+                .extract();
+    }
+
+    public static ExtractableResponse<Response> 카페의_현재_쿠폰_디자인_정책_조회_요청(Owner owner, Long cafeId) {
+        return RestAssured.given()
+                .log().all()
+                .contentType(JSON)
+                .auth().preemptive()
+                .basic(owner.getLoginId(), owner.getEncryptedPassword())
+
+                .when()
+                .get("/api/admin/coupon-setting?cafe-id=" + cafeId)
+
+                .then()
+                .log().all()
+                .extract();
+    }
+}

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/step/ManagerCafeUpdateStep.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/step/ManagerCafeUpdateStep.java
@@ -1,0 +1,31 @@
+package com.stampcrush.backend.acceptance.step;
+
+import com.stampcrush.backend.api.manager.cafe.request.CafeUpdateRequest;
+import com.stampcrush.backend.entity.user.Owner;
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+
+import java.time.LocalTime;
+
+import static io.restassured.http.ContentType.JSON;
+
+public class ManagerCafeUpdateStep {
+
+    public static final CafeUpdateRequest cafeUpdateRequest = new CafeUpdateRequest("hi", LocalTime.MIDNIGHT, LocalTime.NOON, "010123421253", "cafeimage");
+
+    public static ExtractableResponse<Response> 카페_정보_업데이트_요청(Owner owner, CafeUpdateRequest cafeUpdateRequest, Long cafeId) {
+        return RestAssured.given()
+                .log().all()
+                .contentType(JSON)
+                .body(cafeUpdateRequest)
+                .auth().preemptive().basic(owner.getLoginId(), owner.getEncryptedPassword())
+
+                .when()
+                .patch("/api/admin/cafes/" + cafeId)
+
+                .then()
+                .log().all()
+                .extract();
+    }
+}

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/step/ManagerCouponFindStep.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/step/ManagerCouponFindStep.java
@@ -12,22 +12,22 @@ import static io.restassured.RestAssured.given;
 
 public class ManagerCouponFindStep {
 
-    public static List<CustomerAccumulatingCouponFindResponse> 고객의_쿠폰_조회하고_결과_반환(Owner owner, Long savedCafeId, Customer savedCustomer) {
-        ExtractableResponse<Response> response = 고객의_쿠폰_조회_요청(savedCafeId, owner, savedCustomer);
+    public static List<CustomerAccumulatingCouponFindResponse> 고객의_쿠폰_조회하고_결과_반환(Owner owner, Long cafeId, Customer customer) {
+        ExtractableResponse<Response> response = 고객의_쿠폰_조회_요청(cafeId, owner, customer);
         return response.jsonPath()
                 .getList("coupons", CustomerAccumulatingCouponFindResponse.class);
     }
 
-    public static ExtractableResponse<Response> 고객의_쿠폰_조회_요청(Long savedCafeId, Owner owner, Customer savedCustomer) {
+    public static ExtractableResponse<Response> 고객의_쿠폰_조회_요청(Long cafeId, Owner owner, Customer customer) {
         return given()
                 .log().all()
                 .auth().preemptive()
                 .basic(owner.getLoginId(), owner.getEncryptedPassword())
-                .queryParam("cafe-id", savedCafeId)
+                .queryParam("cafe-id", cafeId)
                 .queryParam("active", true)
 
                 .when()
-                .get("api/admin/customers/{customerId}/coupons", savedCustomer.getId())
+                .get("api/admin/customers/{customerId}/coupons", customer.getId())
 
                 .then()
                 .log().all()

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/step/ManagerRewardStep.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/step/ManagerRewardStep.java
@@ -1,0 +1,39 @@
+package com.stampcrush.backend.acceptance.step;
+
+import com.stampcrush.backend.api.manager.reward.request.RewardUsedUpdateRequest;
+import com.stampcrush.backend.entity.user.Owner;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.http.ContentType.JSON;
+
+public class ManagerRewardStep {
+
+    public static ExtractableResponse<Response> 리워드_사용(Owner owner, RewardUsedUpdateRequest rewardUsedUpdateRequest, Long customerId, Long rewardId) {
+        return given()
+                .log().all()
+                .contentType(JSON)
+                .body(rewardUsedUpdateRequest)
+                .auth().preemptive().basic(owner.getLoginId(), owner.getEncryptedPassword())
+                .when()
+                .patch("/api/admin/customers/" + customerId + "/rewards/" + rewardId)
+                .then()
+                .log().all()
+                .extract();
+    }
+
+    public static ExtractableResponse<Response> 리워드_목록_조회(Owner owner, Long cafeId, Long customerId) {
+        return given()
+                .log().all()
+                .queryParam("cafe-id", cafeId)
+                .queryParam("used", false)
+                .contentType(JSON)
+                .auth().preemptive().basic(owner.getLoginId(), owner.getEncryptedPassword())
+                .when()
+                .get("/api/admin/customers/" + customerId + "/rewards")
+                .then()
+                .log().all()
+                .extract();
+    }
+}

--- a/backend/src/test/java/com/stampcrush/backend/api/ControllerSliceTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/ControllerSliceTest.java
@@ -2,6 +2,7 @@ package com.stampcrush.backend.api;
 
 import com.stampcrush.backend.auth.application.util.AuthTokensGenerator;
 import com.stampcrush.backend.common.KorNamingConverter;
+import com.stampcrush.backend.repository.cafe.CafeRepository;
 import com.stampcrush.backend.repository.user.CustomerRepository;
 import com.stampcrush.backend.repository.user.OwnerRepository;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,4 +25,7 @@ public abstract class ControllerSliceTest {
 
     @MockBean
     public AuthTokensGenerator authTokensGenerator;
+
+    @MockBean
+    public CafeRepository cafeRepository;
 }

--- a/backend/src/test/java/com/stampcrush/backend/api/docs/DocsControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/docs/DocsControllerTest.java
@@ -46,8 +46,10 @@ import com.stampcrush.backend.auth.application.manager.ManagerOAuthLoginService;
 import com.stampcrush.backend.auth.application.manager.ManagerOAuthService;
 import com.stampcrush.backend.auth.application.util.AuthTokensGenerator;
 import com.stampcrush.backend.common.KorNamingConverter;
+import com.stampcrush.backend.entity.cafe.Cafe;
 import com.stampcrush.backend.entity.user.Customer;
 import com.stampcrush.backend.entity.user.Owner;
+import com.stampcrush.backend.repository.cafe.CafeRepository;
 import com.stampcrush.backend.repository.user.CustomerRepository;
 import com.stampcrush.backend.repository.user.OwnerRepository;
 import org.junit.jupiter.api.BeforeAll;
@@ -65,6 +67,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.filter.CharacterEncodingFilter;
 
+import java.time.LocalTime;
 import java.util.Base64;
 
 import static com.stampcrush.backend.fixture.CustomerFixture.REGISTER_CUSTOMER_GITCHAN;
@@ -102,6 +105,8 @@ public abstract class DocsControllerTest {
 
     protected static final Long CAFE_ID = 1L;
     protected static final Owner OWNER = OWNER3;
+    protected static final Cafe CAFE = new Cafe(CAFE_ID, "cafe", LocalTime.NOON, LocalTime.MIDNIGHT,
+            "010123432445", "imageUrl", "intro", "road", "detail", "1234", OWNER);
     protected static final Customer CUSTOMER = REGISTER_CUSTOMER_GITCHAN;
 
     protected static String OWNER_BASIC_HEADER;
@@ -189,6 +194,9 @@ public abstract class DocsControllerTest {
 
     @MockBean
     public AuthTokensGenerator authTokensGenerator;
+
+    @MockBean
+    public CafeRepository cafeRepository;
 
     @BeforeAll
     static void setUpAuth() {

--- a/backend/src/test/java/com/stampcrush/backend/api/docs/manager/cafe/ManagerCafeCommandApiDocsControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/docs/manager/cafe/ManagerCafeCommandApiDocsControllerTest.java
@@ -28,6 +28,7 @@ public class ManagerCafeCommandApiDocsControllerTest extends DocsControllerTest 
     void 카페_상세_정보_변경() throws Exception {
         // given
         when(ownerRepository.findByLoginId(OWNER.getLoginId())).thenReturn(Optional.of(OWNER));
+        when(cafeRepository.findById(CAFE_ID)).thenReturn(Optional.of(CAFE));
         CafeUpdateRequest request = new CafeUpdateRequest("안녕하세요", LocalTime.NOON, LocalTime.MIDNIGHT, "01012345678", "imageUrl");
 
         // when, then

--- a/backend/src/test/java/com/stampcrush/backend/api/docs/manager/cafe/ManagerCafeCouponSettingCommandApiDocsControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/docs/manager/cafe/ManagerCafeCouponSettingCommandApiDocsControllerTest.java
@@ -27,6 +27,7 @@ public class ManagerCafeCouponSettingCommandApiDocsControllerTest extends DocsCo
     void 쿠폰_디자인_및_정책_수정() throws Exception {
         // given
         when(ownerRepository.findByLoginId(OWNER.getLoginId())).thenReturn(Optional.of(OWNER));
+        when(cafeRepository.findById(CAFE_ID)).thenReturn(Optional.of(CAFE));
         CafeCouponSettingUpdateRequest request = new CafeCouponSettingUpdateRequest(
                 "frontImageUrl",
                 "backImageUrl",

--- a/backend/src/test/java/com/stampcrush/backend/api/docs/manager/cafe/ManagerCafeCouponSettingFindApiDocsControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/docs/manager/cafe/ManagerCafeCouponSettingFindApiDocsControllerTest.java
@@ -29,6 +29,7 @@ public class ManagerCafeCouponSettingFindApiDocsControllerTest extends DocsContr
         // given
         Long CAFE_ID = 1L;
         when(ownerRepository.findByLoginId(OWNER.getLoginId())).thenReturn(Optional.of(OWNER));
+        when(cafeRepository.findById(CAFE_ID)).thenReturn(Optional.of(CAFE));
         when(managerCafeCouponSettingFindService.findCafeCouponSetting(CAFE_ID)).thenReturn(
                 new CafeCouponSettingFindResultDto("frontImageUrl", "backImageUrl",
                         "stampImageUrl", List.of(
@@ -74,6 +75,7 @@ public class ManagerCafeCouponSettingFindApiDocsControllerTest extends DocsContr
         Long CAFE_ID = 1L;
         Long COUPON_ID = 1L;
         when(ownerRepository.findByLoginId(OWNER.getLoginId())).thenReturn(Optional.of(OWNER));
+        when(cafeRepository.findById(CAFE_ID)).thenReturn(Optional.of(CAFE));
         when(managerCafeCouponSettingFindService.findCouponSetting(CAFE_ID, COUPON_ID)).thenReturn(
                 new CafeCouponSettingFindResultDto("frontImageUrl", "backImageUrl",
                         "stampImageUrl", List.of(

--- a/backend/src/test/java/com/stampcrush/backend/api/docs/manager/coupon/ManagerCouponCommandApiDocsControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/docs/manager/coupon/ManagerCouponCommandApiDocsControllerTest.java
@@ -29,7 +29,7 @@ public class ManagerCouponCommandApiDocsControllerTest extends DocsControllerTes
         Long customerId = 1L;
         when(ownerRepository.findByLoginId(OWNER.getLoginId())).thenReturn(Optional.of(OWNER));
         CouponCreateRequest request = new CouponCreateRequest(cafeId);
-        when(managerCouponCommandService.createCoupon(cafeId, customerId)).thenReturn(1L);
+        when(managerCouponCommandService.createCoupon(OWNER.getId(), cafeId, customerId)).thenReturn(1L);
 
         // when, then
         mockMvc.perform(RestDocumentationRequestBuilders.post("/api/admin/customers/{customerId}/coupons", customerId)

--- a/backend/src/test/java/com/stampcrush/backend/api/docs/manager/coupon/ManagerCouponFindApiDocsControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/docs/manager/coupon/ManagerCouponFindApiDocsControllerTest.java
@@ -69,6 +69,7 @@ public class ManagerCouponFindApiDocsControllerTest extends DocsControllerTest {
         // given
         Long cafeId = 1L;
         when(ownerRepository.findByLoginId(OWNER.getLoginId())).thenReturn(Optional.of(OWNER));
+        when(cafeRepository.findById(CAFE_ID)).thenReturn(Optional.of(CAFE));
         when(managerCouponFindService.findCouponsByCafe(cafeId)).thenReturn(List.of(new CafeCustomerFindResultDto(1L, "레오", 3, 12, 30, LocalDateTime.MIN, true, 10)));
 
         // when, then

--- a/backend/src/test/java/com/stampcrush/backend/api/docs/manager/coupon/ManagerCouponFindApiDocsControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/docs/manager/coupon/ManagerCouponFindApiDocsControllerTest.java
@@ -32,6 +32,7 @@ public class ManagerCouponFindApiDocsControllerTest extends DocsControllerTest {
         Long cafeId = 1L;
 
         when(ownerRepository.findByLoginId(OWNER.getLoginId())).thenReturn(Optional.of(OWNER));
+        when(cafeRepository.findById(CAFE_ID)).thenReturn(Optional.of(CAFE));
         when(managerCouponFindService.findAccumulatingCoupon(cafeId, customerId)).thenReturn(List.of(new CustomerAccumulatingCouponFindResultDto(1L, 1L, "윤생", 3, LocalDateTime.MIN, false, 10)));
 
         // when, then

--- a/backend/src/test/java/com/stampcrush/backend/api/docs/manager/reward/ManagerRewardFindApiDocsControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/docs/manager/reward/ManagerRewardFindApiDocsControllerTest.java
@@ -31,6 +31,7 @@ public class ManagerRewardFindApiDocsControllerTest extends DocsControllerTest {
         Long customerId = 1L;
         Long cafeId = 1L;
         when(ownerRepository.findByLoginId(OWNER.getLoginId())).thenReturn(Optional.of(OWNER));
+        when(cafeRepository.findById(CAFE_ID)).thenReturn(Optional.of(CAFE));
         when(managerRewardFindService.findRewards(any(RewardFindDto.class))).thenReturn(List.of(new RewardFindResultDto(1L, "아메리카노"), new RewardFindResultDto(2L, "조각케익")));
 
         // when, then

--- a/backend/src/test/java/com/stampcrush/backend/api/manager/cafe/ManagerCafeCouponSettingCommandApiControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/manager/cafe/ManagerCafeCouponSettingCommandApiControllerTest.java
@@ -5,12 +5,15 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.stampcrush.backend.api.ControllerSliceTest;
 import com.stampcrush.backend.api.manager.cafe.request.CafeCouponSettingUpdateRequest;
 import com.stampcrush.backend.application.manager.cafe.ManagerCafeCouponSettingCommandService;
+import com.stampcrush.backend.config.WebMvcConfig;
 import com.stampcrush.backend.entity.user.Owner;
 import com.stampcrush.backend.fixture.OwnerFixture;
 import com.stampcrush.backend.helper.AuthHelper.OwnerAuthorization;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
 
 import java.util.List;
 import java.util.Optional;
@@ -22,7 +25,8 @@ import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WebMvcTest(ManagerCafeCouponSettingCommandApiController.class)
+@WebMvcTest(value = ManagerCafeCouponSettingCommandApiController.class,
+     excludeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebMvcConfig.class))
 class ManagerCafeCouponSettingCommandApiControllerTest extends ControllerSliceTest {
 
     private static final CafeCouponSettingUpdateRequest CAFE_COUPON_SETTING_UPDATE_REQUEST = new CafeCouponSettingUpdateRequest(
@@ -36,36 +40,6 @@ class ManagerCafeCouponSettingCommandApiControllerTest extends ControllerSliceTe
 
     @MockBean
     private ManagerCafeCouponSettingCommandService managerCafeCouponSettingCommandService;
-
-    @Test
-    void 카페_쿠폰_정책_변경_시_인증_헤더_정보가_없으면_401_상태코드를_반환한다() throws Exception {
-        String requestBody = formatRequestBody(CAFE_COUPON_SETTING_UPDATE_REQUEST);
-
-        mockMvc.perform(
-                        post("/api/admin/coupon-setting?cafe-id=1")
-                                .contentType(APPLICATION_JSON)
-                                .content(requestBody)
-                )
-                .andExpect(status().isUnauthorized());
-    }
-
-    @Test
-    void 카페_쿠폰_정책_변경_시_인증이_안되면_401_상태코드를_반환한다() throws Exception {
-        OwnerAuthorization ownerAuthorization = createOwnerAuthorization(OwnerFixture.GITCHAN);
-
-        when(ownerRepository.findByLoginId(ownerAuthorization.getOwner().getLoginId()))
-                .thenReturn(Optional.empty());
-
-        String requestBody = formatRequestBody(CAFE_COUPON_SETTING_UPDATE_REQUEST);
-
-        mockMvc.perform(
-                        post("/api/admin/coupon-setting?cafe-id=1")
-                                .contentType(APPLICATION_JSON)
-                                .content(requestBody)
-                                .header(AUTHORIZATION, ownerAuthorization.getBasicAuthHeader())
-                )
-                .andExpect(status().isUnauthorized());
-    }
 
     @Test
     void 카페_쿠폰_정책_변경_시_인증이_되면_204_상태코드와_응답을_반환한다() throws Exception {

--- a/backend/src/test/java/com/stampcrush/backend/api/manager/coupon/ManagerCouponCommandApiControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/manager/coupon/ManagerCouponCommandApiControllerTest.java
@@ -16,7 +16,7 @@ import org.springframework.context.annotation.FilterType;
 import org.springframework.test.web.servlet.MvcResult;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -37,7 +37,7 @@ public class ManagerCouponCommandApiControllerTest extends ControllerSliceTest {
     @Test
     void 쿠폰을_신규_발급한다() throws Exception {
         // given
-        given(managerCouponCommandService.createCoupon(anyLong(), anyLong()))
+        given(managerCouponCommandService.createCoupon(any(), any(), any()))
                 .willReturn(1L);
 
         CouponCreateRequest couponCreateRequest = new CouponCreateRequest(1L);

--- a/backend/src/test/java/com/stampcrush/backend/api/manager/reward/MangerRewardCommandApiControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/manager/reward/MangerRewardCommandApiControllerTest.java
@@ -36,7 +36,7 @@ public class MangerRewardCommandApiControllerTest extends ControllerSliceTest {
         RewardUsedUpdateRequest request = new RewardUsedUpdateRequest(1L, true);
         doNothing()
                 .when(managerRewardCommandService)
-                .useReward(any(RewardUsedUpdateDto.class));
+                .useReward(any(), any(RewardUsedUpdateDto.class));
 
         // when, then
         mockMvc.perform(

--- a/backend/src/test/java/com/stampcrush/backend/application/manager/coupon/ManageCouponCommandServiceTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/application/manager/coupon/ManageCouponCommandServiceTest.java
@@ -78,11 +78,13 @@ public class ManageCouponCommandServiceTest {
 
     private static Cafe cafe;
     private static Customer customer;
+    private static Owner owner;
     private static CouponPolicy couponPolicy;
 
     @BeforeAll
     static void setUp() {
-        cafe = new Cafe(1L, "name", "road", "detailAddress", "phone", null);
+        owner = new Owner(1L, "owner", "id", "pw", "010193847362");
+        cafe = new Cafe(1L, "name", "road", "detailAddress", "phone", owner);
         customer = Customer.temporaryCustomerBuilder()
                 .id(1L)
                 .phoneNumber("01012345678")
@@ -96,6 +98,8 @@ public class ManageCouponCommandServiceTest {
         Coupon currentCoupon = new Coupon(LocalDate.EPOCH, customer, cafe, null, couponPolicy);
         given(customerRepository.findById(anyLong()))
                 .willReturn(Optional.of(customer));
+        given(ownerRepository.findById(anyLong()))
+                .willReturn(Optional.of(owner));
         given(cafeRepository.findById(anyLong()))
                 .willReturn(Optional.of(cafe));
         given(cafePolicyRepository.findByCafe(any()))
@@ -106,7 +110,7 @@ public class ManageCouponCommandServiceTest {
                 .willReturn(List.of(currentCoupon));
 
         // when
-        managerCouponCommandService.createCoupon(1L, 1L);
+        managerCouponCommandService.createCoupon(1L,1L, 1L);
 
         // then
         then(couponRepository).should(times(1)).save(any());
@@ -120,6 +124,8 @@ public class ManageCouponCommandServiceTest {
         // given
         given(customerRepository.findById(anyLong()))
                 .willReturn(Optional.of(customer));
+        given(ownerRepository.findById(anyLong()))
+                .willReturn(Optional.of(owner));
         given(cafeRepository.findById(anyLong()))
                 .willReturn(Optional.of(cafe));
         given(cafePolicyRepository.findByCafe(any()))
@@ -130,7 +136,7 @@ public class ManageCouponCommandServiceTest {
                 .willReturn(Collections.emptyList());
 
         // when
-        managerCouponCommandService.createCoupon(1L, 1L);
+        managerCouponCommandService.createCoupon(1L,1L, 1L);
 
         // then
         then(couponRepository).should(times(1)).save(any());
@@ -141,24 +147,26 @@ public class ManageCouponCommandServiceTest {
     @Test
     void 존재하지_않는_회원이_쿠폰을_발급받으려_하면_예외발생() {
         // given, when
+        given(cafeRepository.findById(anyLong()))
+                .willReturn(Optional.of(cafe));
+        given(ownerRepository.findById(anyLong()))
+                .willReturn(Optional.of(owner));
         given(customerRepository.findById(anyLong()))
                 .willReturn(Optional.empty());
 
         // then
-        assertThatThrownBy(() -> managerCouponCommandService.createCoupon(1L, 1L))
+        assertThatThrownBy(() -> managerCouponCommandService.createCoupon(1L,1L, 1L))
                 .isInstanceOf(CustomerNotFoundException.class);
     }
 
     @Test
     void 존재하지_않는_카페가_쿠폰을_발급하려고_하면_예외발생() {
         // given, when
-        given(customerRepository.findById(anyLong()))
-                .willReturn(Optional.of(customer));
         given(cafeRepository.findById(anyLong()))
                 .willReturn(Optional.empty());
 
         // then
-        assertThatThrownBy(() -> managerCouponCommandService.createCoupon(1L, 1L))
+        assertThatThrownBy(() -> managerCouponCommandService.createCoupon(1L,1L, 1L))
                 .isInstanceOf(CafeNotFoundException.class);
     }
 
@@ -171,9 +179,11 @@ public class ManageCouponCommandServiceTest {
                 .willReturn(Optional.of(cafe));
         given(cafePolicyRepository.findByCafe(any()))
                 .willReturn(Optional.empty());
+        given(ownerRepository.findById(anyLong()))
+                .willReturn(Optional.of(owner));
 
         // then
-        assertThatThrownBy(() -> managerCouponCommandService.createCoupon(1L, 1L))
+        assertThatThrownBy(() -> managerCouponCommandService.createCoupon(1L,1L, 1L))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
@@ -182,6 +192,8 @@ public class ManageCouponCommandServiceTest {
         // given, when
         given(customerRepository.findById(anyLong()))
                 .willReturn(Optional.of(customer));
+        given(ownerRepository.findById(anyLong()))
+                .willReturn(Optional.of(owner));
         given(cafeRepository.findById(anyLong()))
                 .willReturn(Optional.of(cafe));
         given(cafePolicyRepository.findByCafe(any()))
@@ -190,7 +202,7 @@ public class ManageCouponCommandServiceTest {
                 .willReturn(Optional.empty());
 
         // then
-        assertThatThrownBy(() -> managerCouponCommandService.createCoupon(1L, 1L))
+        assertThatThrownBy(() -> managerCouponCommandService.createCoupon(1L,1L, 1L))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
@@ -339,7 +351,7 @@ public class ManageCouponCommandServiceTest {
 
     private void 스탬프_적립을_위해_필요한_엔티티를_조회한다(int maxStampCount, Coupon coupon) {
         given(ownerRepository.findById(any()))
-                .willReturn(Optional.of(new Owner("owner", "id", "pw", "phone")));
+                .willReturn(Optional.of(owner));
         given(customerRepository.findById(any()))
                 .willReturn(Optional.of(customer));
         given(cafeRepository.findAllByOwner(any()))

--- a/backend/src/test/java/com/stampcrush/backend/application/manager/reward/ManagerRewardCommandServiceTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/application/manager/reward/ManagerRewardCommandServiceTest.java
@@ -91,7 +91,7 @@ class ManagerRewardCommandServiceTest {
         RewardUsedUpdateDto rewardUsedUpdateDto = new RewardUsedUpdateDto(unusedReward.getId(), registerCustomer_1.getId(), cafe_1.getId(), true);
 
         // when
-        managerRewardCommandService.useReward(rewardUsedUpdateDto);
+        managerRewardCommandService.useReward(owner_1.getId(), rewardUsedUpdateDto);
 
         // then
         assertThat(unusedReward.getUsed()).isTrue();
@@ -103,7 +103,7 @@ class ManagerRewardCommandServiceTest {
         RewardUsedUpdateDto rewardUsedUpdateDto = new RewardUsedUpdateDto(unusedReward.getId(), Long.MAX_VALUE, cafe_1.getId(), true);
 
         // when, then
-        assertThatThrownBy(() -> managerRewardCommandService.useReward(rewardUsedUpdateDto))
+        assertThatThrownBy(() -> managerRewardCommandService.useReward(owner_1.getId(), rewardUsedUpdateDto))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
@@ -113,7 +113,7 @@ class ManagerRewardCommandServiceTest {
         RewardUsedUpdateDto rewardUsedUpdateDto = new RewardUsedUpdateDto(Long.MAX_VALUE, registerCustomer_1.getId(), cafe_1.getId(), true);
 
         // when, then
-        assertThatThrownBy(() -> managerRewardCommandService.useReward(rewardUsedUpdateDto))
+        assertThatThrownBy(() -> managerRewardCommandService.useReward(owner_1.getId(), rewardUsedUpdateDto))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
@@ -123,7 +123,7 @@ class ManagerRewardCommandServiceTest {
         RewardUsedUpdateDto rewardUsedUpdateDto = new RewardUsedUpdateDto(unusedReward.getId(), registerCustomer_1.getId(), Long.MAX_VALUE, true);
 
         // when, then
-        assertThatThrownBy(() -> managerRewardCommandService.useReward(rewardUsedUpdateDto))
+        assertThatThrownBy(() -> managerRewardCommandService.useReward(owner_1.getId(), rewardUsedUpdateDto))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
@@ -133,7 +133,7 @@ class ManagerRewardCommandServiceTest {
         RewardUsedUpdateDto rewardUsedUpdateDto = new RewardUsedUpdateDto(unusedReward.getId(), temporaryCustomer.getId(), cafe_1.getId(), true);
 
         // when, then
-        assertThatThrownBy(() -> managerRewardCommandService.useReward(rewardUsedUpdateDto))
+        assertThatThrownBy(() -> managerRewardCommandService.useReward(owner_1.getId(), rewardUsedUpdateDto))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
@@ -141,10 +141,10 @@ class ManagerRewardCommandServiceTest {
     void 이미_사용된_리워드를_사용하려하면_예외를_던진다() {
         //given
         RewardUsedUpdateDto rewardUsedUpdateDto = new RewardUsedUpdateDto(unusedReward.getId(), registerCustomer_1.getId(), cafe_1.getId(), true);
-        managerRewardCommandService.useReward(rewardUsedUpdateDto);
+        managerRewardCommandService.useReward(owner_1.getId(), rewardUsedUpdateDto);
 
         // when, then
-        assertThatThrownBy(() -> managerRewardCommandService.useReward(rewardUsedUpdateDto))
+        assertThatThrownBy(() -> managerRewardCommandService.useReward(owner_1.getId(), rewardUsedUpdateDto))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
@@ -154,7 +154,7 @@ class ManagerRewardCommandServiceTest {
         RewardUsedUpdateDto rewardUsedUpdateDto = new RewardUsedUpdateDto(unusedReward.getId(), registerCustomer_1.getId(), cafe_2.getId(), true);
 
         // when, then
-        assertThatThrownBy(() -> managerRewardCommandService.useReward(rewardUsedUpdateDto))
+        assertThatThrownBy(() -> managerRewardCommandService.useReward(owner_2.getId(), rewardUsedUpdateDto))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
@@ -164,7 +164,7 @@ class ManagerRewardCommandServiceTest {
         RewardUsedUpdateDto rewardUsedUpdateDto = new RewardUsedUpdateDto(unusedReward.getId(), registerCustomer_2.getId(), cafe_1.getId(), true);
 
         // when, then
-        assertThatThrownBy(() -> managerRewardCommandService.useReward(rewardUsedUpdateDto))
+        assertThatThrownBy(() -> managerRewardCommandService.useReward(owner_1.getId(), rewardUsedUpdateDto))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 


### PR DESCRIPTION
## 주요 변경사항

- 사장님 API 에 카페가 사장님의 것인지 확인하는 코드를 추가했습니다

```
카페의 현재쿠폰 디자인 조회 -> 쿼리 
쿠폰 디자인 및 정책 수정 -> 쿼리 
쿠폰이 발급될때의 쿠폰 디자인 조회 -> 쿼리
고객의 쿠폰 조회 -> 쿼리
고객의 리워드 조회 -> 쿼리

카페 상세정보 업데이트 -> path variable 
고객 목록 조회 -> path variable

쿠폰 신규 발급 -> request body 
리워드 사용 -> request body
```

## 리뷰어에게...

- 인가 관련 중복되는 코드를 Service 메서드에 추가하기보다 인터셉터 등을 사용해서 중복 로직을 제거할 수 있나 고민을 했는데 cafeId 가 API 마다 queryParameter, path variable, requestBody 로 들어와서 중복로직을 제거하는게 어렵네요....
- 인증 관련 코드가 ArgumentResolver 에 있어서 여기 있는 코드를 재활용하려고 queryParameter 랑 pathVariable 로 들어오는 API 는 ArgumentResolver 에서 처리했습니다. 
- 근데 requestBody 로 들어오는 API 2개는 잘 처리가 안돼서 시간이 부족해서 우선 Service 메서드에 인가 확인 코드 작성해놨습니다.... 
- 인수테스트 작성하면서 Step 객체로 빼는 등 리팩터링도 좀 했습니다
- 코드가 좀 더러운데 개선할거 리뷰 많이 달아주시면 감사합니다

- ### 중복 로직 어떻게 제거할지, 그냥 서비스 메서드에 인가 코드 다 넣어둘지에 대한 의견 많이 부탁드립니다(적극 반영 가능! 넘어려워요)

## 관련 이슈

closes #611 

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [x] `milestone` 설정
