### PR TITLE
[BE] fix: CustomerType에서 이름을 거꾸로 지정한 문제 해결 

### DIFF
--- a/backend/src/main/java/com/stampcrush/backend/application/visitor/profile/dto/VisitorProfileFindByPhoneNumberResultDto.java
+++ b/backend/src/main/java/com/stampcrush/backend/application/visitor/profile/dto/VisitorProfileFindByPhoneNumberResultDto.java
@@ -4,7 +4,7 @@ import com.stampcrush.backend.entity.user.Customer;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
-import static com.stampcrush.backend.entity.user.CustomerType.REGISTERED;
+import static com.stampcrush.backend.entity.user.CustomerType.REGISTER;
 import static com.stampcrush.backend.entity.user.CustomerType.TEMPORARY;
 
 @Getter
@@ -31,8 +31,8 @@ public class VisitorProfileFindByPhoneNumberResultDto {
 
     private static String getRegisterType(Customer customer) {
         if (customer.isRegistered()) {
-            return REGISTERED.getCustomerType();
+            return REGISTER.name().toLowerCase();
         }
-        return TEMPORARY.getCustomerType();
+        return TEMPORARY.name().toLowerCase();
     }
 }

--- a/backend/src/main/java/com/stampcrush/backend/entity/user/Customer.java
+++ b/backend/src/main/java/com/stampcrush/backend/entity/user/Customer.java
@@ -9,7 +9,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import static com.stampcrush.backend.entity.user.CustomerType.REGISTERED;
+import static com.stampcrush.backend.entity.user.CustomerType.REGISTER;
 import static com.stampcrush.backend.entity.user.CustomerType.TEMPORARY;
 import static jakarta.persistence.EnumType.STRING;
 import static jakarta.persistence.GenerationType.IDENTITY;
@@ -66,7 +66,7 @@ public class Customer {
         this.encryptedPassword = encryptedPassword;
         this.oAuthProvider = oAuthProvider;
         this.oAuthId = oAuthId;
-        this.customerType = REGISTERED;
+        this.customerType = REGISTER;
     }
 
     @Builder(builderMethodName = "temporaryCustomerBuilder")
@@ -104,7 +104,7 @@ public class Customer {
     }
 
     public boolean isRegistered() {
-        return customerType == REGISTERED;
+        return customerType == REGISTER;
     }
 
     public void checkPassword(String encryptedPassword) {
@@ -142,6 +142,6 @@ public class Customer {
     }
 
     public void toRegisterCustomer() {
-        this.customerType = REGISTERED;
+        this.customerType = REGISTER;
     }
 }

--- a/backend/src/main/java/com/stampcrush/backend/entity/user/CustomerType.java
+++ b/backend/src/main/java/com/stampcrush/backend/entity/user/CustomerType.java
@@ -2,16 +2,6 @@ package com.stampcrush.backend.entity.user;
 
 public enum CustomerType {
 
-    TEMPORARY("register"),
-    REGISTERED("temporary");
-
-    private final String customerType;
-
-    CustomerType(String customerType) {
-        this.customerType = customerType;
-    }
-
-    public String getCustomerType() {
-        return customerType;
-    }
+    TEMPORARY,
+    REGISTER;
 }

--- a/backend/src/test/java/com/stampcrush/backend/api/visitor/profile/VisitorProfilesFindApiControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/visitor/profile/VisitorProfilesFindApiControllerTest.java
@@ -50,6 +50,6 @@ class VisitorProfilesFindApiControllerTest extends ControllerSliceTest {
                 .andExpect(jsonPath("customers[0].id").value(customer.getId()))
                 .andExpect(jsonPath("customers[0].nickname").value(customer.getNickname()))
                 .andExpect(jsonPath("customers[0].phoneNumber").value(customer.getPhoneNumber()))
-                .andExpect(jsonPath("customers[0].registerType").value(TEMPORARY.getCustomerType()));
+                .andExpect(jsonPath("customers[0].registerType").value(TEMPORARY.name().toLowerCase()));
     }
 }


### PR DESCRIPTION
## 주요 변경사항

younho cha가 정신이 없었는지..
프론트에 보내는 메세지를 거꾸로 지정해 놨더라고요
수정했습니다. 

## 리뷰어에게...

## 관련 이슈

closes

## 체크리스트

- [ ] `reviewers` 설정
- [ ] `label` 설정
- [ ] `milestone` 설정
