### PR TITLE
[FE] fix: 이미지 업로드 요청 인증 헤더 추가

### DIFF
--- a/frontend/src/api/post.ts
+++ b/frontend/src/api/post.ts
@@ -72,6 +72,7 @@ export const postUploadImage = async (file: File) => {
   formData.append('image', file);
 
   return await fetch(`${BASE_URL}/admin/images`, {
+    ...ownerHeader(),
     method: 'POST',
     body: formData,
   });


### PR DESCRIPTION
## 주요 변경사항
- #653 
이슈 이름과 동일합니다.
<img width="650" alt="Screenshot 2023-09-14 at 13 30 16" src="https://github.com/woowacourse-teams/2023-stamp-crush/assets/56749516/e80c4946-40da-46d4-9adf-2ff798b8dc96">


## 리뷰어에게...

## 관련 이슈

closes #653 

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [x] `milestone` 설정
