### PR TITLE
[BE] feat: 자신의 카페 고객이 아니면 리워드 조회 불가능하게 수정

### DIFF
--- a/backend/src/main/java/com/stampcrush/backend/application/manager/reward/ManagerRewardFindService.java
+++ b/backend/src/main/java/com/stampcrush/backend/application/manager/reward/ManagerRewardFindService.java
@@ -5,11 +5,14 @@ import com.stampcrush.backend.application.manager.reward.dto.RewardFindResultDto
 import com.stampcrush.backend.entity.cafe.Cafe;
 import com.stampcrush.backend.entity.reward.Reward;
 import com.stampcrush.backend.entity.user.Owner;
+import com.stampcrush.backend.entity.visithistory.VisitHistory;
 import com.stampcrush.backend.exception.CafeNotFoundException;
 import com.stampcrush.backend.exception.OwnerNotFoundException;
+import com.stampcrush.backend.exception.OwnerUnAuthorizationException;
 import com.stampcrush.backend.repository.cafe.CafeRepository;
 import com.stampcrush.backend.repository.reward.RewardRepository;
 import com.stampcrush.backend.repository.user.OwnerRepository;
+import com.stampcrush.backend.repository.visithistory.VisitHistoryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -24,8 +27,15 @@ public class ManagerRewardFindService {
     private final RewardRepository rewardRepository;
     private final CafeRepository cafeRepository;
     private final OwnerRepository ownerRepository;
+    private final VisitHistoryRepository visitHistoryRepository;
 
     public List<RewardFindResultDto> findRewards(Long ownerId, RewardFindDto rewardFindDto) {
+        List<VisitHistory> visitHistories = visitHistoryRepository.findByCafeIdAndCustomerId(rewardFindDto.getCafeId(), rewardFindDto.getCustomerId());
+
+        if (visitHistories.isEmpty()) {
+            throw new OwnerUnAuthorizationException("카페의 고객이 아닙니다");
+        }
+
         Cafe cafe = cafeRepository.findById(rewardFindDto.getCafeId())
                 .orElseThrow(() -> new CafeNotFoundException("카페를 찾지 못했습니다."));
         Owner owner = ownerRepository.findById(ownerId)

--- a/backend/src/main/java/com/stampcrush/backend/repository/visithistory/VisitHistoryRepository.java
+++ b/backend/src/main/java/com/stampcrush/backend/repository/visithistory/VisitHistoryRepository.java
@@ -12,4 +12,6 @@ public interface VisitHistoryRepository extends JpaRepository<VisitHistory, Long
     List<VisitHistory> findByCafeAndCustomer(Cafe cafe, Customer customer);
 
     List<VisitHistory> findVisitHistoriesByCustomer(Customer customer);
+
+    List<VisitHistory> findByCafeIdAndCustomerId(Long cafeId, Long customerId);
 }

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/ManagerRewardFindAcceptanceTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/ManagerRewardFindAcceptanceTest.java
@@ -3,7 +3,6 @@ package com.stampcrush.backend.acceptance;
 import com.stampcrush.backend.api.manager.cafe.request.CafeCreateRequest;
 import com.stampcrush.backend.api.manager.coupon.request.CouponCreateRequest;
 import com.stampcrush.backend.api.manager.coupon.request.StampCreateRequest;
-import com.stampcrush.backend.api.manager.reward.request.RewardUsedUpdateRequest;
 import com.stampcrush.backend.api.manager.reward.response.RewardFindResponse;
 import com.stampcrush.backend.api.manager.reward.response.RewardsFindResponse;
 import com.stampcrush.backend.auth.OAuthProvider;
@@ -13,7 +12,6 @@ import com.stampcrush.backend.repository.user.CustomerRepository;
 import com.stampcrush.backend.repository.user.OwnerRepository;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
-import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -22,11 +20,10 @@ import java.util.List;
 import static com.stampcrush.backend.acceptance.step.ManagerCafeCreateStep.카페_생성_요청하고_아이디_반환;
 import static com.stampcrush.backend.acceptance.step.ManagerCouponCreateStep.쿠폰_생성_요청하고_아이디_반환;
 import static com.stampcrush.backend.acceptance.step.ManagerRewardStep.리워드_목록_조회;
-import static com.stampcrush.backend.acceptance.step.ManagerRewardStep.리워드_사용;
 import static com.stampcrush.backend.acceptance.step.ManagerStampCreateStep.쿠폰에_스탬프를_적립_요청;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ManagerRewardCommandAcceptanceTest extends AcceptanceTest {
+public class ManagerRewardFindAcceptanceTest extends AcceptanceTest {
 
     // TODO 회원가입, 로그인 구현 후 제거
     @Autowired
@@ -37,7 +34,7 @@ public class ManagerRewardCommandAcceptanceTest extends AcceptanceTest {
     private CustomerRepository customerRepository;
 
     @Test
-    void 카페사장이_가입_회원의_리워드를_사용한다() {
+    void 카페사장이_가입_회원의_리워드를_조회한다() {
         // given
         Customer customer = 가입_회원_생성_후_가입_고객_반환();
         Owner owner = 카페_사장_생성_후_사장_반환();
@@ -47,71 +44,57 @@ public class ManagerRewardCommandAcceptanceTest extends AcceptanceTest {
         Long couponId = 쿠폰_생성_요청하고_아이디_반환(owner, couponCreateRequest, customer.getId());
         StampCreateRequest stampCreateRequest = new StampCreateRequest(10);
         쿠폰에_스탬프를_적립_요청(owner, customer, couponId, stampCreateRequest);
-        ExtractableResponse<Response> response = 리워드_목록_조회(owner, cafeId, customer.getId());
-        List<RewardFindResponse> rewards = response.body().as(RewardsFindResponse.class).getRewards();
-        Long rewardId = rewards.get(0).getId();
 
-        //when
-        RewardUsedUpdateRequest request = new RewardUsedUpdateRequest(cafeId, true);
-        리워드_사용(owner, request, customer.getId(), rewardId);
-        ExtractableResponse<Response> actual = 리워드_목록_조회(owner, cafeId, customer.getId());
-        List<RewardFindResponse> restRewards = actual.body().as(RewardsFindResponse.class).getRewards();
+        // when
+        ExtractableResponse<Response> rewardsResponse = 리워드_목록_조회(owner, cafeId, customer.getId());
+        List<RewardFindResponse> rewards = rewardsResponse.body().as(RewardsFindResponse.class).getRewards();
 
         // then
-        SoftAssertions softAssertions = new SoftAssertions();
-        softAssertions.assertThat(rewards.size()).isEqualTo(1);
-        softAssertions.assertThat(restRewards.size()).isEqualTo(0);
-        softAssertions.assertAll();
+        assertThat(rewards.size()).isEqualTo(1);
     }
 
     @Test
-    void 카페사장이_임시_회원의_리워드를_사용할_수_없다() {
-        // given
-        Customer customer = 임시_회원_생성_후_가입_고객_반환();
-        Owner owner = 카페_사장_생성_후_사장_반환();
-        CafeCreateRequest cafeCreateRequest = new CafeCreateRequest("cafe", "잠실", "루터회관", "111111111");
-        Long cafeId = 카페_생성_요청하고_아이디_반환(owner, cafeCreateRequest);
-        CouponCreateRequest couponCreateRequest = new CouponCreateRequest(cafeId);
-        Long couponId = 쿠폰_생성_요청하고_아이디_반환(owner, couponCreateRequest, customer.getId());
-        StampCreateRequest stampCreateRequest = new StampCreateRequest(10);
-        쿠폰에_스탬프를_적립_요청(owner, customer, couponId, stampCreateRequest);
-        ExtractableResponse<Response> response = 리워드_목록_조회(owner, cafeId, customer.getId());
-        List<RewardFindResponse> rewards = response.body().as(RewardsFindResponse.class).getRewards();
-        Long rewardId = rewards.get(0).getId();
-
-        //when
-        RewardUsedUpdateRequest request = new RewardUsedUpdateRequest(cafeId, true);
-        리워드_사용(owner, request, customer.getId(), rewardId);
-        ExtractableResponse<Response> actual = 리워드_목록_조회(owner, cafeId, customer.getId());
-        List<RewardFindResponse> restRewards = actual.body().as(RewardsFindResponse.class).getRewards();
-
-        // then
-        SoftAssertions softAssertions = new SoftAssertions();
-        softAssertions.assertThat(rewards.size()).isEqualTo(1);
-        softAssertions.assertThat(restRewards.size()).isEqualTo(1);
-        softAssertions.assertAll();
-    }
-
-    @Test
-    void 카페_사장이_자신의_카페_리워드가_아니면_사용할_수_없다() {
+    void 자신의_카페가_아니면_리워드_조회_불가능하다() {
         // given
         Customer customer = 가입_회원_생성_후_가입_고객_반환();
         Owner owner = 카페_사장_생성_후_사장_반환();
         Owner notOwner = ownerRepository.save(new Owner("notowner", "id", "pw", "01093726453"));
 
+
         CafeCreateRequest cafeCreateRequest = new CafeCreateRequest("cafe", "잠실", "루터회관", "111111111");
         Long cafeId = 카페_생성_요청하고_아이디_반환(owner, cafeCreateRequest);
         CouponCreateRequest couponCreateRequest = new CouponCreateRequest(cafeId);
         Long couponId = 쿠폰_생성_요청하고_아이디_반환(owner, couponCreateRequest, customer.getId());
         StampCreateRequest stampCreateRequest = new StampCreateRequest(10);
         쿠폰에_스탬프를_적립_요청(owner, customer, couponId, stampCreateRequest);
-        ExtractableResponse<Response> rewardsResponse = 리워드_목록_조회(owner, cafeId, customer.getId());
-        List<RewardFindResponse> rewards = rewardsResponse.body().as(RewardsFindResponse.class).getRewards();
-        Long rewardId = rewards.get(0).getId();
 
-        //when
-        RewardUsedUpdateRequest request = new RewardUsedUpdateRequest(cafeId, true);
-        ExtractableResponse<Response> response = 리워드_사용(notOwner, request, customer.getId(), rewardId);
+        // when
+        ExtractableResponse<Response> response = 리워드_목록_조회(notOwner, cafeId, customer.getId());
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(401);
+    }
+
+    @Test
+    void 자신의_카페_고객이_아니면_리워드_조회가_불가능하다() {
+        // given
+        Customer customer = 가입_회원_생성_후_가입_고객_반환();
+        Owner owner = 카페_사장_생성_후_사장_반환();
+
+        Customer notMyCustomer = customerRepository.save(Customer.registeredCustomerBuilder()
+                .nickname("jena")
+                .build());
+
+
+        CafeCreateRequest cafeCreateRequest = new CafeCreateRequest("cafe", "잠실", "루터회관", "111111111");
+        Long cafeId = 카페_생성_요청하고_아이디_반환(owner, cafeCreateRequest);
+        CouponCreateRequest couponCreateRequest = new CouponCreateRequest(cafeId);
+        Long couponId = 쿠폰_생성_요청하고_아이디_반환(owner, couponCreateRequest, customer.getId());
+        StampCreateRequest stampCreateRequest = new StampCreateRequest(10);
+        쿠폰에_스탬프를_적립_요청(owner, customer, couponId, stampCreateRequest);
+
+        // when
+        ExtractableResponse<Response> response = 리워드_목록_조회(owner, cafeId, notMyCustomer.getId());
 
         // then
         assertThat(response.statusCode()).isEqualTo(401);

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/ManagerRewardFindAcceptanceTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/ManagerRewardFindAcceptanceTest.java
@@ -105,8 +105,6 @@ public class ManagerRewardFindAcceptanceTest extends AcceptanceTest {
         Customer customer = Customer.registeredCustomerBuilder()
                 .nickname("leo")
                 .email("leo@gmail.com")
-                .loginId("leoId")
-                .encryptedPassword("pw")
                 .oAuthProvider(OAuthProvider.KAKAO)
                 .oAuthId(123L)
                 .build();

--- a/backend/src/test/java/com/stampcrush/backend/application/manager/reward/ManagerRewardCommandServiceTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/application/manager/reward/ManagerRewardCommandServiceTest.java
@@ -8,10 +8,12 @@ import com.stampcrush.backend.entity.cafe.Cafe;
 import com.stampcrush.backend.entity.reward.Reward;
 import com.stampcrush.backend.entity.user.Customer;
 import com.stampcrush.backend.entity.user.Owner;
+import com.stampcrush.backend.entity.visithistory.VisitHistory;
 import com.stampcrush.backend.repository.cafe.CafeRepository;
 import com.stampcrush.backend.repository.reward.RewardRepository;
 import com.stampcrush.backend.repository.user.CustomerRepository;
 import com.stampcrush.backend.repository.user.OwnerRepository;
+import com.stampcrush.backend.repository.visithistory.VisitHistoryRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -47,6 +49,9 @@ class ManagerRewardCommandServiceTest {
     @Autowired
     private CustomerRepository customerRepository;
 
+    @Autowired
+    private VisitHistoryRepository visitHistoryRepository;
+
     private Owner owner_1;
     private Owner owner_2;
     private Cafe cafe_1;
@@ -81,6 +86,8 @@ class ManagerRewardCommandServiceTest {
         temporaryCustomer = customerRepository.save(Customer.temporaryCustomerBuilder()
                 .phoneNumber("01033333333")
                 .build());
+
+        VisitHistory visitHistory = visitHistoryRepository.save(new VisitHistory(cafe_1, registerCustomer_1, 3));
 
         unusedReward = rewardRepository.save(new Reward("Americano", registerCustomer_1, cafe_1));
     }

--- a/backend/src/test/java/com/stampcrush/backend/repository/visithistory/VisitHistoryRepositoryTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/repository/visithistory/VisitHistoryRepositoryTest.java
@@ -67,7 +67,6 @@ class VisitHistoryRepositoryTest {
 
     @Test
     void 특정_카페에_대한_특정_고객의_방문_이력을_조회한다() {
-//        Customer.createRegisteredCustomer("jena", "01012345678", OAuthProvider.KAKAO, 123L);
         // given
         Customer registered = Customer.registeredCustomerBuilder()
                 .nickname("jena")
@@ -121,5 +120,36 @@ class VisitHistoryRepositoryTest {
         // then
         assertThat(customer1Cafe1VisitHistory).usingRecursiveComparison().isEqualTo(expected1);
         assertThat(customer2Cafe2VisitHistory).usingRecursiveComparison().isEqualTo(expected2);
+    }
+
+    @Test
+    void 카페_아이디와_고객_아이디로_방문횟수를_조회한다() {
+        Customer registered = Customer.registeredCustomerBuilder()
+                .nickname("jena")
+                .phoneNumber("01012345678")
+                .build();
+        Customer customer1 = customerRepository.save(registered);
+
+        Customer customer2 = customerRepository.save(Customer.temporaryCustomerBuilder()
+                .phoneNumber("010000011111")
+                .build());
+
+        Owner cafe1Owner = ownerRepository.save(new Owner("owner1", "owner1Id", "owner1Pw", "01076532456"));
+        Cafe cafe1 = cafeRepository.save(new Cafe("우아한카페",
+                LocalTime.NOON,
+                LocalTime.MIDNIGHT,
+                "01012345678",
+                "cafeImageUrl",
+                "introduction",
+                "roadAddress",
+                "detailAddress",
+                "buisnessRegistrationNumber",
+                cafe1Owner
+        ));
+
+        VisitHistory visitHistory1 = visitHistoryRepository.save(new VisitHistory(cafe1, customer1, 3));
+        VisitHistory visitHistory2 = visitHistoryRepository.save(new VisitHistory(cafe1, customer2, 5));
+
+        assertThat(visitHistoryRepository.findByCafeIdAndCustomerId(cafe1.getId(), customer1.getId())).containsExactly(visitHistory1);
     }
 }


### PR DESCRIPTION
## 주요 변경사항


## 리뷰어에게...

- 풀리퀘 #678 과 동일한 변경입니다
- 깃꼬여서 다시 PR 올렸습니다
- 어프루브 다 받은거 + 제가 맡은 부분 인수테스트 회원가입 API 로 수정하려면 이 PR 이 머지가 되어야 해서 머지하겠습니다

## 관련 이슈

closes #523 

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [x] `milestone` 설정
