### PR TITLE
[BE] refactor: Visitor.cafe, Manager.reward 인수테스트를 리팩터링한다

### DIFF
--- a/backend/src/test/java/com/stampcrush/backend/acceptance/AcceptanceTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/AcceptanceTest.java
@@ -1,5 +1,6 @@
 package com.stampcrush.backend.acceptance;
 
+import com.stampcrush.backend.auth.application.util.AuthTokensGenerator;
 import com.stampcrush.backend.common.DataCleaner;
 import com.stampcrush.backend.common.DataClearExtension;
 import com.stampcrush.backend.common.KorNamingConverter;
@@ -18,9 +19,10 @@ import static org.springframework.boot.test.context.SpringBootTest.WebEnvironmen
 @SpringBootTest(webEnvironment = RANDOM_PORT)
 public class AcceptanceTest {
 
+    @Autowired
+    protected AuthTokensGenerator authTokensGenerator;
     @LocalServerPort
     private int port;
-
     @Autowired
     private DataCleaner cleaner;
 

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/VisitorCafeFindAcceptanceTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/VisitorCafeFindAcceptanceTest.java
@@ -3,20 +3,22 @@ package com.stampcrush.backend.acceptance;
 import com.stampcrush.backend.api.visitor.cafe.response.CafeInfoFindByCustomerResponse;
 import com.stampcrush.backend.api.visitor.cafe.response.CafeInfoFindResponse;
 import com.stampcrush.backend.application.visitor.cafe.dto.CafeInfoFindByCustomerResultDto;
+import com.stampcrush.backend.auth.api.request.OAuthRegisterCustomerCreateRequest;
+import com.stampcrush.backend.auth.api.request.OAuthRegisterOwnerCreateRequest;
 import com.stampcrush.backend.entity.cafe.Cafe;
-import com.stampcrush.backend.entity.user.Customer;
-import com.stampcrush.backend.fixture.CustomerFixture;
-import com.stampcrush.backend.fixture.OwnerFixture;
 import com.stampcrush.backend.repository.cafe.CafeRepository;
-import com.stampcrush.backend.repository.user.CustomerRepository;
-import com.stampcrush.backend.repository.user.OwnerRepository;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import static com.stampcrush.backend.acceptance.step.ManagerCafeCreateStep.CAFE_CREATE_REQUEST;
+import static com.stampcrush.backend.acceptance.step.ManagerCafeCreateStep.카페_생성_요청하고_아이디_반환_2;
+import static com.stampcrush.backend.acceptance.step.ManagerJoinStep.O_AUTH_OWNER_CREATE_REQUEST;
+import static com.stampcrush.backend.acceptance.step.ManagerJoinStep.카페_사장_회원_가입_요청하고_액세스_토큰_반환;
 import static com.stampcrush.backend.acceptance.step.VisitorCafeFindStep.고객의_카페_정보_조회_요청;
-import static com.stampcrush.backend.fixture.CafeFixture.cafeOfSavedOwner;
+import static com.stampcrush.backend.acceptance.step.VisitorJoinStep.O_AUTH_REGISTER_CUSTOMER_CREATE_REQUEST_JENA;
+import static com.stampcrush.backend.acceptance.step.VisitorJoinStep.가입_고객_회원_가입_요청하고_액세스_토큰_반환;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 
@@ -25,35 +27,35 @@ public class VisitorCafeFindAcceptanceTest extends AcceptanceTest {
     @Autowired
     private CafeRepository cafeRepository;
 
-    @Autowired
-    private OwnerRepository ownerRepository;
-
-    @Autowired
-    private CustomerRepository customerRepository;
-
     @Test
     void 고객이_카페정보를_조회한다() {
         // given
-        Customer customer = customerRepository.save(CustomerFixture.REGISTER_CUSTOMER_JENA);
-        Cafe savedCafe = cafeRepository.save(cafeOfSavedOwner(ownerRepository.save(OwnerFixture.GITCHAN))
-        );
+        OAuthRegisterCustomerCreateRequest registerCustomerCreateRequest = O_AUTH_REGISTER_CUSTOMER_CREATE_REQUEST_JENA;
+        String accessTokenCustomer = 가입_고객_회원_가입_요청하고_액세스_토큰_반환(registerCustomerCreateRequest);
+
+        OAuthRegisterOwnerCreateRequest registerOwnerCreateRequest = O_AUTH_OWNER_CREATE_REQUEST;
+        String accessTokenOwner = 카페_사장_회원_가입_요청하고_액세스_토큰_반환(registerOwnerCreateRequest);
+
+        Long cafeId = 카페_생성_요청하고_아이디_반환_2(accessTokenOwner, CAFE_CREATE_REQUEST);
+        Cafe cafe = cafeRepository.findById(cafeId).get();
 
         // when
-        ExtractableResponse<Response> response = 고객의_카페_정보_조회_요청(customer, savedCafe.getId());
+        ExtractableResponse<Response> response = 고객의_카페_정보_조회_요청(accessTokenCustomer, cafeId);
         CafeInfoFindByCustomerResponse cafeInfoFindByCustomerResponse = response.body().as(CafeInfoFindByCustomerResponse.class);
 
         // then
         assertThat(cafeInfoFindByCustomerResponse.getCafe())
                 .usingRecursiveComparison()
-                .isEqualTo(CafeInfoFindResponse.from(CafeInfoFindByCustomerResultDto.from(savedCafe)));
+                .isEqualTo(CafeInfoFindResponse.from(CafeInfoFindByCustomerResultDto.from(cafe)));
     }
 
     @Test
     void 고객이_존재하지_않는_카페를_조회하면_에러가_발생한다() {
-        Customer customer = customerRepository.save(CustomerFixture.REGISTER_CUSTOMER_JENA);
+        OAuthRegisterCustomerCreateRequest registerCustomerCreateRequest = O_AUTH_REGISTER_CUSTOMER_CREATE_REQUEST_JENA;
+        String accessTokenCustomer = 가입_고객_회원_가입_요청하고_액세스_토큰_반환(registerCustomerCreateRequest);
 
         long NOT_EXIST_CAFE_ID = 1L;
-        ExtractableResponse<Response> response = 고객의_카페_정보_조회_요청(customer, NOT_EXIST_CAFE_ID);
+        ExtractableResponse<Response> response = 고객의_카페_정보_조회_요청(accessTokenCustomer, NOT_EXIST_CAFE_ID);
 
         assertThat(response.statusCode()).isEqualTo(NOT_FOUND.value());
     }

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/step/ManagerCafeCreateStep.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/step/ManagerCafeCreateStep.java
@@ -34,4 +34,26 @@ public class ManagerCafeCreateStep {
                 .log().all()
                 .extract();
     }
+
+    public static Long 카페_생성_요청하고_아이디_반환_2(String accessToken, CafeCreateRequest cafeCreateRequest) {
+        ExtractableResponse<Response> response = 카페_생성_요청_2(accessToken, cafeCreateRequest);
+        String location = response.header("Location");
+        return Long.valueOf(location.split("/")[2]);
+    }
+
+    public static ExtractableResponse<Response> 카페_생성_요청_2(String accessToken, CafeCreateRequest cafeCreateRequest) {
+        return RestAssured.given()
+                .log().all()
+                .contentType(JSON)
+                .body(cafeCreateRequest)
+                .auth().preemptive()
+                .oauth2(accessToken)
+
+                .when()
+                .post("/api/admin/cafes")
+
+                .then()
+                .log().all()
+                .extract();
+    }
 }

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/step/ManagerCouponCreateStep.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/step/ManagerCouponCreateStep.java
@@ -33,4 +33,26 @@ public class ManagerCouponCreateStep {
                 .log().all()
                 .extract();
     }
+
+    public static Long 쿠폰_생성_요청하고_아이디_반환_2(String accessToken, CouponCreateRequest request, Long customerId) {
+        ExtractableResponse<Response> response = 쿠폰_생성_요청_2(accessToken, request, customerId);
+        CouponCreateResponse couponCreateResponse = response.body().as(CouponCreateResponse.class);
+        return couponCreateResponse.getCouponId();
+    }
+
+    public static ExtractableResponse<Response> 쿠폰_생성_요청_2(String accessToken, CouponCreateRequest request, Long customerId) {
+        return RestAssured.given()
+                .log().all()
+                .contentType(JSON)
+                .body(request)
+                .auth().preemptive()
+                .oauth2(accessToken)
+
+                .when()
+                .post("/api/admin/customers/" + customerId + "/coupons")
+
+                .then()
+                .log().all()
+                .extract();
+    }
 }

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/step/ManagerJoinStep.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/step/ManagerJoinStep.java
@@ -1,5 +1,6 @@
 package com.stampcrush.backend.acceptance.step;
 
+import com.stampcrush.backend.auth.OAuthProvider;
 import com.stampcrush.backend.auth.api.request.OAuthRegisterOwnerCreateRequest;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
@@ -8,6 +9,12 @@ import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
 
 public class ManagerJoinStep {
+
+    public static final OAuthRegisterOwnerCreateRequest O_AUTH_OWNER_CREATE_REQUEST = new OAuthRegisterOwnerCreateRequest(
+            "owner",
+            OAuthProvider.KAKAO,
+            938273L
+    );
 
     public static String 카페_사장_회원_가입_요청하고_액세스_토큰_반환(OAuthRegisterOwnerCreateRequest request) {
         ExtractableResponse<Response> response = 카페_사장_회원_가입_요청(request);

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/step/ManagerJoinStep.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/step/ManagerJoinStep.java
@@ -16,6 +16,12 @@ public class ManagerJoinStep {
             938273L
     );
 
+    public static final OAuthRegisterOwnerCreateRequest O_AUTH_OWNER_CREATE_REQUEST_2 = new OAuthRegisterOwnerCreateRequest(
+            "notOwner",
+            OAuthProvider.KAKAO,
+            932862L
+    );
+
     public static String 카페_사장_회원_가입_요청하고_액세스_토큰_반환(OAuthRegisterOwnerCreateRequest request) {
         ExtractableResponse<Response> response = 카페_사장_회원_가입_요청(request);
         return response.jsonPath().getString("accessToken");

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/step/ManagerRewardStep.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/step/ManagerRewardStep.java
@@ -1,8 +1,6 @@
 package com.stampcrush.backend.acceptance.step;
 
 import com.stampcrush.backend.api.manager.reward.request.RewardUsedUpdateRequest;
-import com.stampcrush.backend.entity.user.Owner;
-import com.stampcrush.backend.helper.BearerAuthHelper;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 
@@ -11,13 +9,13 @@ import static io.restassured.http.ContentType.JSON;
 
 public class ManagerRewardStep {
 
-    public static ExtractableResponse<Response> 리워드_사용(Owner owner, RewardUsedUpdateRequest rewardUsedUpdateRequest, Long customerId, Long rewardId) {
+    public static ExtractableResponse<Response> 리워드_사용(String accessToken, RewardUsedUpdateRequest rewardUsedUpdateRequest, Long customerId, Long rewardId) {
         return given()
                 .log().all()
                 .contentType(JSON)
                 .body(rewardUsedUpdateRequest)
                 .auth().preemptive()
-                .oauth2(BearerAuthHelper.generateToken(owner.getId()))
+                .oauth2(accessToken)
 
                 .when()
                 .patch("/api/admin/customers/" + customerId + "/rewards/" + rewardId)
@@ -26,14 +24,14 @@ public class ManagerRewardStep {
                 .extract();
     }
 
-    public static ExtractableResponse<Response> 리워드_목록_조회(Owner owner, Long cafeId, Long customerId) {
+    public static ExtractableResponse<Response> 리워드_목록_조회(String accessToken, Long cafeId, Long customerId) {
         return given()
                 .log().all()
                 .queryParam("cafe-id", cafeId)
                 .queryParam("used", false)
                 .contentType(JSON)
                 .auth().preemptive()
-                .oauth2(BearerAuthHelper.generateToken(owner.getId()))
+                .oauth2(accessToken)
 
                 .when()
                 .get("/api/admin/customers/" + customerId + "/rewards")

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/step/ManagerStampCreateStep.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/step/ManagerStampCreateStep.java
@@ -27,4 +27,20 @@ public class ManagerStampCreateStep {
                 .log().all()
                 .extract();
     }
+
+    public static ExtractableResponse<Response> 쿠폰에_스탬프를_적립_요청_2(String accessToken, Long customerId, Long couponId, StampCreateRequest stampCreateRequest) {
+        return given()
+                .log().all()
+                .body(stampCreateRequest)
+                .contentType(JSON)
+                .auth().preemptive()
+                .oauth2(accessToken)
+
+                .when()
+                .post("/api/admin/customers/{customerId}/coupons/{couponId}/stamps", customerId, couponId)
+
+                .then()
+                .log().all()
+                .extract();
+    }
 }

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/step/VisitorCafeFindStep.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/step/VisitorCafeFindStep.java
@@ -1,7 +1,5 @@
 package com.stampcrush.backend.acceptance.step;
 
-import com.stampcrush.backend.entity.user.Customer;
-import com.stampcrush.backend.helper.BearerAuthHelper;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import org.springframework.http.MediaType;
@@ -10,12 +8,12 @@ import static io.restassured.RestAssured.given;
 
 public final class VisitorCafeFindStep {
 
-    public static ExtractableResponse<Response> 고객의_카페_정보_조회_요청(Customer customer, Long cafeId) {
+    public static ExtractableResponse<Response> 고객의_카페_정보_조회_요청(String accessToken, Long cafeId) {
         return given()
                 .log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .auth().preemptive()
-                .oauth2(BearerAuthHelper.generateToken(customer.getId()))
+                .oauth2(accessToken)
 
                 .when()
                 .get("/api/cafes/" + cafeId)

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/step/VisitorJoinStep.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/step/VisitorJoinStep.java
@@ -1,5 +1,6 @@
 package com.stampcrush.backend.acceptance.step;
 
+import com.stampcrush.backend.auth.OAuthProvider;
 import com.stampcrush.backend.auth.api.request.OAuthRegisterCustomerCreateRequest;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
@@ -9,6 +10,13 @@ import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
 
 public class VisitorJoinStep {
+
+    public static final OAuthRegisterCustomerCreateRequest O_AUTH_REGISTER_CUSTOMER_CREATE_REQUEST_JENA = new OAuthRegisterCustomerCreateRequest(
+            "jena",
+            "jena@gmail.com",
+            OAuthProvider.KAKAO,
+            938272L
+    );
 
     public static Long 임시_고객_회원_가입_요청하고_아이디_반환(String phoneNumber) {
         ExtractableResponse<Response> response = 임시_고객_회원_가입_요청(phoneNumber);


### PR DESCRIPTION
## 주요 변경사항

- Visitor.cafe, Manager.reward 인수테스트를 회원가입 API 를 사용하도록 리팩터링했습니다
- Step 객체들의 매개변수를 accessToken 으로 바꿔줘야할 필요가 있어 제가 담당한 패키지가 아닌 Step 을 바꿔줘야 할때는 새로 함수 추가했습니다(충돌 방지!) 
- 인수테스트 수정이 다 머지가 되고 나면 통일하면 될거같아요

## 리뷰어에게...

## 관련 이슈

closes

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [x] `milestone` 설정
