### PR TITLE
[BE] feat: 5차 데모데이때 추가된 API 에 대한 문서화 테스트를 작성한다

### DIFF
--- a/backend/src/test/java/com/stampcrush/backend/api/docs/manager/cafe/ManagerCafeCommandApiDocsControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/docs/manager/cafe/ManagerCafeCommandApiDocsControllerTest.java
@@ -23,7 +23,7 @@ import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-public class ManagerCafeCommandApiDocsControllerTest extends DocsControllerTest {
+class ManagerCafeCommandApiDocsControllerTest extends DocsControllerTest {
 
     @Test
     void 카페_상세_정보_변경() throws Exception {
@@ -48,7 +48,7 @@ public class ManagerCafeCommandApiDocsControllerTest extends DocsControllerTest 
                                         ResourceSnippetParameters.builder()
                                                 .tag("사장 모드")
                                                 .description("카페 상세 정보 업데이트")
-                                                .requestHeaders(headerWithName("Authorization").description("임시(Basic)"))
+                                                .requestHeaders(headerWithName("Authorization").description("Bearer"))
                                                 .requestFields(
                                                         fieldWithPath("openTime").description("오픈 시간"),
                                                         fieldWithPath("closeTime").description("마감 시간"),
@@ -92,7 +92,7 @@ public class ManagerCafeCommandApiDocsControllerTest extends DocsControllerTest 
                                         ResourceSnippetParameters.builder()
                                                 .tag("사장 모드")
                                                 .description("카페 등록")
-                                                .requestHeaders(headerWithName("Authorization").description("임시(Basic)"))
+                                                .requestHeaders(headerWithName("Authorization").description("Bearer"))
                                                 .requestFields(fieldWithPath("name").description("카페 이름"),
                                                         fieldWithPath("roadAddress").description("도로명 주소"),
                                                         fieldWithPath("detailAddress").description("상세 주소"),

--- a/backend/src/test/java/com/stampcrush/backend/api/docs/manager/cafe/ManagerCafeCouponSettingCommandApiDocsControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/docs/manager/cafe/ManagerCafeCouponSettingCommandApiDocsControllerTest.java
@@ -22,7 +22,7 @@ import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-public class ManagerCafeCouponSettingCommandApiDocsControllerTest extends DocsControllerTest {
+class ManagerCafeCouponSettingCommandApiDocsControllerTest extends DocsControllerTest {
 
     @Test
     void 쿠폰_디자인_및_정책_수정() throws Exception {
@@ -54,7 +54,7 @@ public class ManagerCafeCouponSettingCommandApiDocsControllerTest extends DocsCo
                                         ResourceSnippetParameters.builder()
                                                 .tag("사장 모드")
                                                 .description("쿠폰 디자인 및 정책 수정")
-                                                .requestHeaders(headerWithName("Authorization").description("임시(Basic)"))
+                                                .requestHeaders(headerWithName("Authorization").description("Bearer"))
                                                 .queryParameters(parameterWithName("cafe-id").description("카페 ID"))
                                                 .requestFields(
                                                         fieldWithPath("frontImageUrl").description("쿠폰 앞면 이미지 URL"),

--- a/backend/src/test/java/com/stampcrush/backend/api/docs/manager/cafe/ManagerCafeCouponSettingFindApiDocsControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/docs/manager/cafe/ManagerCafeCouponSettingFindApiDocsControllerTest.java
@@ -23,7 +23,7 @@ import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-public class ManagerCafeCouponSettingFindApiDocsControllerTest extends DocsControllerTest {
+class ManagerCafeCouponSettingFindApiDocsControllerTest extends DocsControllerTest {
 
     @Test
     void 현재_카페의_쿠폰_디자인_정책_조회() throws Exception {
@@ -57,7 +57,7 @@ public class ManagerCafeCouponSettingFindApiDocsControllerTest extends DocsContr
                                         ResourceSnippetParameters.builder()
                                                 .tag("사장 모드")
                                                 .description("카페의 현재 쿠폰 디자인 조회")
-                                                .requestHeaders(headerWithName("Authorization").description("임시(Basic)"))
+                                                .requestHeaders(headerWithName("Authorization").description("Bearer"))
                                                 .queryParameters(parameterWithName("cafe-id").description("카페 Id"))
                                                 .responseFields(
                                                         fieldWithPath("frontImageUrl").description("프론트 이미지 URL"),
@@ -108,7 +108,7 @@ public class ManagerCafeCouponSettingFindApiDocsControllerTest extends DocsContr
                                         ResourceSnippetParameters.builder()
                                                 .tag("사장 모드")
                                                 .description("쿠폰이 발급될때의 쿠폰 디자인 조회")
-                                                .requestHeaders(headerWithName("Authorization").description("임시(Basic)"))
+                                                .requestHeaders(headerWithName("Authorization").description("Bearer"))
                                                 .queryParameters(parameterWithName("cafe-id").description("카페 Id"))
                                                 .responseFields(
                                                         fieldWithPath("frontImageUrl").description("프론트 이미지 URL"),

--- a/backend/src/test/java/com/stampcrush/backend/api/docs/manager/cafe/ManagerCafeFindApiDocsControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/docs/manager/cafe/ManagerCafeFindApiDocsControllerTest.java
@@ -44,7 +44,7 @@ class ManagerCafeFindApiDocsControllerTest extends DocsControllerTest {
                                         ResourceSnippetParameters.builder()
                                                 .tag("사장 모드")
                                                 .description("카페 정보 조회")
-                                                .requestHeaders(headerWithName("Authorization").description("임시(Basic)"))
+                                                .requestHeaders(headerWithName("Authorization").description("Bearer"))
                                                 .responseFields(
                                                         fieldWithPath("cafes[].id").description("카페 ID"),
                                                         fieldWithPath("cafes[].name").description("카페 이름"),

--- a/backend/src/test/java/com/stampcrush/backend/api/docs/manager/coupon/ManagerCouponCommandApiDocsControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/docs/manager/coupon/ManagerCouponCommandApiDocsControllerTest.java
@@ -21,7 +21,7 @@ import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-public class ManagerCouponCommandApiDocsControllerTest extends DocsControllerTest {
+class ManagerCouponCommandApiDocsControllerTest extends DocsControllerTest {
 
     @Test
     void 쿠폰_신규_발급() throws Exception {
@@ -47,7 +47,7 @@ public class ManagerCouponCommandApiDocsControllerTest extends DocsControllerTes
                                         ResourceSnippetParameters.builder()
                                                 .tag("사장 모드")
                                                 .description("쿠폰 신규 발급")
-                                                .requestHeaders(headerWithName("Authorization").description("임시(Basic)"))
+                                                .requestHeaders(headerWithName("Authorization").description("Bearer"))
                                                 .requestFields(fieldWithPath("cafeId").description("카페 ID"))
                                                 .requestSchema(Schema.schema("CouponCreateRequest"))
                                                 .responseFields(fieldWithPath("couponId").description("쿠폰 ID"))
@@ -82,7 +82,7 @@ public class ManagerCouponCommandApiDocsControllerTest extends DocsControllerTes
                                         ResourceSnippetParameters.builder()
                                                 .tag("사장 모드")
                                                 .description("스탬프 적립")
-                                                .requestHeaders(headerWithName("Authorization").description("임시(Basic)"))
+                                                .requestHeaders(headerWithName("Authorization").description("Bearer"))
                                                 .requestFields(fieldWithPath("earningStampCount").description("적립할 스탬프 개수"))
                                                 .requestSchema(Schema.schema("StampCreateRequest"))
                                                 .build()

--- a/backend/src/test/java/com/stampcrush/backend/api/docs/manager/coupon/ManagerCouponFindApiDocsControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/docs/manager/coupon/ManagerCouponFindApiDocsControllerTest.java
@@ -24,7 +24,7 @@ import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-public class ManagerCouponFindApiDocsControllerTest extends DocsControllerTest {
+class ManagerCouponFindApiDocsControllerTest extends DocsControllerTest {
 
     @Test
     void 고객의_쿠폰_조회() throws Exception {
@@ -53,7 +53,7 @@ public class ManagerCouponFindApiDocsControllerTest extends DocsControllerTest {
                                 ResourceSnippetParameters.builder()
                                         .tag("사장 모드")
                                         .description("고객의 쿠폰 조회")
-                                        .requestHeaders(headerWithName("Authorization").description("임시(Basic)"))
+                                        .requestHeaders(headerWithName("Authorization").description("Bearer"))
                                         .queryParameters(ResourceDocumentation.parameterWithName("cafe-id").description("카페 Id"),
                                                 ResourceDocumentation.parameterWithName("active").description("true(활성화된 쿠폰만 조회)"))
                                         .responseFields(
@@ -93,7 +93,7 @@ public class ManagerCouponFindApiDocsControllerTest extends DocsControllerTest {
                                 ResourceSnippetParameters.builder()
                                         .tag("사장 모드")
                                         .description("고객 목록 조회")
-                                        .requestHeaders(headerWithName("Authorization").description("임시(Basic)"))
+                                        .requestHeaders(headerWithName("Authorization").description("Bearer"))
                                         .responseFields(
                                                 fieldWithPath("customers[].id").description("고객 ID"),
                                                 fieldWithPath("customers[].nickname").description("닉네임"),

--- a/backend/src/test/java/com/stampcrush/backend/api/docs/manager/customer/ManagerCustomerCommandApiDocsControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/docs/manager/customer/ManagerCustomerCommandApiDocsControllerTest.java
@@ -44,7 +44,7 @@ class ManagerCustomerCommandApiDocsControllerTest extends DocsControllerTest {
                                         ResourceSnippetParameters.builder()
                                                 .tag("사장 모드")
                                                 .description("임시 고객 생성")
-                                                .requestHeaders(headerWithName("Authorization").description("임시(Basic)"))
+                                                .requestHeaders(headerWithName("Authorization").description("Bearer"))
                                                 .requestFields(fieldWithPath("phoneNumber").description("고객 전화번호"))
                                                 .requestSchema(Schema.schema("TemporaryCustomerCreateRequest"))
                                                 .responseHeaders(headerWithName("Location").description("/customers/{customerId}"))

--- a/backend/src/test/java/com/stampcrush/backend/api/docs/manager/customer/ManagerCustomerFindApiDocsControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/docs/manager/customer/ManagerCustomerFindApiDocsControllerTest.java
@@ -44,7 +44,7 @@ class ManagerCustomerFindApiDocsControllerTest extends DocsControllerTest {
                                         ResourceSnippetParameters.builder()
                                                 .tag("사장 모드")
                                                 .description("전화번호로 고객 조회")
-                                                .requestHeaders(headerWithName("Authorization").description("임시(Basic)"))
+                                                .requestHeaders(headerWithName("Authorization").description("Bearer"))
                                                 .queryParameters(parameterWithName("phone-number").description("입력한 전화번호"))
                                                 .responseFields(
                                                         fieldWithPath("customer[].id").description("고객 ID"),

--- a/backend/src/test/java/com/stampcrush/backend/api/docs/manager/image/ManagerImageCommandApiDocsControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/docs/manager/image/ManagerImageCommandApiDocsControllerTest.java
@@ -15,6 +15,7 @@ import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.docume
 import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -44,6 +45,7 @@ public class ManagerImageCommandApiDocsControllerTest extends DocsControllerTest
                                         ResourceSnippetParameters.builder()
                                                 .tag("사장 모드")
                                                 .description("이미지 업로드")
+                                                .requestHeaders(headerWithName("Authorization").description("Bearer"))
                                                 .responseFields(
                                                         fieldWithPath("imageUrl").description("업로드한 이미지의 Url")
                                                 )

--- a/backend/src/test/java/com/stampcrush/backend/api/docs/manager/reward/ManagerRewardCommandApiDocsControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/docs/manager/reward/ManagerRewardCommandApiDocsControllerTest.java
@@ -20,7 +20,7 @@ import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-public class ManagerRewardCommandApiDocsControllerTest extends DocsControllerTest {
+class ManagerRewardCommandApiDocsControllerTest extends DocsControllerTest {
 
     @Test
     void 리워드_사용() throws Exception {
@@ -44,7 +44,7 @@ public class ManagerRewardCommandApiDocsControllerTest extends DocsControllerTes
                                         ResourceSnippetParameters.builder()
                                                 .tag("사장 모드")
                                                 .description("리워드 사용")
-                                                .requestHeaders(headerWithName("Authorization").description("임시(Basic)"))
+                                                .requestHeaders(headerWithName("Authorization").description("Bearer"))
                                                 .requestFields(fieldWithPath("cafeId").description("카페 Id"),
                                                         fieldWithPath("used").description("사용(true)"))
                                                 .requestSchema(Schema.schema("RewardUsedUpdateRequest"))

--- a/backend/src/test/java/com/stampcrush/backend/api/docs/manager/reward/ManagerRewardFindApiDocsControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/docs/manager/reward/ManagerRewardFindApiDocsControllerTest.java
@@ -24,7 +24,7 @@ import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-public class ManagerRewardFindApiDocsControllerTest extends DocsControllerTest {
+class ManagerRewardFindApiDocsControllerTest extends DocsControllerTest {
 
     @Test
     void 고객의_리워드_조회() throws Exception {
@@ -53,7 +53,7 @@ public class ManagerRewardFindApiDocsControllerTest extends DocsControllerTest {
                                         ResourceSnippetParameters.builder()
                                                 .tag("사장 모드")
                                                 .description("고객의 리워드 조회")
-                                                .requestHeaders(headerWithName("Authorization").description("임시(Basic)"))
+                                                .requestHeaders(headerWithName("Authorization").description("Bearer"))
                                                 .queryParameters(parameterWithName("cafe-id").description("카페 Id"),
                                                         parameterWithName("used").description("false"))
                                                 .responseFields(

--- a/backend/src/test/java/com/stampcrush/backend/api/docs/manager/sample/ManagerSampleCouponFindApiDocsControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/docs/manager/sample/ManagerSampleCouponFindApiDocsControllerTest.java
@@ -56,7 +56,7 @@ public class ManagerSampleCouponFindApiDocsControllerTest extends DocsController
                                         ResourceSnippetParameters.builder()
                                                 .tag("사장 모드")
                                                 .description("스탬프 개수별로 기본 샘플 조회")
-                                                .requestHeaders(headerWithName("Authorization").description("임시(Basic)"))
+                                                .requestHeaders(headerWithName("Authorization").description("Bearer"))
                                                 .queryParameters(parameterWithName("max-stamp-count").description("스탬프 개수(8, 10, 12)"))
                                                 .responseFields(
                                                         fieldWithPath("sampleFrontImages[].id").description("쿠폰 앞면 이미지 ID"),

--- a/backend/src/test/java/com/stampcrush/backend/api/docs/visitor/cafe/VisitorCafeFindApiDocsControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/docs/visitor/cafe/VisitorCafeFindApiDocsControllerTest.java
@@ -42,7 +42,7 @@ class VisitorCafeFindApiDocsControllerTest extends DocsControllerTest {
                                         ResourceSnippetParameters.builder()
                                                 .tag("고객 모드")
                                                 .description("카페 정보 조회")
-                                                .requestHeaders(headerWithName("Authorization").description("임시(Basic)"))
+                                                .requestHeaders(headerWithName("Authorization").description("Bearer"))
                                                 .responseFields(
                                                         fieldWithPath("cafe.id").description("카페 ID"),
                                                         fieldWithPath("cafe.name").description("카페 이름"),

--- a/backend/src/test/java/com/stampcrush/backend/api/docs/visitor/coupon/VisitorCouponCommandApiDocsControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/docs/visitor/coupon/VisitorCouponCommandApiDocsControllerTest.java
@@ -19,7 +19,7 @@ import static org.springframework.restdocs.headers.HeaderDocumentation.headerWit
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-public class VisitorCouponCommandApiDocsControllerTest extends DocsControllerTest {
+class VisitorCouponCommandApiDocsControllerTest extends DocsControllerTest {
 
     @Test
     void 쿠폰_삭제() throws Exception {
@@ -46,7 +46,7 @@ public class VisitorCouponCommandApiDocsControllerTest extends DocsControllerTes
                                         ResourceSnippetParameters.builder()
                                                 .tag("고객 모드")
                                                 .description("쿠폰 삭제")
-                                                .requestHeaders(headerWithName("Authorization").description("임시(Basic)"))
+                                                .requestHeaders(headerWithName("Authorization").description("Bearer"))
                                                 .build()
                                 )
                         )

--- a/backend/src/test/java/com/stampcrush/backend/api/docs/visitor/coupon/VisitorCouponFindApiDocsControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/docs/visitor/coupon/VisitorCouponFindApiDocsControllerTest.java
@@ -23,7 +23,7 @@ import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-public class VisitorCouponFindApiDocsControllerTest extends DocsControllerTest {
+class VisitorCouponFindApiDocsControllerTest extends DocsControllerTest {
 
     @Test
     void 고객의_쿠폰_조회_요청_시_인증이_되면_200_상태코드와_응답을_반환한다() throws Exception {
@@ -47,38 +47,38 @@ public class VisitorCouponFindApiDocsControllerTest extends DocsControllerTest {
         when(authTokensGenerator.extractMemberId(anyString())).thenReturn(CUSTOMER.getId());
 
         mockMvc.perform(
-                RestDocumentationRequestBuilders.get("/api/coupons")
-                        .contentType(APPLICATION_JSON)
-                        .header(HttpHeaders.AUTHORIZATION, CUSTOMER_BEARER_HEADER))
+                        RestDocumentationRequestBuilders.get("/api/coupons")
+                                .contentType(APPLICATION_JSON)
+                                .header(HttpHeaders.AUTHORIZATION, CUSTOMER_BEARER_HEADER))
                 .andDo(document("visitor/coupon/coupon-list",
-                        preprocessRequest(prettyPrint()),
-                        preprocessResponse(prettyPrint()),
-                        resource(
-                                ResourceSnippetParameters.builder()
-                                        .tag("고객 모드")
-                                        .description("쿠폰 리스트 조회")
-                                        .requestHeaders(headerWithName("Authorization").description("임시(Basic)"))
-                                        .responseFields(
-                                                fieldWithPath("coupons[].cafeInfo.id").description("카페 ID"),
-                                                fieldWithPath("coupons[].cafeInfo.name").description("카페 이름"),
-                                                fieldWithPath("coupons[].cafeInfo.isFavorites").description("카페 즐겨찾기 여부"),
-                                                fieldWithPath("coupons[].couponInfos[].id").description("쿠폰 ID"),
-                                                fieldWithPath("coupons[].couponInfos[].status").description("쿠폰 상태 (ACCUMULATING, REWARDED, EXPIRED)"),
-                                                fieldWithPath("coupons[].couponInfos[].stampCount").description("스탬프 개수"),
-                                                fieldWithPath("coupons[].couponInfos[].maxStampCount").description("최대 스탬프 개수"),
-                                                fieldWithPath("coupons[].couponInfos[].rewardName").description("보상 이름"),
-                                                fieldWithPath("coupons[].couponInfos[].frontImageUrl").description("쿠폰 앞면 이미지 URL"),
-                                                fieldWithPath("coupons[].couponInfos[].backImageUrl").description("쿠폰 뒷면 이미지 URL"),
-                                                fieldWithPath("coupons[].couponInfos[].stampImageUrl").description("스탬프 이미지 URL"),
-                                                fieldWithPath("coupons[].couponInfos[].coordinates[].order").description("좌표 순서"),
-                                                fieldWithPath("coupons[].couponInfos[].coordinates[].xCoordinate").description("X 좌표"),
-                                                fieldWithPath("coupons[].couponInfos[].coordinates[].yCoordinate").description("Y 좌표")
-                                        )
-                                        .responseSchema(Schema.schema("CustomerCouponsFindResponse"))
-                                        .build()
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint()),
+                                resource(
+                                        ResourceSnippetParameters.builder()
+                                                .tag("고객 모드")
+                                                .description("쿠폰 리스트 조회")
+                                                .requestHeaders(headerWithName("Authorization").description("Bearer"))
+                                                .responseFields(
+                                                        fieldWithPath("coupons[].cafeInfo.id").description("카페 ID"),
+                                                        fieldWithPath("coupons[].cafeInfo.name").description("카페 이름"),
+                                                        fieldWithPath("coupons[].cafeInfo.isFavorites").description("카페 즐겨찾기 여부"),
+                                                        fieldWithPath("coupons[].couponInfos[].id").description("쿠폰 ID"),
+                                                        fieldWithPath("coupons[].couponInfos[].status").description("쿠폰 상태 (ACCUMULATING, REWARDED, EXPIRED)"),
+                                                        fieldWithPath("coupons[].couponInfos[].stampCount").description("스탬프 개수"),
+                                                        fieldWithPath("coupons[].couponInfos[].maxStampCount").description("최대 스탬프 개수"),
+                                                        fieldWithPath("coupons[].couponInfos[].rewardName").description("보상 이름"),
+                                                        fieldWithPath("coupons[].couponInfos[].frontImageUrl").description("쿠폰 앞면 이미지 URL"),
+                                                        fieldWithPath("coupons[].couponInfos[].backImageUrl").description("쿠폰 뒷면 이미지 URL"),
+                                                        fieldWithPath("coupons[].couponInfos[].stampImageUrl").description("스탬프 이미지 URL"),
+                                                        fieldWithPath("coupons[].couponInfos[].coordinates[].order").description("좌표 순서"),
+                                                        fieldWithPath("coupons[].couponInfos[].coordinates[].xCoordinate").description("X 좌표"),
+                                                        fieldWithPath("coupons[].couponInfos[].coordinates[].yCoordinate").description("Y 좌표")
+                                                )
+                                                .responseSchema(Schema.schema("CustomerCouponsFindResponse"))
+                                                .build()
+                                )
                         )
                 )
-        )
                 .andExpect(status().isOk());
     }
 }

--- a/backend/src/test/java/com/stampcrush/backend/api/docs/visitor/favorites/VisitorFavoritesCommandApiDocsControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/docs/visitor/favorites/VisitorFavoritesCommandApiDocsControllerTest.java
@@ -20,7 +20,7 @@ import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-public class VisitorFavoritesCommandApiDocsControllerTest extends DocsControllerTest {
+class VisitorFavoritesCommandApiDocsControllerTest extends DocsControllerTest {
 
     @Test
     void 즐겨찾기_등록_해제_요청() throws Exception {
@@ -43,7 +43,7 @@ public class VisitorFavoritesCommandApiDocsControllerTest extends DocsController
                                         ResourceSnippetParameters.builder()
                                                 .tag("고객 모드")
                                                 .description("카페 즐겨찾기 등록/해제")
-                                                .requestHeaders(headerWithName("Authorization").description("임시(Basic)"))
+                                                .requestHeaders(headerWithName("Authorization").description("Bearer"))
                                                 .requestFields(fieldWithPath("isFavorites").description("등록(true)/ 해제(false)"))
                                                 .requestSchema(Schema.schema("FavoritesUpdateRequest"))
                                                 .build()

--- a/backend/src/test/java/com/stampcrush/backend/api/docs/visitor/profile/VisitorProfilesCommandApiDocsControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/docs/visitor/profile/VisitorProfilesCommandApiDocsControllerTest.java
@@ -3,6 +3,7 @@ package com.stampcrush.backend.api.docs.visitor.profile;
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.epages.restdocs.apispec.Schema;
 import com.stampcrush.backend.api.docs.DocsControllerTest;
+import com.stampcrush.backend.api.visitor.profile.VisitorProfilesLinkDataRequest;
 import com.stampcrush.backend.api.visitor.profile.request.VisitorProfilesPhoneNumberUpdateRequest;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
@@ -20,7 +21,7 @@ import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-public class VisitorProfilesCommandApiDocsControllerTest extends DocsControllerTest {
+class VisitorProfilesCommandApiDocsControllerTest extends DocsControllerTest {
 
     @Test
     void 고객이_전화번호_등록() throws Exception {
@@ -43,9 +44,40 @@ public class VisitorProfilesCommandApiDocsControllerTest extends DocsControllerT
                                         ResourceSnippetParameters.builder()
                                                 .tag("고객 모드")
                                                 .description("고객이 전화번호 등록")
-                                                .requestHeaders(headerWithName("Authorization").description("임시(Basic)"))
+                                                .requestHeaders(headerWithName("Authorization").description("Bearer"))
                                                 .requestFields(fieldWithPath("phoneNumber").description("고객이 등록할 전화번호"))
                                                 .requestSchema(Schema.schema("VisitorProfilesPhoneNumberUpdateRequest"))
+                                                .build()
+                                )
+                        )
+                )
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void 임시회원_가입회원_연동() throws Exception {
+        // given
+        when(customerRepository.findById(CUSTOMER.getId())).thenReturn(Optional.of(CUSTOMER));
+        when(customerRepository.findByLoginId(CUSTOMER.getLoginId())).thenReturn(Optional.of(CUSTOMER));
+
+        VisitorProfilesLinkDataRequest request = new VisitorProfilesLinkDataRequest(1L);
+        when(authTokensGenerator.isValidToken(anyString())).thenReturn(true);
+        when(authTokensGenerator.extractMemberId(anyString())).thenReturn(CUSTOMER.getId());
+        // when, then
+        mockMvc.perform(
+                        RestDocumentationRequestBuilders.post("/api/profiles/link-data")
+                                .content(objectMapper.writeValueAsString(request))
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .header(HttpHeaders.AUTHORIZATION, CUSTOMER_BEARER_HEADER))
+                .andDo(document("visitor/profiles/link-data",
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint()),
+                                resource(
+                                        ResourceSnippetParameters.builder()
+                                                .tag("고객 모드")
+                                                .description("가입 고객 임시 고객 데이터 연동")
+                                                .requestHeaders(headerWithName("Authorization").description("Bearer"))
+                                                .requestSchema(Schema.schema("VisitorProfilesLinkDataRequest"))
                                                 .build()
                                 )
                         )

--- a/backend/src/test/java/com/stampcrush/backend/api/docs/visitor/profile/VisitorProfilesFindApiDocsControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/docs/visitor/profile/VisitorProfilesFindApiDocsControllerTest.java
@@ -3,8 +3,8 @@ package com.stampcrush.backend.api.docs.visitor.profile;
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.epages.restdocs.apispec.Schema;
 import com.stampcrush.backend.api.docs.DocsControllerTest;
+import com.stampcrush.backend.application.visitor.profile.dto.VisitorProfileFindByPhoneNumberResultDto;
 import com.stampcrush.backend.application.visitor.profile.dto.VisitorProfileFindResultDto;
-import com.stampcrush.backend.repository.user.CustomerRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -13,6 +13,7 @@ import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import java.util.Optional;
 
 import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
+import static com.epages.restdocs.apispec.ResourceDocumentation.parameterWithName;
 import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
@@ -21,7 +22,7 @@ import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-public class VisitorProfilesFindApiDocsControllerTest extends DocsControllerTest {
+class VisitorProfilesFindApiDocsControllerTest extends DocsControllerTest {
 
     @Test
     void 고객의_프로필_조회() throws Exception {
@@ -48,7 +49,7 @@ public class VisitorProfilesFindApiDocsControllerTest extends DocsControllerTest
                                         ResourceSnippetParameters.builder()
                                                 .tag("고객 모드")
                                                 .description("고객 프로필 조회")
-                                                .requestHeaders(headerWithName("Authorization").description("임시(Basic)"))
+                                                .requestHeaders(headerWithName("Authorization").description("Bearer"))
                                                 .responseFields(
                                                         fieldWithPath("profile.id").description("고객 ID"),
                                                         fieldWithPath("profile.nickname").description("고객 닉네임"),
@@ -56,6 +57,48 @@ public class VisitorProfilesFindApiDocsControllerTest extends DocsControllerTest
                                                         fieldWithPath("profile.email").description("고객 이메일")
                                                 )
                                                 .requestSchema(Schema.schema("VisitorProfilesFindResponse"))
+                                                .build()
+                                )
+                        )
+                )
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void 전화번호로_고객_조회() throws Exception {
+        // given
+        when(customerRepository.findById(CUSTOMER.getId())).thenReturn(Optional.of(CUSTOMER));
+        when(customerRepository.findByLoginId(CUSTOMER.getLoginId())).thenReturn(Optional.of(CUSTOMER));
+        when(visitorProfilesFindService.findCustomerProfileByNumber(CUSTOMER.getPhoneNumber()))
+                .thenReturn(
+                        new VisitorProfileFindByPhoneNumberResultDto(CUSTOMER.getId(), "jena", "01012345678",
+                                "register")
+                );
+        when(authTokensGenerator.isValidToken(anyString())).thenReturn(true);
+        when(authTokensGenerator.extractMemberId(anyString())).thenReturn(CUSTOMER.getId());
+
+        // when, then
+        mockMvc.perform(
+                        RestDocumentationRequestBuilders.get("/api/profiles/search")
+                                .param("phone-number", CUSTOMER.getPhoneNumber())
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .header(HttpHeaders.AUTHORIZATION, CUSTOMER_BEARER_HEADER))
+                .andDo(document("visitor/profiles/findByPhoneNumber",
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint()),
+                                resource(
+                                        ResourceSnippetParameters.builder()
+                                                .tag("고객 모드")
+                                                .description("전화번호로 고객 조회")
+                                                .requestHeaders(headerWithName("Authorization").description("Bearer"))
+                                                .queryParameters(parameterWithName("phone-number").description("전화번호"))
+                                                .responseFields(
+                                                        fieldWithPath("customers[].id").description("고객 ID"),
+                                                        fieldWithPath("customers[].nickname").description("고객 닉네임"),
+                                                        fieldWithPath("customers[].phoneNumber").description("고객 전화번호"),
+                                                        fieldWithPath("customers[].registerType").description("고객 가입 여부")
+                                                )
+                                                .requestSchema(Schema.schema("VisitorProfilesFindByPhoneNumberResponse"))
                                                 .build()
                                 )
                         )

--- a/backend/src/test/java/com/stampcrush/backend/api/docs/visitor/reward/VisitorRewardsFindApiDocsControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/docs/visitor/reward/VisitorRewardsFindApiDocsControllerTest.java
@@ -24,7 +24,7 @@ import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-public class VisitorRewardsFindApiDocsControllerTest extends DocsControllerTest {
+class VisitorRewardsFindApiDocsControllerTest extends DocsControllerTest {
 
     @Test
     void 리워드_조회() throws Exception {
@@ -55,7 +55,7 @@ public class VisitorRewardsFindApiDocsControllerTest extends DocsControllerTest 
                                         ResourceSnippetParameters.builder()
                                                 .tag("고객 모드")
                                                 .description("리워드 조회")
-                                                .requestHeaders(headerWithName("Authorization").description("임시(Basic)"))
+                                                .requestHeaders(headerWithName("Authorization").description("Bearer"))
                                                 .queryParameters(parameterWithName("used").description("false(사용 가능한 리워드), true(사용한 리워드)"))
                                                 .responseFields(
                                                         fieldWithPath("rewards[].id").description("리워드 ID"),

--- a/backend/src/test/java/com/stampcrush/backend/api/docs/visitor/visithistory/VisitorVisitHistoryFindApiDocsControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/docs/visitor/visithistory/VisitorVisitHistoryFindApiDocsControllerTest.java
@@ -23,7 +23,7 @@ import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-public class VisitorVisitHistoryFindApiDocsControllerTest extends DocsControllerTest {
+class VisitorVisitHistoryFindApiDocsControllerTest extends DocsControllerTest {
 
     @Test
     void 스탬프_적립내역_조회() throws Exception {
@@ -54,7 +54,7 @@ public class VisitorVisitHistoryFindApiDocsControllerTest extends DocsController
                                         ResourceSnippetParameters.builder()
                                                 .tag("고객 모드")
                                                 .description("스탬프 적립내역 조회")
-                                                .requestHeaders(headerWithName("Authorization").description("임시(Basic)"))
+                                                .requestHeaders(headerWithName("Authorization").description("Bearer"))
                                                 .responseFields(
                                                         fieldWithPath("stampHistories[].id").description("적립내역 ID"),
                                                         fieldWithPath("stampHistories[].cafeName").description("카페 이름"),


### PR DESCRIPTION
## 주요 변경사항

- 전화번호로 고객 조회, 임시 회원<-> 가입회원 연동에 대한 API 문서를 작성했습니다
- 인증방식 변경에 따른 테스트 문서 설명을 Basic -> Bearer 로 변경했습니다

## 리뷰어에게...

## 관련 이슈

closes #681 

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [x] `milestone` 설정
