### PR TITLE
[BE] test: Manager.customer , Manager.sample, Visitor.coupon 인수테스트 리팩터링

### DIFF
--- a/backend/src/main/java/com/stampcrush/backend/application/manager/customer/ManagerCustomerCommandService.java
+++ b/backend/src/main/java/com/stampcrush/backend/application/manager/customer/ManagerCustomerCommandService.java
@@ -28,6 +28,7 @@ public class ManagerCustomerCommandService {
 
     private void checkExistCustomer(String phoneNumber) {
         if (!customerRepository.findByPhoneNumber(phoneNumber).isEmpty()) {
+            // TODO: OwnerBadRequestException일까?
             throw new CustomerBadRequestException("이미 존재하는 회원입니다");
         }
     }

--- a/backend/src/main/java/com/stampcrush/backend/application/visitor/coupon/VisitorCouponFindService.java
+++ b/backend/src/main/java/com/stampcrush/backend/application/visitor/coupon/VisitorCouponFindService.java
@@ -31,7 +31,7 @@ public class VisitorCouponFindService {
     public List<CustomerCouponFindResultDto> findOneCouponForOneCafe(Long customerId) {
         // TODO: customer를 찾아서 쿼리하지 않고, 곧바로 cusotmerId를 쿼리에 사용해도 될 것 같음.
         Customer customer = findExistingCustomer(customerId);
-        List<Coupon> coupons = couponRepository.findFilteredAndSortedCoupons(customer, CouponStatus.ACCUMULATING);
+        List<Coupon> coupons = couponRepository.findCouponsByCustomerAndStatus(customer, CouponStatus.ACCUMULATING);
 
         return coupons.stream()
                 .map(coupon -> formatToDto(customer, coupon))

--- a/backend/src/main/java/com/stampcrush/backend/application/visitor/coupon/VisitorCouponFindService.java
+++ b/backend/src/main/java/com/stampcrush/backend/application/visitor/coupon/VisitorCouponFindService.java
@@ -29,6 +29,7 @@ public class VisitorCouponFindService {
     private final CouponStampCoordinateRepository couponStampCoordinateRepository;
 
     public List<CustomerCouponFindResultDto> findOneCouponForOneCafe(Long customerId) {
+        // TODO: customer를 찾아서 쿼리하지 않고, 곧바로 cusotmerId를 쿼리에 사용해도 될 것 같음.
         Customer customer = findExistingCustomer(customerId);
         List<Coupon> coupons = couponRepository.findFilteredAndSortedCoupons(customer, CouponStatus.ACCUMULATING);
 

--- a/backend/src/main/java/com/stampcrush/backend/auth/api/VisitorAuthController.java
+++ b/backend/src/main/java/com/stampcrush/backend/auth/api/VisitorAuthController.java
@@ -20,6 +20,7 @@ public class VisitorAuthController {
 
     private final VisitorAuthService visitorAuthService;
 
+    @Deprecated
     @PostMapping("/temporary/test")
     public ResponseEntity<Void> joinTemporaryCustomer(
             @RequestParam("phone-number") String phoneNumber

--- a/backend/src/main/java/com/stampcrush/backend/auth/application/VisitorAuthService.java
+++ b/backend/src/main/java/com/stampcrush/backend/auth/application/VisitorAuthService.java
@@ -28,6 +28,7 @@ public class VisitorAuthService {
         return authTokensGenerator.generate(customerId);
     }
 
+    @Deprecated
     public Long joinTemporaryCustomer(String phoneNumber) {
         Customer customer = Customer.temporaryCustomerBuilder()
                 .phoneNumber(phoneNumber)

--- a/backend/src/main/java/com/stampcrush/backend/repository/coupon/CouponRepository.java
+++ b/backend/src/main/java/com/stampcrush/backend/repository/coupon/CouponRepository.java
@@ -13,6 +13,7 @@ import java.util.Optional;
 
 public interface CouponRepository extends JpaRepository<Coupon, Long> {
 
+    // TODO: coupon_policy, coupon_design을 같이 가져오자
     @Query("select distinct cp from Coupon cp left join fetch cp.stamps join fetch cp.cafe join fetch cp.customer where cp.cafe = :cafe")
     List<Coupon> findByCafe(@Param("cafe") Cafe cafe);
 

--- a/backend/src/main/java/com/stampcrush/backend/repository/coupon/CouponRepository.java
+++ b/backend/src/main/java/com/stampcrush/backend/repository/coupon/CouponRepository.java
@@ -18,8 +18,11 @@ public interface CouponRepository extends JpaRepository<Coupon, Long> {
 
     List<Coupon> findByCafeAndCustomerAndStatus(@Param("cafe") Cafe cafe, @Param("customer") Customer customer, @Param("status") CouponStatus status);
 
+    // TODO: 즐겨찾기가 붙어있는지 등에 따라 정렬하기로 했었는데, 현재 로직에서는 정렬을 하고 있지 않아서, 아래 메서드로 대체함
     @Query("SELECT c FROM Coupon c LEFT JOIN Favorites f ON c.cafe.id = f.cafe.id WHERE c.customer = :customer AND c.status = :status ORDER BY f.isFavorites DESC, c.expiredDate ASC")
     List<Coupon> findFilteredAndSortedCoupons(@Param("customer") Customer customer, @Param("status") CouponStatus status);
+
+    List<Coupon> findCouponsByCustomerAndStatus(Customer customer, CouponStatus couponStatus);
 
     Optional<Coupon> findByIdAndCustomerId(Long id, Long customerId);
 }

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/ManagerCustomerCommandAcceptanceTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/ManagerCustomerCommandAcceptanceTest.java
@@ -1,9 +1,6 @@
 package com.stampcrush.backend.acceptance;
 
 import com.stampcrush.backend.api.manager.customer.request.TemporaryCustomerCreateRequest;
-import com.stampcrush.backend.api.manager.customer.response.CustomerFindResponse;
-import com.stampcrush.backend.api.manager.customer.response.CustomersFindResponse;
-import com.stampcrush.backend.application.manager.customer.dto.CustomerFindDto;
 import com.stampcrush.backend.auth.OAuthProvider;
 import com.stampcrush.backend.auth.api.request.OAuthRegisterCustomerCreateRequest;
 import com.stampcrush.backend.auth.application.util.AuthTokensGenerator;
@@ -16,7 +13,6 @@ import io.restassured.response.Response;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import static com.stampcrush.backend.acceptance.step.ManagerCustomerFindStep.전화번호로_고객_조회_요청;
 import static com.stampcrush.backend.acceptance.step.ManagerJoinStep.OWNER_CREATE_REQUEST;
 import static com.stampcrush.backend.acceptance.step.ManagerJoinStep.카페_사장_회원_가입_요청하고_액세스_토큰_반환;
 import static com.stampcrush.backend.acceptance.step.VisitorJoinStep.가입_고객_회원_가입_요청하고_액세스_토큰_반환;
@@ -25,7 +21,6 @@ import static com.stampcrush.backend.acceptance.step.VisitorJoinStep.임시_고�
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
-import static org.springframework.http.HttpStatus.OK;
 
 public class ManagerCustomerCommandAcceptanceTest extends AcceptanceTest {
 
@@ -37,65 +32,6 @@ public class ManagerCustomerCommandAcceptanceTest extends AcceptanceTest {
 
     @Autowired
     private AuthTokensGenerator authTokensGenerator;
-
-    @Test
-    void 전화번호로_가입_고객을_조회한다() {
-        // given
-        String ownerAccessToken = 카페_사장_회원_가입_요청하고_액세스_토큰_반환(OWNER_CREATE_REQUEST);
-        Long ownerId = authTokensGenerator.extractMemberId(ownerAccessToken);
-        Owner owner = ownerRepository.findById(ownerId).get();
-
-        Long temporaryCustomerId = 임시_고객_회원_가입_요청하고_아이디_반환(ownerAccessToken, new TemporaryCustomerCreateRequest("01012345678"));
-        Customer customer = customerRepository.findById(temporaryCustomerId).get();
-
-        // when
-        ExtractableResponse<Response> response = 전화번호로_고객_조회_요청(owner, "01012345678");
-        CustomersFindResponse customers = response.body().as(CustomersFindResponse.class);
-
-        // then
-        assertSoftly(softAssertions -> {
-            softAssertions.assertThat(response.statusCode()).isEqualTo(OK.value());
-            softAssertions.assertThat(customers.getCustomer()).containsExactlyInAnyOrder(CustomerFindResponse.from(CustomerFindDto.from(customer)));
-        });
-    }
-
-    @Test
-    void 전화번호로_임시_고객을_조회한다() {
-        // given
-        String ownerAccessToken = 카페_사장_회원_가입_요청하고_액세스_토큰_반환(OWNER_CREATE_REQUEST);
-        Long ownerId = authTokensGenerator.extractMemberId(ownerAccessToken);
-        Owner owner = ownerRepository.findById(ownerId).get();
-
-        Long temporaryCustomerId = 임시_고객_회원_가입_요청하고_아이디_반환(ownerAccessToken, new TemporaryCustomerCreateRequest("01012345678"));
-        Customer customer = customerRepository.findById(temporaryCustomerId).get();
-
-        // when
-        ExtractableResponse<Response> response = 전화번호로_고객_조회_요청(owner, "01012345678");
-        CustomersFindResponse customers = response.body().as(CustomersFindResponse.class);
-
-        // then
-        assertSoftly(softAssertions -> {
-            softAssertions.assertThat(response.statusCode()).isEqualTo(OK.value());
-            softAssertions.assertThat(customers.getCustomer()).containsExactly(CustomerFindResponse.from(CustomerFindDto.from(customer)));
-        });
-    }
-
-    @Test
-    void 고객이_존재하지_않는_경우_빈_배열을_반환한다() {
-        // given, when
-        String ownerAccessToken = 카페_사장_회원_가입_요청하고_액세스_토큰_반환(OWNER_CREATE_REQUEST);
-        Long ownerId = authTokensGenerator.extractMemberId(ownerAccessToken);
-        Owner owner = ownerRepository.findById(ownerId).get();
-
-        ExtractableResponse<Response> response = 전화번호로_고객_조회_요청(owner, "01012345678");
-        CustomersFindResponse customers = response.body().as(CustomersFindResponse.class);
-
-        // then
-        assertSoftly(softAssertions -> {
-            softAssertions.assertThat(response.statusCode()).isEqualTo(OK.value());
-            softAssertions.assertThat(customers.getCustomer().size()).isEqualTo(0);
-        });
-    }
 
     @Test
     void 임시_고객을_생성한다() {

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/ManagerCustomerCommandAcceptanceTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/ManagerCustomerCommandAcceptanceTest.java
@@ -4,6 +4,9 @@ import com.stampcrush.backend.api.manager.customer.request.TemporaryCustomerCrea
 import com.stampcrush.backend.api.manager.customer.response.CustomerFindResponse;
 import com.stampcrush.backend.api.manager.customer.response.CustomersFindResponse;
 import com.stampcrush.backend.application.manager.customer.dto.CustomerFindDto;
+import com.stampcrush.backend.auth.OAuthProvider;
+import com.stampcrush.backend.auth.api.request.OAuthRegisterOwnerCreateRequest;
+import com.stampcrush.backend.auth.application.util.AuthTokensGenerator;
 import com.stampcrush.backend.entity.user.Customer;
 import com.stampcrush.backend.entity.user.Owner;
 import com.stampcrush.backend.helper.BearerAuthHelper;
@@ -12,39 +15,39 @@ import com.stampcrush.backend.repository.user.OwnerRepository;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 
-import static com.stampcrush.backend.fixture.OwnerFixture.OWNER3;
+import static com.stampcrush.backend.acceptance.step.ManagerJoinStep.카페_사장_회원_가입_요청하고_액세스_토큰_반환;
+import static com.stampcrush.backend.acceptance.step.VisitorJoinStep.임시_고객_회원_가입_요청하고_아이디_반환;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.OK;
 
 public class ManagerCustomerCommandAcceptanceTest extends AcceptanceTest {
 
+    private static final OAuthRegisterOwnerCreateRequest OWNER_CREATE_REQUEST = new OAuthRegisterOwnerCreateRequest(
+            "깃짱", OAuthProvider.KAKAO, 123234L
+    );
     @Autowired
     private CustomerRepository customerRepository;
 
     @Autowired
     private OwnerRepository ownerRepository;
 
-    private Owner owner;
-
-    @BeforeEach
-    void setUp() {
-        owner = ownerRepository.save(OWNER3);
-    }
+    @Autowired
+    private AuthTokensGenerator authTokensGenerator;
 
     @Test
     void 전화번호로_가입_고객을_조회한다() {
         // given
-        Customer customer = Customer.temporaryCustomerBuilder()
-                .phoneNumber("01012345678")
-                .build();
-        customerRepository.save(customer);
+        String ownerAccessToken = 카페_사장_회원_가입_요청하고_액세스_토큰_반환(OWNER_CREATE_REQUEST);
+        Long ownerId = authTokensGenerator.extractMemberId(ownerAccessToken);
+        Owner owner = ownerRepository.findById(ownerId).get();
+
+        Long temporaryCustomerId = 임시_고객_회원_가입_요청하고_아이디_반환("01012345678");
+        Customer customer = customerRepository.findById(temporaryCustomerId).get();
 
         // when
         ExtractableResponse<Response> response = requestFindCustomerByPhoneNumber(owner, "01012345678");
@@ -60,10 +63,12 @@ public class ManagerCustomerCommandAcceptanceTest extends AcceptanceTest {
     @Test
     void 전화번호로_임시_고객을_조회한다() {
         // given
-        Customer customer = Customer.temporaryCustomerBuilder()
-                .phoneNumber("01012345678")
-                .build();
-        customerRepository.save(customer);
+        String ownerAccessToken = 카페_사장_회원_가입_요청하고_액세스_토큰_반환(OWNER_CREATE_REQUEST);
+        Long ownerId = authTokensGenerator.extractMemberId(ownerAccessToken);
+        Owner owner = ownerRepository.findById(ownerId).get();
+
+        Long temporaryCustomerId = 임시_고객_회원_가입_요청하고_아이디_반환("01012345678");
+        Customer customer = customerRepository.findById(temporaryCustomerId).get();
 
         // when
         ExtractableResponse<Response> response = requestFindCustomerByPhoneNumber(owner, "01012345678");
@@ -79,6 +84,10 @@ public class ManagerCustomerCommandAcceptanceTest extends AcceptanceTest {
     @Test
     void 고객이_존재하지_않는_경우_빈_배열을_반환한다() {
         // given, when
+        String ownerAccessToken = 카페_사장_회원_가입_요청하고_액세스_토큰_반환(OWNER_CREATE_REQUEST);
+        Long ownerId = authTokensGenerator.extractMemberId(ownerAccessToken);
+        Owner owner = ownerRepository.findById(ownerId).get();
+
         ExtractableResponse<Response> response = requestFindCustomerByPhoneNumber(owner, "01012345678");
         CustomersFindResponse customers = response.body().as(CustomersFindResponse.class);
 
@@ -92,10 +101,12 @@ public class ManagerCustomerCommandAcceptanceTest extends AcceptanceTest {
     @Test
     void 임시_고객을_생성한다() {
         // given
-        TemporaryCustomerCreateRequest temporaryCustomerCreateRequest = new TemporaryCustomerCreateRequest("01012345678");
+        String ownerAccessToken = 카페_사장_회원_가입_요청하고_액세스_토큰_반환(OWNER_CREATE_REQUEST);
+        Long ownerId = authTokensGenerator.extractMemberId(ownerAccessToken);
+        Owner owner = ownerRepository.findById(ownerId).get();
 
         // when
-        Long temporaryCustomerId = createTemporaryCustomer(owner, temporaryCustomerCreateRequest);
+        Long temporaryCustomerId = 임시_고객_회원_가입_요청하고_아이디_반환("01012345678");
         Customer temporaryCustomer = customerRepository.findById(temporaryCustomerId).get();
 
         // then
@@ -108,11 +119,14 @@ public class ManagerCustomerCommandAcceptanceTest extends AcceptanceTest {
     @Test
     void 존재하는_회원의_번호로_고객을_생성하려면_에러를_발생한다() {
         // given
-        Customer customer = Customer.temporaryCustomerBuilder()
-                .phoneNumber("01012345678")
-                .build();
-        customerRepository.save(customer);
-        TemporaryCustomerCreateRequest temporaryCustomerCreateRequest = new TemporaryCustomerCreateRequest(customer.getPhoneNumber());
+        String ownerAccessToken = 카페_사장_회원_가입_요청하고_액세스_토큰_반환(OWNER_CREATE_REQUEST);
+        Long ownerId = authTokensGenerator.extractMemberId(ownerAccessToken);
+        Owner owner = ownerRepository.findById(ownerId).get();
+
+        Long temporaryCustomerId = 임시_고객_회원_가입_요청하고_아이디_반환("01012345678");
+        Customer temporaryCustomer = customerRepository.findById(temporaryCustomerId).get();
+
+        TemporaryCustomerCreateRequest temporaryCustomerCreateRequest = new TemporaryCustomerCreateRequest(temporaryCustomer.getPhoneNumber());
 
         // when, then
         RestAssured.given()
@@ -144,26 +158,5 @@ public class ManagerCustomerCommandAcceptanceTest extends AcceptanceTest {
                 .then()
                 .log().all()
                 .extract();
-    }
-
-    private Long createTemporaryCustomer(Owner owner, TemporaryCustomerCreateRequest request) {
-        ExtractableResponse<Response> response = RestAssured.given()
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .body(request)
-                .auth().preemptive()
-                .oauth2(BearerAuthHelper.generateToken(owner.getId()))
-
-                .when()
-                .post("/api/admin/temporary-customers")
-
-                .then()
-                .statusCode(HttpStatus.CREATED.value())
-                .extract();
-
-        return getIdFromCreatedResponse(response);
-    }
-
-    private long getIdFromCreatedResponse(ExtractableResponse<Response> response) {
-        return Long.parseLong(response.header("Location").split("/")[2]);
     }
 }

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/ManagerCustomerCommandAcceptanceTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/ManagerCustomerCommandAcceptanceTest.java
@@ -1,13 +1,8 @@
 package com.stampcrush.backend.acceptance;
 
 import com.stampcrush.backend.api.manager.customer.request.TemporaryCustomerCreateRequest;
-import com.stampcrush.backend.auth.OAuthProvider;
-import com.stampcrush.backend.auth.api.request.OAuthRegisterCustomerCreateRequest;
-import com.stampcrush.backend.auth.application.util.AuthTokensGenerator;
 import com.stampcrush.backend.entity.user.Customer;
-import com.stampcrush.backend.entity.user.Owner;
 import com.stampcrush.backend.repository.user.CustomerRepository;
-import com.stampcrush.backend.repository.user.OwnerRepository;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import org.junit.jupiter.api.Test;
@@ -15,7 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import static com.stampcrush.backend.acceptance.step.ManagerJoinStep.OWNER_CREATE_REQUEST;
 import static com.stampcrush.backend.acceptance.step.ManagerJoinStep.카페_사장_회원_가입_요청하고_액세스_토큰_반환;
-import static com.stampcrush.backend.acceptance.step.VisitorJoinStep.가입_고객_회원_가입_요청하고_액세스_토큰_반환;
+import static com.stampcrush.backend.acceptance.step.VisitorJoinStep.TEMPORARY_CUSTOMER_CREATE_REQUEST;
 import static com.stampcrush.backend.acceptance.step.VisitorJoinStep.임시_고객_회원_가입_요청;
 import static com.stampcrush.backend.acceptance.step.VisitorJoinStep.임시_고객_회원_가입_요청하고_아이디_반환;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -27,27 +22,22 @@ public class ManagerCustomerCommandAcceptanceTest extends AcceptanceTest {
     @Autowired
     private CustomerRepository customerRepository;
 
-    @Autowired
-    private OwnerRepository ownerRepository;
-
-    @Autowired
-    private AuthTokensGenerator authTokensGenerator;
-
     @Test
     void 임시_고객을_생성한다() {
         // given
         String ownerAccessToken = 카페_사장_회원_가입_요청하고_액세스_토큰_반환(OWNER_CREATE_REQUEST);
-        Long ownerId = authTokensGenerator.extractMemberId(ownerAccessToken);
-        Owner owner = ownerRepository.findById(ownerId).get();
+        TemporaryCustomerCreateRequest temporaryCustomerCreateRequest = TEMPORARY_CUSTOMER_CREATE_REQUEST;
+        Long temporaryCustomerId = 임시_고객_회원_가입_요청하고_아이디_반환(ownerAccessToken, temporaryCustomerCreateRequest);
+        Customer temporaryCustomer = customerRepository.findById(temporaryCustomerId).get();
 
         // when
-        Long temporaryCustomerId = 임시_고객_회원_가입_요청하고_아이디_반환(ownerAccessToken, new TemporaryCustomerCreateRequest("01012345678"));
-        Customer temporaryCustomer = customerRepository.findById(temporaryCustomerId).get();
+        String phoneNumber = temporaryCustomerCreateRequest.getPhoneNumber();
+        String lastFourDigits = phoneNumber.substring(phoneNumber.length() - 4);
 
         // then
         assertSoftly(softly -> {
-            softly.assertThat(temporaryCustomer.getNickname()).isEqualTo("5678");
-            softly.assertThat(temporaryCustomer.getPhoneNumber()).isEqualTo("01012345678");
+            softly.assertThat(temporaryCustomer.getNickname()).isEqualTo(lastFourDigits);
+            softly.assertThat(temporaryCustomer.getPhoneNumber()).isEqualTo(phoneNumber);
         });
     }
 
@@ -55,16 +45,14 @@ public class ManagerCustomerCommandAcceptanceTest extends AcceptanceTest {
     void 존재하는_회원의_번호로_고객을_생성하려면_에러를_발생한다() {
         // given
         String ownerAccessToken = 카페_사장_회원_가입_요청하고_액세스_토큰_반환(OWNER_CREATE_REQUEST);
-        Long ownerId = authTokensGenerator.extractMemberId(ownerAccessToken);
-        Owner owner = ownerRepository.findById(ownerId).get();
 
-        String accessToken = 가입_고객_회원_가입_요청하고_액세스_토큰_반환(new OAuthRegisterCustomerCreateRequest(
-                "깃짱", "gitchan@gmail.com", OAuthProvider.KAKAO, 12314124L
-        ));
-        Long temporaryCustomerId = 임시_고객_회원_가입_요청하고_아이디_반환("01012345678");
+        Long temporaryCustomerId = 임시_고객_회원_가입_요청하고_아이디_반환(ownerAccessToken, TEMPORARY_CUSTOMER_CREATE_REQUEST);
         Customer temporaryCustomer = customerRepository.findById(temporaryCustomerId).get();
 
-        ExtractableResponse<Response> response = 임시_고객_회원_가입_요청(ownerAccessToken, new TemporaryCustomerCreateRequest(temporaryCustomer.getPhoneNumber()));
+        ExtractableResponse<Response> response = 임시_고객_회원_가입_요청(
+                ownerAccessToken,
+                new TemporaryCustomerCreateRequest(temporaryCustomer.getPhoneNumber())
+        );
 
         // when, then
         assertThat(response.statusCode()).isEqualTo(BAD_REQUEST.value());

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/ManagerCustomerFindAcceptanceTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/ManagerCustomerFindAcceptanceTest.java
@@ -1,0 +1,93 @@
+package com.stampcrush.backend.acceptance;
+
+import com.stampcrush.backend.api.manager.customer.request.TemporaryCustomerCreateRequest;
+import com.stampcrush.backend.api.manager.customer.response.CustomerFindResponse;
+import com.stampcrush.backend.api.manager.customer.response.CustomersFindResponse;
+import com.stampcrush.backend.application.manager.customer.dto.CustomerFindDto;
+import com.stampcrush.backend.auth.application.util.AuthTokensGenerator;
+import com.stampcrush.backend.entity.user.Customer;
+import com.stampcrush.backend.entity.user.Owner;
+import com.stampcrush.backend.repository.user.CustomerRepository;
+import com.stampcrush.backend.repository.user.OwnerRepository;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static com.stampcrush.backend.acceptance.step.ManagerCustomerFindStep.전화번호로_고객_조회_요청;
+import static com.stampcrush.backend.acceptance.step.ManagerJoinStep.OWNER_CREATE_REQUEST;
+import static com.stampcrush.backend.acceptance.step.ManagerJoinStep.카페_사장_회원_가입_요청하고_액세스_토큰_반환;
+import static com.stampcrush.backend.acceptance.step.VisitorJoinStep.임시_고객_회원_가입_요청하고_아이디_반환;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.springframework.http.HttpStatus.OK;
+
+public class ManagerCustomerFindAcceptanceTest extends AcceptanceTest {
+
+    @Autowired
+    private CustomerRepository customerRepository;
+
+    @Autowired
+    private OwnerRepository ownerRepository;
+
+    @Autowired
+    private AuthTokensGenerator authTokensGenerator;
+
+    @Test
+    void 전화번호로_가입_고객을_조회한다() {
+        // given
+        String ownerAccessToken = 카페_사장_회원_가입_요청하고_액세스_토큰_반환(OWNER_CREATE_REQUEST);
+        Long ownerId = authTokensGenerator.extractMemberId(ownerAccessToken);
+        Owner owner = ownerRepository.findById(ownerId).get();
+
+        Long temporaryCustomerId = 임시_고객_회원_가입_요청하고_아이디_반환(ownerAccessToken, new TemporaryCustomerCreateRequest("01012345678"));
+        Customer customer = customerRepository.findById(temporaryCustomerId).get();
+
+        // when
+        ExtractableResponse<Response> response = 전화번호로_고객_조회_요청(owner, "01012345678");
+        CustomersFindResponse customers = response.body().as(CustomersFindResponse.class);
+
+        // then
+        assertSoftly(softAssertions -> {
+            softAssertions.assertThat(response.statusCode()).isEqualTo(OK.value());
+            softAssertions.assertThat(customers.getCustomer()).containsExactlyInAnyOrder(CustomerFindResponse.from(CustomerFindDto.from(customer)));
+        });
+    }
+
+    @Test
+    void 전화번호로_임시_고객을_조회한다() {
+        // given
+        String ownerAccessToken = 카페_사장_회원_가입_요청하고_액세스_토큰_반환(OWNER_CREATE_REQUEST);
+        Long ownerId = authTokensGenerator.extractMemberId(ownerAccessToken);
+        Owner owner = ownerRepository.findById(ownerId).get();
+
+        Long temporaryCustomerId = 임시_고객_회원_가입_요청하고_아이디_반환(ownerAccessToken, new TemporaryCustomerCreateRequest("01012345678"));
+        Customer customer = customerRepository.findById(temporaryCustomerId).get();
+
+        // when
+        ExtractableResponse<Response> response = 전화번호로_고객_조회_요청(owner, "01012345678");
+        CustomersFindResponse customers = response.body().as(CustomersFindResponse.class);
+
+        // then
+        assertSoftly(softAssertions -> {
+            softAssertions.assertThat(response.statusCode()).isEqualTo(OK.value());
+            softAssertions.assertThat(customers.getCustomer()).containsExactly(CustomerFindResponse.from(CustomerFindDto.from(customer)));
+        });
+    }
+
+    @Test
+    void 고객이_존재하지_않는_경우_빈_배열을_반환한다() {
+        // given, when
+        String ownerAccessToken = 카페_사장_회원_가입_요청하고_액세스_토큰_반환(OWNER_CREATE_REQUEST);
+        Long ownerId = authTokensGenerator.extractMemberId(ownerAccessToken);
+        Owner owner = ownerRepository.findById(ownerId).get();
+
+        ExtractableResponse<Response> response = 전화번호로_고객_조회_요청(owner, "01012345678");
+        CustomersFindResponse customers = response.body().as(CustomersFindResponse.class);
+
+        // then
+        assertSoftly(softAssertions -> {
+            softAssertions.assertThat(response.statusCode()).isEqualTo(OK.value());
+            softAssertions.assertThat(customers.getCustomer().size()).isEqualTo(0);
+        });
+    }
+}

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/ManagerSampleCouponFindAcceptanceTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/ManagerSampleCouponFindAcceptanceTest.java
@@ -1,24 +1,27 @@
 package com.stampcrush.backend.acceptance;
 
+import com.stampcrush.backend.auth.application.util.AuthTokensGenerator;
 import com.stampcrush.backend.entity.sample.SampleBackImage;
 import com.stampcrush.backend.entity.user.Owner;
-import com.stampcrush.backend.helper.BearerAuthHelper;
 import com.stampcrush.backend.repository.sample.SampleBackImageRepository;
 import com.stampcrush.backend.repository.sample.SampleFrontImageRepository;
 import com.stampcrush.backend.repository.sample.SampleStampCoordinateRepository;
 import com.stampcrush.backend.repository.sample.SampleStampImageRepository;
 import com.stampcrush.backend.repository.user.OwnerRepository;
-import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 
-import static com.stampcrush.backend.fixture.OwnerFixture.OWNER3;
-import static com.stampcrush.backend.fixture.SampleCouponFixture.*;
+import static com.stampcrush.backend.acceptance.step.ManagerJoinStep.OWNER_CREATE_REQUEST;
+import static com.stampcrush.backend.acceptance.step.ManagerJoinStep.카페_사장_회원_가입_요청하고_액세스_토큰_반환;
+import static com.stampcrush.backend.acceptance.step.ManagerSampleCouponFindStep.샘플_쿠폰_조회_요청;
+import static com.stampcrush.backend.fixture.SampleCouponFixture.SAMPLE_BACK_IMAGE;
+import static com.stampcrush.backend.fixture.SampleCouponFixture.SAMPLE_COORDINATES_SIZE_EIGHT;
+import static com.stampcrush.backend.fixture.SampleCouponFixture.SAMPLE_FRONT_IMAGE;
+import static com.stampcrush.backend.fixture.SampleCouponFixture.SAMPLE_STAMP_IMAGE;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
@@ -39,7 +42,8 @@ public class ManagerSampleCouponFindAcceptanceTest extends AcceptanceTest {
     @Autowired
     private OwnerRepository ownerRepository;
 
-    private Owner owner;
+    @Autowired
+    private AuthTokensGenerator authTokensGenerator;
 
     @BeforeEach
     void setUp() {
@@ -49,47 +53,16 @@ public class ManagerSampleCouponFindAcceptanceTest extends AcceptanceTest {
                 .peek(e -> e.setSampleBackImage(savedSampleBackImage))
                 .forEach(e -> sampleStampCoordinateRepository.save(e));
         sampleStampImageRepository.save(SAMPLE_STAMP_IMAGE);
-
-        owner = ownerRepository.save(OWNER3);
-    }
-
-    @Disabled
-    @Test
-    void 전체_쿠폰_샘플을_조회한다() {
-        // given, when
-        ExtractableResponse<Response> response = RestAssured.given()
-                .log().all()
-
-                .when()
-                .auth().preemptive()
-                .oauth2(BearerAuthHelper.generateToken(owner.getId()))
-                .get("/api/admin/coupon-samples")
-
-                .then()
-                .extract();
-
-        // then
-        assertAll(
-                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
-                () -> assertThat(response.jsonPath().getList("sampleFrontImages").size()).isEqualTo(1),
-                () -> assertThat(response.jsonPath().getList("sampleBackImages").size()).isEqualTo(1),
-                () -> assertThat(response.jsonPath().getList("sampleStampImages").size()).isEqualTo(1)
-        );
     }
 
     @Test
     void 최대_스탬프_개수로_쿠폰_샘플을_필터링해서_조회한다() {
         // given, when
-        ExtractableResponse<Response> response = RestAssured.given()
-                .log().all()
+        String accessToken = 카페_사장_회원_가입_요청하고_액세스_토큰_반환(OWNER_CREATE_REQUEST);
+        Long ownerId = authTokensGenerator.extractMemberId(accessToken);
+        Owner owner = ownerRepository.findById(ownerId).get();
 
-                .when()
-                .auth().preemptive()
-                .oauth2(BearerAuthHelper.generateToken(owner.getId()))
-                .get("/api/admin/coupon-samples?max-stamp-count=8")
-
-                .then()
-                .extract();
+        ExtractableResponse<Response> response = 샘플_쿠폰_조회_요청(accessToken, 8);
 
         // then
         assertAll(
@@ -103,16 +76,11 @@ public class ManagerSampleCouponFindAcceptanceTest extends AcceptanceTest {
     @Test
     void 해당하는_최대_스탬프_개수의_샘플_쿠폰이_없으면_뒷면이_조회되지_않는다() {
         // given, when
-        ExtractableResponse<Response> response = RestAssured.given()
-                .log().all()
+        String accessToken = 카페_사장_회원_가입_요청하고_액세스_토큰_반환(OWNER_CREATE_REQUEST);
+        Long ownerId = authTokensGenerator.extractMemberId(accessToken);
+        Owner owner = ownerRepository.findById(ownerId).get();
 
-                .when()
-                .auth().preemptive()
-                .oauth2(BearerAuthHelper.generateToken(owner.getId()))
-                .get("/api/admin/coupon-samples?max-stamp-count=10")
-
-                .then()
-                .extract();
+        ExtractableResponse<Response> response = 샘플_쿠폰_조회_요청(accessToken, 10);
 
         // then
         assertAll(

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/ManagerSampleCouponFindAcceptanceTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/ManagerSampleCouponFindAcceptanceTest.java
@@ -2,7 +2,6 @@ package com.stampcrush.backend.acceptance;
 
 import com.stampcrush.backend.auth.application.util.AuthTokensGenerator;
 import com.stampcrush.backend.entity.sample.SampleBackImage;
-import com.stampcrush.backend.entity.user.Owner;
 import com.stampcrush.backend.repository.sample.SampleBackImageRepository;
 import com.stampcrush.backend.repository.sample.SampleFrontImageRepository;
 import com.stampcrush.backend.repository.sample.SampleStampCoordinateRepository;
@@ -59,8 +58,6 @@ public class ManagerSampleCouponFindAcceptanceTest extends AcceptanceTest {
     void 최대_스탬프_개수로_쿠폰_샘플을_필터링해서_조회한다() {
         // given, when
         String accessToken = 카페_사장_회원_가입_요청하고_액세스_토큰_반환(OWNER_CREATE_REQUEST);
-        Long ownerId = authTokensGenerator.extractMemberId(accessToken);
-        Owner owner = ownerRepository.findById(ownerId).get();
 
         ExtractableResponse<Response> response = 샘플_쿠폰_조회_요청(accessToken, 8);
 
@@ -77,8 +74,6 @@ public class ManagerSampleCouponFindAcceptanceTest extends AcceptanceTest {
     void 해당하는_최대_스탬프_개수의_샘플_쿠폰이_없으면_뒷면이_조회되지_않는다() {
         // given, when
         String accessToken = 카페_사장_회원_가입_요청하고_액세스_토큰_반환(OWNER_CREATE_REQUEST);
-        Long ownerId = authTokensGenerator.extractMemberId(accessToken);
-        Owner owner = ownerRepository.findById(ownerId).get();
 
         ExtractableResponse<Response> response = 샘플_쿠폰_조회_요청(accessToken, 10);
 

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/VisitorCouponCommandAcceptanceTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/VisitorCouponCommandAcceptanceTest.java
@@ -1,0 +1,58 @@
+package com.stampcrush.backend.acceptance;
+
+import com.stampcrush.backend.api.manager.coupon.request.CouponCreateRequest;
+import com.stampcrush.backend.auth.application.util.AuthTokensGenerator;
+import com.stampcrush.backend.entity.user.Customer;
+import com.stampcrush.backend.repository.coupon.CouponRepository;
+import com.stampcrush.backend.repository.user.CustomerRepository;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+
+import static com.stampcrush.backend.acceptance.step.ManagerCafeCouponSettingUpdateStep.CAFE_COUPON_SETTING_UPDATE_REQUEST;
+import static com.stampcrush.backend.acceptance.step.ManagerCafeCouponSettingUpdateStep.카페_쿠폰_정책_수정_요청;
+import static com.stampcrush.backend.acceptance.step.ManagerCafeCreateStep.CAFE_CREATE_REQUEST;
+import static com.stampcrush.backend.acceptance.step.ManagerCafeCreateStep.카페_생성_요청하고_아이디_반환_2;
+import static com.stampcrush.backend.acceptance.step.ManagerCouponCreateStep.쿠폰_생성_요청하고_아이디_반환;
+import static com.stampcrush.backend.acceptance.step.ManagerJoinStep.OWNER_GITCHAN_JOIN_REQUEST;
+import static com.stampcrush.backend.acceptance.step.ManagerJoinStep.카페_사장_회원_가입_요청하고_액세스_토큰_반환;
+import static com.stampcrush.backend.acceptance.step.VisitorCouponDeleteStep.쿠폰_삭제_요청;
+import static com.stampcrush.backend.acceptance.step.VisitorJoinStep.REGISTER_CUSTOMER_GITCHAN_CREATE_REQUEST;
+import static com.stampcrush.backend.acceptance.step.VisitorJoinStep.가입_고객_회원_가입_요청하고_액세스_토큰_반환;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+public class VisitorCouponCommandAcceptanceTest extends AcceptanceTest {
+
+    @Autowired
+    private CustomerRepository customerRepository;
+
+    @Autowired
+    private CouponRepository couponRepository;
+
+    @Autowired
+    private AuthTokensGenerator authTokensGenerator;
+
+    @Test
+    void 쿠폰을_삭제할_수_있다() {
+        // given, when
+        String gitchanAccessToken = 카페_사장_회원_가입_요청하고_액세스_토큰_반환(OWNER_GITCHAN_JOIN_REQUEST);
+        String customerAccessToken = 가입_고객_회원_가입_요청하고_액세스_토큰_반환(REGISTER_CUSTOMER_GITCHAN_CREATE_REQUEST);
+        Long customerId = authTokensGenerator.extractMemberId(customerAccessToken);
+        Customer customer = customerRepository.findById(customerId).get();
+
+        Long gitchanCafeId = 카페_생성_요청하고_아이디_반환_2(gitchanAccessToken, CAFE_CREATE_REQUEST);
+        카페_쿠폰_정책_수정_요청(CAFE_COUPON_SETTING_UPDATE_REQUEST, gitchanAccessToken, gitchanCafeId);
+
+        Long gitchanCafeCouponId = 쿠폰_생성_요청하고_아이디_반환(gitchanAccessToken, new CouponCreateRequest(gitchanCafeId), customer.getId());
+
+        ExtractableResponse<Response> response = 쿠폰_삭제_요청(customerAccessToken, gitchanCafeCouponId);
+
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value()),
+                () -> assertThat(couponRepository.findById(gitchanCafeCouponId)).isEmpty()
+        );
+    }
+}

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/VisitorCouponFindAcceptanceTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/VisitorCouponFindAcceptanceTest.java
@@ -2,14 +2,14 @@ package com.stampcrush.backend.acceptance;
 
 import com.stampcrush.backend.api.manager.coupon.request.CouponCreateRequest;
 import com.stampcrush.backend.auth.OAuthProvider;
+import com.stampcrush.backend.auth.api.request.OAuthRegisterOwnerCreateRequest;
+import com.stampcrush.backend.auth.application.util.AuthTokensGenerator;
 import com.stampcrush.backend.entity.cafe.Cafe;
 import com.stampcrush.backend.entity.coupon.Coupon;
 import com.stampcrush.backend.entity.user.Customer;
-import com.stampcrush.backend.entity.user.Owner;
 import com.stampcrush.backend.repository.cafe.CafeRepository;
 import com.stampcrush.backend.repository.coupon.CouponRepository;
 import com.stampcrush.backend.repository.user.CustomerRepository;
-import com.stampcrush.backend.repository.user.OwnerRepository;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import org.junit.jupiter.api.Disabled;
@@ -20,26 +20,16 @@ import org.springframework.http.HttpStatus;
 import static com.stampcrush.backend.acceptance.step.ManagerCafeCouponSettingUpdateStep.CAFE_COUPON_SETTING_UPDATE_REQUEST;
 import static com.stampcrush.backend.acceptance.step.ManagerCafeCouponSettingUpdateStep.카페_쿠폰_정책_수정_요청;
 import static com.stampcrush.backend.acceptance.step.ManagerCafeCreateStep.CAFE_CREATE_REQUEST;
-import static com.stampcrush.backend.acceptance.step.ManagerCafeCreateStep.카페_생성_요청하고_아이디_반환;
+import static com.stampcrush.backend.acceptance.step.ManagerCafeCreateStep.카페_생성_요청하고_아이디_반환_2;
 import static com.stampcrush.backend.acceptance.step.ManagerCouponCreateStep.쿠폰_생성_요청하고_아이디_반환;
+import static com.stampcrush.backend.acceptance.step.ManagerJoinStep.카페_사장_회원_가입_요청하고_액세스_토큰_반환;
 import static com.stampcrush.backend.acceptance.step.VisitorCouponFindStep.고객의_쿠폰_카페별로_1개씩_조회_요청;
-import static com.stampcrush.backend.fixture.OwnerFixture.GITCHAN;
-import static com.stampcrush.backend.fixture.OwnerFixture.JENA;
+import static com.stampcrush.backend.acceptance.step.VisitorJoinStep.REGISTER_CUSTOMER_CREATE_REQUEST;
+import static com.stampcrush.backend.acceptance.step.VisitorJoinStep.가입_고객_회원_가입_요청하고_액세스_토큰_반환;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 public class VisitorCouponFindAcceptanceTest extends AcceptanceTest {
-
-    private final Customer registerCustomer = Customer.registeredCustomerBuilder()
-            .nickname("깃짱")
-            .email("email@email.com")
-            .loginId("cutomerId")
-            .encryptedPassword("customerPw")
-            .oAuthProvider(OAuthProvider.KAKAO)
-            .oAuthId(123L)
-            .build();
-    @Autowired
-    private OwnerRepository ownerRepository;
 
     @Autowired
     private CustomerRepository customerRepository;
@@ -50,27 +40,31 @@ public class VisitorCouponFindAcceptanceTest extends AcceptanceTest {
     @Autowired
     private CouponRepository couponRepository;
 
+    @Autowired
+    private AuthTokensGenerator authTokensGenerator;
+
     @Test
     void 카페당_하나의_쿠폰을_조회할_수_있다() {
         // given
-        // TODO: Owner에 대한 회원가입 로직이 생기면 요청으로 대체한다.
-        Owner gitchan = ownerRepository.save(GITCHAN);
-        Owner jena = ownerRepository.save(JENA);
+        String gitchanAccessToken = 카페_사장_회원_가입_요청하고_액세스_토큰_반환(new OAuthRegisterOwnerCreateRequest("깃짱", OAuthProvider.KAKAO, 123L));
+        String jenaAccessToken = 카페_사장_회원_가입_요청하고_액세스_토큰_반환(new OAuthRegisterOwnerCreateRequest("제나", OAuthProvider.KAKAO, 12341L));
 
-        Customer customer = customerRepository.save(registerCustomer);
+        String customerAccessToken = 가입_고객_회원_가입_요청하고_액세스_토큰_반환(REGISTER_CUSTOMER_CREATE_REQUEST);
+        Long customerId = authTokensGenerator.extractMemberId(customerAccessToken);
+        Customer customer = customerRepository.findById(customerId).get();
 
-        Long gitchanCafeId = 카페_생성_요청하고_아이디_반환(gitchan, CAFE_CREATE_REQUEST);
+        Long gitchanCafeId = 카페_생성_요청하고_아이디_반환_2(gitchanAccessToken, CAFE_CREATE_REQUEST);
         Cafe gitchanCafe = cafeRepository.findById(gitchanCafeId).get();
-        카페_쿠폰_정책_수정_요청(CAFE_COUPON_SETTING_UPDATE_REQUEST, gitchan, gitchanCafeId);
+        카페_쿠폰_정책_수정_요청(CAFE_COUPON_SETTING_UPDATE_REQUEST, gitchanAccessToken, gitchanCafeId);
 
-        Long jenaCafeId = 카페_생성_요청하고_아이디_반환(jena, CAFE_CREATE_REQUEST);
+        Long jenaCafeId = 카페_생성_요청하고_아이디_반환_2(jenaAccessToken, CAFE_CREATE_REQUEST);
         Cafe jenaCafe = cafeRepository.findById(jenaCafeId).get();
-        카페_쿠폰_정책_수정_요청(CAFE_COUPON_SETTING_UPDATE_REQUEST, jena, jenaCafeId);
+        카페_쿠폰_정책_수정_요청(CAFE_COUPON_SETTING_UPDATE_REQUEST, jenaAccessToken, jenaCafeId);
 
-        Long gitchanCafeCouponId = 쿠폰_생성_요청하고_아이디_반환(gitchan, new CouponCreateRequest(gitchanCafeId), customer.getId());
+        Long gitchanCafeCouponId = 쿠폰_생성_요청하고_아이디_반환(gitchanAccessToken, new CouponCreateRequest(gitchanCafeId), customer.getId());
         Coupon gitchanCafeCoupon = couponRepository.findById(gitchanCafeCouponId).get();
 
-        Long jenaCafeCouponId = 쿠폰_생성_요청하고_아이디_반환(jena, new CouponCreateRequest(jenaCafeId), customer.getId());
+        Long jenaCafeCouponId = 쿠폰_생성_요청하고_아이디_반환(jenaAccessToken, new CouponCreateRequest(jenaCafeId), customer.getId());
         Coupon jenaCafeCoupon = couponRepository.findById(jenaCafeCouponId).get();
 
         // when
@@ -81,13 +75,18 @@ public class VisitorCouponFindAcceptanceTest extends AcceptanceTest {
                 () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
                 () -> assertThat(response.jsonPath().getList("coupons")).isNotEmpty(),
                 () -> assertThat(response.jsonPath().getList("coupons").size()).isEqualTo(2),
+
                 () -> assertThat(response.jsonPath().getLong("coupons[0].cafeInfo.id")).isEqualTo(gitchanCafeId),
                 () -> assertThat(response.jsonPath().getString("coupons[0].cafeInfo.name")).isEqualTo(gitchanCafe.getName()),
                 () -> assertThat(response.jsonPath().getLong("coupons[0].couponInfos[0].id")).isEqualTo(gitchanCafeCouponId),
                 () -> assertThat(response.jsonPath().getString("coupons[0].couponInfos[0].status")).isEqualTo(gitchanCafeCoupon.getStatus().name()),
                 () -> assertThat(response.jsonPath().getList("coupons[0].couponInfos[0].coordinates")).isNotEmpty(),
-                () -> assertThat(response.jsonPath().getLong("coupons[1].cafeInfo.id")).isEqualTo(jenaCafeCouponId),
-                () -> assertThat(response.jsonPath().getLong("coupons[1].couponInfos[0].id")).isEqualTo(jenaCafeCouponId)
+
+                () -> assertThat(response.jsonPath().getLong("coupons[1].cafeInfo.id")).isEqualTo(jenaCafeId),
+                () -> assertThat(response.jsonPath().getString("coupons[1].cafeInfo.name")).isEqualTo(jenaCafe.getName()),
+                () -> assertThat(response.jsonPath().getLong("coupons[1].couponInfos[0].id")).isEqualTo(jenaCafeCouponId),
+                () -> assertThat(response.jsonPath().getString("coupons[1].couponInfos[0].status")).isEqualTo(jenaCafeCoupon.getStatus().name()),
+                () -> assertThat(response.jsonPath().getList("coupons[1].couponInfos[0].coordinates")).isNotEmpty()
         );
     }
 
@@ -97,16 +96,18 @@ public class VisitorCouponFindAcceptanceTest extends AcceptanceTest {
         // given
 
         // TODO: Owner에 대한 회원가입 로직이 생기면 요청으로 대체한다.
-        Owner gitchan = ownerRepository.save(GITCHAN);
-        Owner jena = ownerRepository.save(JENA);
+        String gitchanAccessToken = 카페_사장_회원_가입_요청하고_액세스_토큰_반환(new OAuthRegisterOwnerCreateRequest("깃짱", OAuthProvider.KAKAO, 123L));
+        String jenaAccessToken = 카페_사장_회원_가입_요청하고_액세스_토큰_반환(new OAuthRegisterOwnerCreateRequest("제나", OAuthProvider.KAKAO, 12341L));
 
-        Customer customer = customerRepository.save(registerCustomer);
+        String customerAccessToken = 가입_고객_회원_가입_요청하고_액세스_토큰_반환(REGISTER_CUSTOMER_CREATE_REQUEST);
+        Long customerId = authTokensGenerator.extractMemberId(customerAccessToken);
+        Customer customer = customerRepository.findById(customerId).get();
 
-        Long gitchanCafeId = 카페_생성_요청하고_아이디_반환(gitchan, CAFE_CREATE_REQUEST);
-        Long jenaCafeId = 카페_생성_요청하고_아이디_반환(jena, CAFE_CREATE_REQUEST);
+        Long gitchanCafeId = 카페_생성_요청하고_아이디_반환_2(gitchanAccessToken, CAFE_CREATE_REQUEST);
+        Long jenaCafeId = 카페_생성_요청하고_아이디_반환_2(jenaAccessToken, CAFE_CREATE_REQUEST);
 
-        Long gitchanCafeCouponId = 쿠폰_생성_요청하고_아이디_반환(gitchan, new CouponCreateRequest(gitchanCafeId), customer.getId());
-        Long jenaCafeCouponId = 쿠폰_생성_요청하고_아이디_반환(jena, new CouponCreateRequest(jenaCafeId), customer.getId());
+        Long gitchanCafeCouponId = 쿠폰_생성_요청하고_아이디_반환(gitchanAccessToken, new CouponCreateRequest(gitchanCafeId), customer.getId());
+        Long jenaCafeCouponId = 쿠폰_생성_요청하고_아이디_반환(jenaAccessToken, new CouponCreateRequest(jenaCafeId), customer.getId());
         accumulateCouponUntilRewarded(gitchanCafeCouponId);
 
         // when

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/VisitorCouponFindAcceptanceTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/VisitorCouponFindAcceptanceTest.java
@@ -24,7 +24,7 @@ import static com.stampcrush.backend.acceptance.step.ManagerCafeCreateStep.카�
 import static com.stampcrush.backend.acceptance.step.ManagerCouponCreateStep.쿠폰_생성_요청하고_아이디_반환;
 import static com.stampcrush.backend.acceptance.step.ManagerJoinStep.카페_사장_회원_가입_요청하고_액세스_토큰_반환;
 import static com.stampcrush.backend.acceptance.step.VisitorCouponFindStep.고객의_쿠폰_카페별로_1개씩_조회_요청;
-import static com.stampcrush.backend.acceptance.step.VisitorJoinStep.REGISTER_CUSTOMER_CREATE_REQUEST;
+import static com.stampcrush.backend.acceptance.step.VisitorJoinStep.REGISTER_CUSTOMER_GITCHAN_CREATE_REQUEST;
 import static com.stampcrush.backend.acceptance.step.VisitorJoinStep.가입_고객_회원_가입_요청하고_액세스_토큰_반환;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -49,7 +49,7 @@ public class VisitorCouponFindAcceptanceTest extends AcceptanceTest {
         String gitchanAccessToken = 카페_사장_회원_가입_요청하고_액세스_토큰_반환(new OAuthRegisterOwnerCreateRequest("깃짱", OAuthProvider.KAKAO, 123L));
         String jenaAccessToken = 카페_사장_회원_가입_요청하고_액세스_토큰_반환(new OAuthRegisterOwnerCreateRequest("제나", OAuthProvider.KAKAO, 12341L));
 
-        String customerAccessToken = 가입_고객_회원_가입_요청하고_액세스_토큰_반환(REGISTER_CUSTOMER_CREATE_REQUEST);
+        String customerAccessToken = 가입_고객_회원_가입_요청하고_액세스_토큰_반환(REGISTER_CUSTOMER_GITCHAN_CREATE_REQUEST);
         Long customerId = authTokensGenerator.extractMemberId(customerAccessToken);
         Customer customer = customerRepository.findById(customerId).get();
 
@@ -99,7 +99,7 @@ public class VisitorCouponFindAcceptanceTest extends AcceptanceTest {
         String gitchanAccessToken = 카페_사장_회원_가입_요청하고_액세스_토큰_반환(new OAuthRegisterOwnerCreateRequest("깃짱", OAuthProvider.KAKAO, 123L));
         String jenaAccessToken = 카페_사장_회원_가입_요청하고_액세스_토큰_반환(new OAuthRegisterOwnerCreateRequest("제나", OAuthProvider.KAKAO, 12341L));
 
-        String customerAccessToken = 가입_고객_회원_가입_요청하고_액세스_토큰_반환(REGISTER_CUSTOMER_CREATE_REQUEST);
+        String customerAccessToken = 가입_고객_회원_가입_요청하고_액세스_토큰_반환(REGISTER_CUSTOMER_GITCHAN_CREATE_REQUEST);
         Long customerId = authTokensGenerator.extractMemberId(customerAccessToken);
         Customer customer = customerRepository.findById(customerId).get();
 

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/step/ManagerCafeCouponSettingUpdateStep.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/step/ManagerCafeCouponSettingUpdateStep.java
@@ -25,12 +25,29 @@ public class ManagerCafeCouponSettingUpdateStep {
             6
     );
 
+    @Deprecated
     public static ExtractableResponse<Response> 카페_쿠폰_정책_수정_요청(CafeCouponSettingUpdateRequest request, Owner owner, Long cafeId) {
         return RestAssured.given()
                 .log().all()
                 .contentType(JSON)
                 .auth().preemptive()
                 .oauth2(BearerAuthHelper.generateToken(owner.getId()))
+                .body(request)
+
+                .when()
+                .post("/api/admin/coupon-setting?cafe-id=" + cafeId)
+
+                .then()
+                .log().all()
+                .extract();
+    }
+
+    public static ExtractableResponse<Response> 카페_쿠폰_정책_수정_요청(CafeCouponSettingUpdateRequest request, String ownerAccessToken, Long cafeId) {
+        return RestAssured.given()
+                .log().all()
+                .contentType(JSON)
+                .auth().preemptive()
+                .oauth2(ownerAccessToken)
                 .body(request)
 
                 .when()

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/step/ManagerCafeCreateStep.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/step/ManagerCafeCreateStep.java
@@ -13,12 +13,14 @@ public class ManagerCafeCreateStep {
 
     public static final CafeCreateRequest CAFE_CREATE_REQUEST = new CafeCreateRequest("깃짱카페", "서초구", "우리집", "01010101010");
 
+    @Deprecated
     public static Long 카페_생성_요청하고_아이디_반환(Owner owner, CafeCreateRequest cafeCreateRequest) {
         ExtractableResponse<Response> response = 카페_생성_요청(owner, cafeCreateRequest);
         String location = response.header("Location");
         return Long.valueOf(location.split("/")[2]);
     }
 
+    @Deprecated
     public static ExtractableResponse<Response> 카페_생성_요청(Owner owner, CafeCreateRequest cafeCreateRequest) {
         return RestAssured.given()
                 .log().all()
@@ -26,6 +28,28 @@ public class ManagerCafeCreateStep {
                 .body(cafeCreateRequest)
                 .auth().preemptive()
                 .oauth2(BearerAuthHelper.generateToken(owner.getId()))
+
+                .when()
+                .post("/api/admin/cafes")
+
+                .then()
+                .log().all()
+                .extract();
+    }
+
+    public static Long 카페_생성_요청하고_아이디_반환_2(String accessToken, CafeCreateRequest cafeCreateRequest) {
+        ExtractableResponse<Response> response = 카페_생성_요청_2(accessToken, cafeCreateRequest);
+        String location = response.header("Location");
+        return Long.valueOf(location.split("/")[2]);
+    }
+
+    public static ExtractableResponse<Response> 카페_생성_요청_2(String accessToken, CafeCreateRequest cafeCreateRequest) {
+        return RestAssured.given()
+                .log().all()
+                .contentType(JSON)
+                .body(cafeCreateRequest)
+                .auth().preemptive()
+                .oauth2(accessToken)
 
                 .when()
                 .post("/api/admin/cafes")

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/step/ManagerCouponCreateStep.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/step/ManagerCouponCreateStep.java
@@ -33,4 +33,26 @@ public class ManagerCouponCreateStep {
                 .log().all()
                 .extract();
     }
+
+    public static Long 쿠폰_생성_요청하고_아이디_반환(String accessToken, CouponCreateRequest request, Long customerId) {
+        ExtractableResponse<Response> response = 쿠폰_생성_요청(accessToken, request, customerId);
+        CouponCreateResponse couponCreateResponse = response.body().as(CouponCreateResponse.class);
+        return couponCreateResponse.getCouponId();
+    }
+
+    public static ExtractableResponse<Response> 쿠폰_생성_요청(String accessToken, CouponCreateRequest request, Long customerId) {
+        return RestAssured.given()
+                .log().all()
+                .contentType(JSON)
+                .body(request)
+                .auth().preemptive()
+                .oauth2(accessToken)
+
+                .when()
+                .post("/api/admin/customers/" + customerId + "/coupons")
+
+                .then()
+                .log().all()
+                .extract();
+    }
 }

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/step/ManagerCustomerFindStep.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/step/ManagerCustomerFindStep.java
@@ -2,8 +2,10 @@ package com.stampcrush.backend.acceptance.step;
 
 import com.stampcrush.backend.entity.user.Owner;
 import com.stampcrush.backend.helper.BearerAuthHelper;
+import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import org.springframework.http.MediaType;
 
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
@@ -19,6 +21,22 @@ public class ManagerCustomerFindStep {
 
                 .when()
                 .get("/api/admin/cafes/{cafeId}/customers", cafeId)
+
+                .then()
+                .log().all()
+                .extract();
+    }
+
+    public static ExtractableResponse<Response> 전화번호로_고객_조회_요청(Owner owner, String phoneNumber) {
+        return RestAssured.given()
+                .log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .param("phone-number", phoneNumber)
+                .auth().preemptive()
+                .oauth2(BearerAuthHelper.generateToken(owner.getId()))
+
+                .when()
+                .get("/api/admin/customers")
 
                 .then()
                 .log().all()

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/step/ManagerJoinStep.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/step/ManagerJoinStep.java
@@ -14,6 +14,10 @@ public class ManagerJoinStep {
             "깃짱", OAuthProvider.KAKAO, 123234L
     );
 
+    public static final OAuthRegisterOwnerCreateRequest OWNER_GITCHAN_JOIN_REQUEST = new OAuthRegisterOwnerCreateRequest(
+            "깃짱", OAuthProvider.KAKAO, 123L
+    );
+
     public static String 카페_사장_회원_가입_요청하고_액세스_토큰_반환(OAuthRegisterOwnerCreateRequest request) {
         ExtractableResponse<Response> response = 카페_사장_회원_가입_요청(request);
         return response.jsonPath().getString("accessToken");

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/step/ManagerJoinStep.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/step/ManagerJoinStep.java
@@ -1,5 +1,6 @@
 package com.stampcrush.backend.acceptance.step;
 
+import com.stampcrush.backend.auth.OAuthProvider;
 import com.stampcrush.backend.auth.api.request.OAuthRegisterOwnerCreateRequest;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
@@ -8,6 +9,10 @@ import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
 
 public class ManagerJoinStep {
+
+    public static final OAuthRegisterOwnerCreateRequest OWNER_CREATE_REQUEST = new OAuthRegisterOwnerCreateRequest(
+            "깃짱", OAuthProvider.KAKAO, 123234L
+    );
 
     public static String 카페_사장_회원_가입_요청하고_액세스_토큰_반환(OAuthRegisterOwnerCreateRequest request) {
         ExtractableResponse<Response> response = 카페_사장_회원_가입_요청(request);

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/step/ManagerSampleCouponFindStep.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/step/ManagerSampleCouponFindStep.java
@@ -1,0 +1,21 @@
+package com.stampcrush.backend.acceptance.step;
+
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+
+public class ManagerSampleCouponFindStep {
+
+    public static ExtractableResponse<Response> 샘플_쿠폰_조회_요청(String accessToken, int maxStampCount) {
+        return RestAssured.given()
+                .log().all()
+                .auth().preemptive()
+                .oauth2(accessToken)
+
+                .when()
+                .get("/api/admin/coupon-samples?max-stamp-count=" + maxStampCount)
+
+                .then()
+                .extract();
+    }
+}

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/step/VisitorCouponDeleteStep.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/step/VisitorCouponDeleteStep.java
@@ -1,0 +1,22 @@
+package com.stampcrush.backend.acceptance.step;
+
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+
+public class VisitorCouponDeleteStep {
+
+    public static ExtractableResponse<Response> 쿠폰_삭제_요청(String customerAccessToken, Long gitchanCafeCouponId) {
+        return RestAssured.given()
+                .log().all()
+                .auth().preemptive()
+                .oauth2(customerAccessToken)
+
+                .when()
+                .delete("/api/coupons/" + gitchanCafeCouponId)
+
+                .then()
+                .log().all()
+                .extract();
+    }
+}

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/step/VisitorJoinStep.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/step/VisitorJoinStep.java
@@ -12,7 +12,7 @@ import static io.restassured.http.ContentType.JSON;
 
 public class VisitorJoinStep {
 
-    public static final OAuthRegisterCustomerCreateRequest REGISTER_CUSTOMER_CREATE_REQUEST = new OAuthRegisterCustomerCreateRequest(
+    public static final OAuthRegisterCustomerCreateRequest REGISTER_CUSTOMER_GITCHAN_CREATE_REQUEST = new OAuthRegisterCustomerCreateRequest(
             "깃짱", "gitchan@naver.com", OAuthProvider.KAKAO, 123142L
     );
 

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/step/VisitorJoinStep.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/step/VisitorJoinStep.java
@@ -1,6 +1,7 @@
 package com.stampcrush.backend.acceptance.step;
 
 import com.stampcrush.backend.api.manager.customer.request.TemporaryCustomerCreateRequest;
+import com.stampcrush.backend.auth.OAuthProvider;
 import com.stampcrush.backend.auth.api.request.OAuthRegisterCustomerCreateRequest;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
@@ -10,6 +11,10 @@ import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
 
 public class VisitorJoinStep {
+
+    public static final OAuthRegisterCustomerCreateRequest REGISTER_CUSTOMER_CREATE_REQUEST = new OAuthRegisterCustomerCreateRequest(
+            "깃짱", "gitchan@naver.com", OAuthProvider.KAKAO, 123142L
+    );
 
     @Deprecated // 프로덕션에서 해당하는 API가 있어서, 사용하지 않음.
     public static Long 임시_고객_회원_가입_요청하고_아이디_반환(String phoneNumber) {

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/step/VisitorJoinStep.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/step/VisitorJoinStep.java
@@ -16,6 +16,8 @@ public class VisitorJoinStep {
             "깃짱", "gitchan@naver.com", OAuthProvider.KAKAO, 123142L
     );
 
+    public static final TemporaryCustomerCreateRequest TEMPORARY_CUSTOMER_CREATE_REQUEST = new TemporaryCustomerCreateRequest("01012345678");
+
     @Deprecated // 프로덕션에서 해당하는 API가 있어서, 사용하지 않음.
     public static Long 임시_고객_회원_가입_요청하고_아이디_반환(String phoneNumber) {
         ExtractableResponse<Response> response = 임시_고객_회원_가입_요청(phoneNumber);

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/step/VisitorJoinStep.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/step/VisitorJoinStep.java
@@ -1,5 +1,6 @@
 package com.stampcrush.backend.acceptance.step;
 
+import com.stampcrush.backend.api.manager.customer.request.TemporaryCustomerCreateRequest;
 import com.stampcrush.backend.auth.api.request.OAuthRegisterCustomerCreateRequest;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
@@ -10,12 +11,14 @@ import static io.restassured.http.ContentType.JSON;
 
 public class VisitorJoinStep {
 
+    @Deprecated // 프로덕션에서 해당하는 API가 있어서, 사용하지 않음.
     public static Long 임시_고객_회원_가입_요청하고_아이디_반환(String phoneNumber) {
         ExtractableResponse<Response> response = 임시_고객_회원_가입_요청(phoneNumber);
         String location = response.header("Location");
         return Long.valueOf(location.split("/")[2]);
     }
 
+    @Deprecated // 프로덕션에서 해당하는 API가 있어서, 사용하지 않음.
     public static ExtractableResponse<Response> 임시_고객_회원_가입_요청(String phoneNumber) {
         return RestAssured.given()
                 .log().all()
@@ -23,6 +26,28 @@ public class VisitorJoinStep {
 
                 .when()
                 .post("/api/login/temporary/test?phone-number=" + phoneNumber)
+
+                .then()
+                .log().all()
+                .extract();
+    }
+
+    public static Long 임시_고객_회원_가입_요청하고_아이디_반환(String accessToken, TemporaryCustomerCreateRequest request) {
+        ExtractableResponse<Response> response = 임시_고객_회원_가입_요청(accessToken, request);
+        String location = response.header("Location");
+        return Long.valueOf(location.split("/")[2]);
+    }
+
+    public static ExtractableResponse<Response> 임시_고객_회원_가입_요청(String accessToken, TemporaryCustomerCreateRequest request) {
+        return RestAssured.given()
+                .log().all()
+                .contentType(JSON)
+                .auth().preemptive()
+                .oauth2(accessToken)
+                .body(request)
+
+                .when()
+                .post("/api/admin/temporary-customers")
 
                 .then()
                 .log().all()

--- a/backend/src/test/java/com/stampcrush/backend/application/visitor/coupon/VisitorCouponFindServiceTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/application/visitor/coupon/VisitorCouponFindServiceTest.java
@@ -62,7 +62,7 @@ class VisitorCouponFindServiceTest {
         when(customerRepository.findById(customerId))
                 .thenReturn(Optional.of(customer));
 
-        when(couponRepository.findFilteredAndSortedCoupons(customer, CouponStatus.ACCUMULATING))
+        when(couponRepository.findCouponsByCustomerAndStatus(customer, CouponStatus.ACCUMULATING))
                 .thenReturn(new ArrayList<>());
 
         assertThat(visitorCouponFindService.findOneCouponForOneCafe(customerId)).isEmpty();
@@ -77,7 +77,7 @@ class VisitorCouponFindServiceTest {
         when(customerRepository.findById(customerId))
                 .thenReturn(Optional.of(customer));
 
-        when(couponRepository.findFilteredAndSortedCoupons(customer, CouponStatus.ACCUMULATING))
+        when(couponRepository.findCouponsByCustomerAndStatus(customer, CouponStatus.ACCUMULATING))
                 .thenReturn(List.of(gitchanCoupon));
 
         when(visitorFavoritesFindService.findIsFavorites(gitchanCoupon.getCafe(), customer))

--- a/backend/src/test/java/com/stampcrush/backend/repository/coupon/CouponRepositoryTest2.java
+++ b/backend/src/test/java/com/stampcrush/backend/repository/coupon/CouponRepositoryTest2.java
@@ -166,7 +166,7 @@ class CouponRepositoryTest2 {
         Coupon jenaCafeCoupon = saveCoupon(jenaCafe, savedCustomer, couponDesignRepository.save(CouponDesignFixture.COUPON_DESIGN_2), couponPolicyRepository.save(CouponPolicyFixture.COUPON_POLICY_2));
 
         // when
-        List<Coupon> findCoupon = couponRepository.findFilteredAndSortedCoupons(savedCustomer, CouponStatus.ACCUMULATING);
+        List<Coupon> findCoupon = couponRepository.findCouponsByCustomerAndStatus(savedCustomer, CouponStatus.ACCUMULATING);
 
         // then
         assertThat(findCoupon).containsExactlyInAnyOrder(gitchanCafeCoupon, jenaCafeCoupon);
@@ -187,7 +187,7 @@ class CouponRepositoryTest2 {
         changeCafeCouponStatusToRewarded(gitchanCafeCoupon, gitchanCafeCouponPolicy.getMaxStampCount());
 
         // when
-        List<Coupon> findCoupon = couponRepository.findFilteredAndSortedCoupons(savedCustomer, CouponStatus.ACCUMULATING);
+        List<Coupon> findCoupon = couponRepository.findCouponsByCustomerAndStatus(savedCustomer, CouponStatus.ACCUMULATING);
 
         // then
         assertThat(findCoupon).containsOnly(jenaCafeCoupon);


### PR DESCRIPTION
## 주요 변경사항

- 인수테스트에서 회원가입 로직 새로 만든 회원가입 API로 대체하기
    - `Manager.customer` , `Manager.sample`, `Visitor.coupon`

## 리뷰어에게...

## 관련 이슈

closes

## 체크리스트

- [ ] `reviewers` 설정
- [ ] `label` 설정
- [ ] `milestone` 설정
