### PR TITLE
[FE] bug: 고객모드의 카페 상세페이지에서 탭바를 보이지 않도록 한다. 

### DIFF
--- a/frontend/src/pages/Customer/CouponList/CouponDetail/index.tsx
+++ b/frontend/src/pages/Customer/CouponList/CouponDetail/index.tsx
@@ -6,6 +6,7 @@ import {
   ContentContainer,
   CouponDetailContainer,
   DeleteButton,
+  DetailItem,
   OverviewContainer,
 } from './style';
 import { BiArrowBack } from 'react-icons/bi';
@@ -94,28 +95,32 @@ const CouponDetail = ({
           <Text>{cafeData.cafe.introduction}</Text>
         </OverviewContainer>
         <ContentContainer>
-          <Text ariaLabel="쿠폰 정책">
+          <DetailItem>
             <FaRegBell size={22} />
-            {`${couponInfos.rewardName} 무료!`}
-          </Text>
-          {cafeData.cafe.openTime && cafeData.cafe.closeTime && (
-            <Text ariaLabel="영업 시간">
-              <FaRegClock size={22} />
-              {`${cafeData.cafe.openTime} - ${cafeData.cafe.closeTime}`}
-            </Text>
-          )}
-          {cafeData.cafe.telephoneNumber && (
-            <Text ariaLabel="전화번호">
-              <FaPhoneAlt size={22} />
-              {parsePhoneNumber(cafeData.cafe.telephoneNumber)}
-            </Text>
-          )}
-          {cafeData.cafe.roadAddress && (
-            <Text ariaLabel="주소">
-              <FaLocationDot size={22} />
-              {cafeData.cafe.roadAddress + ' ' + cafeData.cafe.detailAddress}
-            </Text>
-          )}
+            <Text ariaLabel="쿠폰 정책">{`${couponInfos.rewardName} 무료!`}</Text>
+          </DetailItem>
+          <DetailItem>
+            {cafeData.cafe.openTime && cafeData.cafe.closeTime && (
+              <Text ariaLabel="영업 시간">
+                <FaRegClock size={22} />
+                {`${cafeData.cafe.openTime} - ${cafeData.cafe.closeTime}`}
+              </Text>
+            )}
+          </DetailItem>
+          <DetailItem>
+            <FaPhoneAlt size={22} />
+            {cafeData.cafe.telephoneNumber && (
+              <Text ariaLabel="전화번호">{parsePhoneNumber(cafeData.cafe.telephoneNumber)}</Text>
+            )}
+          </DetailItem>
+          <DetailItem>
+            <FaLocationDot size={22} />
+            {cafeData.cafe.roadAddress && (
+              <Text ariaLabel="주소">
+                {cafeData.cafe.roadAddress + ' ' + cafeData.cafe.detailAddress}
+              </Text>
+            )}
+          </DetailItem>
         </ContentContainer>
       </CouponDetailContainer>
       {isOpen && (

--- a/frontend/src/pages/Customer/CouponList/CouponDetail/style.tsx
+++ b/frontend/src/pages/Customer/CouponList/CouponDetail/style.tsx
@@ -11,6 +11,7 @@ export const CouponDetailContainer = styled.section<{ $isDetail: boolean }>`
   background: white;
   max-width: 450px;
   transform: translateY(100%);
+  z-index: 1;
 
   ${({ $isDetail }) =>
     $isDetail &&
@@ -74,14 +75,30 @@ export const CafeImage = styled.img`
   object-fit: cover;
 `;
 
+export const DetailItem = styled.div`
+  display: flex;
+  flex-direction: row;
+  gap: 10px;
+
+  & > :first-child {
+    min-width: 22px;
+    min-height: 22px;
+  }
+`;
+
 export const ContentContainer = styled.div`
   display: flex;
   flex-direction: column;
   position: absolute;
   bottom: 15%;
   left: 50px;
-  width: 345px;
+  width: 310px;
   gap: 10px;
+
+  /** iPhone SE */
+  @media only screen and (min-device-width: 320px) and (max-device-width: 375px) {
+    width: 290px;
+  }
 
   :nth-child(n) {
     display: flex;


### PR DESCRIPTION
## 주요 변경사항

- `z-index`로 탭바를 가려서 보이지 않도록 했는데, 완벽한 대처는 아닌 것으로 생각합니다. 다른 방안이 있다면 피드백주세요.
- 주소가 화면 밖으로 삐져나오는 경우를 대처했습니다.
- 주소가 긴 경우 아이콘의 레이아웃이 망가지는데 해당 경우에 대한 대처로 `min-width`, `min-height`를 주어 해결했습니다.

## 리뷰어에게...

## 관련 이슈

closes #707 

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [x] `milestone` 설정
