### PR TITLE
[FE] fix: token 만료 시 만료된 토큰을 삭제한다.

### DIFF
--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -9,7 +9,14 @@ const request = async (path: string, init?: RequestInit) => {
     },
   });
 
-  if (!response.ok) throw new Error(response.status.toString());
+  if (!response.ok) {
+    if (response.status === 401) {
+      // TODO: 현재는 로그인에 실패하면 모든 토큰을 비워버림. 추후 고객 페이지 요청과 사장님 페이지의 요청의 에러핸들링을 분리해야함.
+      localStorage.setItem('login-token', '');
+      localStorage.setItem('admin-login-token', '');
+    }
+    throw new Error(response.status.toString());
+  }
   return response;
 };
 

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -16,7 +16,7 @@ const request = async (path: string, init?: RequestInit) => {
       localStorage.setItem('admin-login-token', '');
       const REDIRECT_URL =
         process.env.NODE_ENV === 'development' ? 'http://localhost:3000' : (BASE_URL as string);
-      location.href = REDIRECT_URL;
+      location.href = `${REDIRECT_URL}/login`;
     }
     throw new Error(response.status.toString());
   }

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -14,6 +14,9 @@ const request = async (path: string, init?: RequestInit) => {
       // TODO: 현재는 로그인에 실패하면 모든 토큰을 비워버림. 추후 고객 페이지 요청과 사장님 페이지의 요청의 에러핸들링을 분리해야함.
       localStorage.setItem('login-token', '');
       localStorage.setItem('admin-login-token', '');
+      const REDIRECT_URL =
+        process.env.NODE_ENV === 'development' ? 'http://localhost:3000' : (BASE_URL as string);
+      location.href = REDIRECT_URL;
     }
     throw new Error(response.status.toString());
   }


### PR DESCRIPTION
## 주요 변경사항
현재 JWT access token이 만료된 상태에서 웹에 접근하면, 오류 페이지로 이동합니다. 지금까지 해결방법은 localStorage를 직접 비워주는 것밖에 방법이 없었습니다. 

현재 가지고 있는 토큰으로 인증을 시도하는데 만료된 토큰이라면 백엔드에서 401 HTTP 상태 코드가 반환됩니다. 따라서 최상단의 api 요청 로직에서 401 code일 시 토큰을 비워줍니다.

## 리뷰어에게...
- 에러 처리하는 부분을 보면, 어떤 api 요청이든 customer, admin을 비워줄 수 밖에 없습니다. 이를 구분하려면 고객 요청과 사장님 페이지 요청을 각각 구분하여 사용하여야 될 것 같습니다. (TODO 에 남겨두었습니다.)
- 401보다 구체적인 에러코드가 나오면, 상태코드 대신 에러응답값을 이용해 에러핸들링을 해줘도 좋을 것 같습니다.
- 추가로 refresh token이 구현된 이후에서도 이 분기문 안에서 처리해줘도 좋을 것 같아요.

## 관련 이슈
- #684 
closes #684 

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [x] `milestone` 설정
