### PR TITLE
[FE] fix: CustomerOrderOption 버그 수정

### DIFF
--- a/frontend/src/pages/Admin/CustomerList/hooks/useGetCustomers.ts
+++ b/frontend/src/pages/Admin/CustomerList/hooks/useGetCustomers.ts
@@ -5,7 +5,7 @@ import { CustomersRes } from '../../../../types/api/response';
 import { Customer } from '../../../../types/domain/customer';
 import { Option } from '../../../../types/utils';
 
-interface CustomerOrderOption extends Omit<Option, 'key'> {
+export interface CustomerOrderOption extends Omit<Option, 'key'> {
   key: keyof Customer;
 }
 

--- a/frontend/src/pages/Admin/CustomerList/index.tsx
+++ b/frontend/src/pages/Admin/CustomerList/index.tsx
@@ -6,7 +6,7 @@ import { CUSTOMERS_ORDER_OPTIONS } from '../../../constants';
 import LoadingSpinner from '../../../components/LoadingSpinner';
 import Customers from './Customers';
 import { useRedirectRegisterPage } from '../../../hooks/useRedirectRegisterPage';
-import useGetCustomers from './hooks/useGetCustomers';
+import useGetCustomers, { CustomerOrderOption } from './hooks/useGetCustomers';
 
 const CustomerList = () => {
   const cafeId = useRedirectRegisterPage();
@@ -14,7 +14,7 @@ const CustomerList = () => {
     key: 'stampCount',
     value: '스탬프순',
   });
-  const { data: customers, status } = useGetCustomers(cafeId, orderOption);
+  const { data: customers, status } = useGetCustomers(cafeId, orderOption as CustomerOrderOption);
 
   if (status === 'loading') return <LoadingSpinner />;
   if (status === 'error') return <CustomerContainer>Error</CustomerContainer>;


### PR DESCRIPTION
## 주요 변경사항

해당 [pr](https://github.com/woowacourse-teams/2023-stamp-crush/pull/695)을 머지한 후 빌드하다가 발생한 에러를 수정하였습니다.

에러가 발생한 이유는 다음과 같습니다. 

4번의 타입 단언을 피하고자 아래와 같이 리팩토링 하였었는데, 
<img width="1438" alt="스크린샷 2023-09-20 오전 11 14 10" src="https://github.com/woowacourse-teams/2023-stamp-crush/assets/62367797/3b831d44-41f0-401f-b9d2-254ccc80656d">

훅을 사용하는 컴포넌트 단에서 타입에러가 발생했었습니다.

따라서 훅의 인자에 타입단언을 해주어서 해결하였습니다.
훅의 인자에 타입단언을 피하려면 SelectBox의 Option의 key 타입을 제네릭으로 받도록 추상화하여야 하는데, 
현재 SelectBox가 많은 페이지에서 사용되고 있기 때문에, 조금 더 고민해봐야할 것 같습니다.!!


## 리뷰어에게...

## 관련 이슈

closes #720

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [x] `milestone` 설정
