### PR TITLE
[BE] fix: 고객이 쿠폰만 있고 방문횟수가 없을때 에러 수정

### DIFF
--- a/backend/src/main/java/com/stampcrush/backend/application/manager/coupon/ManagerCouponFindService.java
+++ b/backend/src/main/java/com/stampcrush/backend/application/manager/coupon/ManagerCouponFindService.java
@@ -55,6 +55,11 @@ public class ManagerCouponFindService {
         for (CustomerCoupons customerCoupon : customerCoupons) {
             Coupons coupons = new Coupons(customerCoupon.coupons);
             VisitHistories visitHistories = findVisitHistories(cafe, customerCoupon);
+
+            if (visitHistories.getVisitCount() == 0) {
+                continue;
+            }
+
             // TODO: CustomerCouponStatistics 없애도 될 것 같다.
             CustomerCouponStatistics customerCouponStatistics = coupons.calculateStatistics();
             cafeCustomerFindResultDtos.add(

--- a/backend/src/main/java/com/stampcrush/backend/application/manager/reward/ManagerRewardFindService.java
+++ b/backend/src/main/java/com/stampcrush/backend/application/manager/reward/ManagerRewardFindService.java
@@ -8,7 +8,7 @@ import com.stampcrush.backend.entity.user.Owner;
 import com.stampcrush.backend.entity.visithistory.VisitHistory;
 import com.stampcrush.backend.exception.CafeNotFoundException;
 import com.stampcrush.backend.exception.OwnerNotFoundException;
-import com.stampcrush.backend.exception.OwnerUnAuthorizationException;
+import com.stampcrush.backend.exception.VisitHistoryNotFoundException;
 import com.stampcrush.backend.repository.cafe.CafeRepository;
 import com.stampcrush.backend.repository.reward.RewardRepository;
 import com.stampcrush.backend.repository.user.OwnerRepository;
@@ -33,7 +33,7 @@ public class ManagerRewardFindService {
         List<VisitHistory> visitHistories = visitHistoryRepository.findByCafeIdAndCustomerId(rewardFindDto.getCafeId(), rewardFindDto.getCustomerId());
 
         if (visitHistories.isEmpty()) {
-            throw new OwnerUnAuthorizationException("카페의 고객이 아닙니다");
+            throw new VisitHistoryNotFoundException("카페의 고객이 아닙니다");
         }
 
         Cafe cafe = cafeRepository.findById(rewardFindDto.getCafeId())

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/ManagerRewardFindAcceptanceTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/ManagerRewardFindAcceptanceTest.java
@@ -12,6 +12,7 @@ import com.stampcrush.backend.repository.user.CustomerRepository;
 import com.stampcrush.backend.repository.user.OwnerRepository;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -72,7 +73,7 @@ public class ManagerRewardFindAcceptanceTest extends AcceptanceTest {
         ExtractableResponse<Response> response = 리워드_목록_조회(notOwner, cafeId, customer.getId());
 
         // then
-        assertThat(response.statusCode()).isEqualTo(401);
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.SC_UNAUTHORIZED);
     }
 
     @Test
@@ -97,7 +98,7 @@ public class ManagerRewardFindAcceptanceTest extends AcceptanceTest {
         ExtractableResponse<Response> response = 리워드_목록_조회(owner, cafeId, notMyCustomer.getId());
 
         // then
-        assertThat(response.statusCode()).isEqualTo(401);
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.SC_NOT_FOUND);
     }
 
     // TODO 회원가입, 로그인 구현 후 API CAll 로 대체


### PR DESCRIPTION
## 주요 변경사항

- 사장님의 고객목록 조회 시 방문횟수 0이면 반환값에서 제외
- 사장님의 리워드 사용 조회 시 전화번호로 조회된 고객이 카페의 고객이 아니면 NotFound 에러로 수정(현재 UnAuthorized 에러 발생 시 로그인 페이지로 리다이렉트 됨)

## 리뷰어에게...

## 관련 이슈

closes

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [x] `milestone` 설정
