### PR TITLE
[BE] feat: 스탬프 적립 시 슬랙으로 알림을 보낸다

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -43,6 +43,9 @@ dependencies {
     implementation 'org.flywaydb:flyway-core'
     implementation 'org.flywaydb:flyway-mysql'
 
+    implementation group: 'com.slack.api', name: 'slack-api-client', version: '1.30.0'
+
+
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/backend/src/main/java/com/stampcrush/backend/application/manager/coupon/ManagerCouponCommandService.java
+++ b/backend/src/main/java/com/stampcrush/backend/application/manager/coupon/ManagerCouponCommandService.java
@@ -1,6 +1,7 @@
 package com.stampcrush.backend.application.manager.coupon;
 
 import com.stampcrush.backend.application.manager.coupon.dto.StampCreateDto;
+import com.stampcrush.backend.application.manager.event.StampCreateEvent;
 import com.stampcrush.backend.entity.cafe.Cafe;
 import com.stampcrush.backend.entity.cafe.CafeCouponDesign;
 import com.stampcrush.backend.entity.cafe.CafePolicy;
@@ -26,6 +27,7 @@ import com.stampcrush.backend.repository.user.CustomerRepository;
 import com.stampcrush.backend.repository.user.OwnerRepository;
 import com.stampcrush.backend.repository.visithistory.VisitHistoryRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -47,6 +49,7 @@ public class ManagerCouponCommandService {
     private final OwnerRepository ownerRepository;
     private final RewardRepository rewardRepository;
     private final VisitHistoryRepository visitHistoryRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     private record CustomerCoupons(Customer customer, List<Coupon> coupons) {
     }
@@ -105,6 +108,7 @@ public class ManagerCouponCommandService {
 
         VisitHistory visitHistory = new VisitHistory(cafe, customer, earningStampCount);
         visitHistoryRepository.save(visitHistory);
+        eventPublisher.publishEvent(new StampCreateEvent(customer.getPhoneNumber(), stampCreateDto.getEarningStampCount()));
         if (coupon.isLessThanMaxStampAfterAccumulateStamp(earningStampCount)) {
             coupon.accumulate(earningStampCount);
             return;

--- a/backend/src/main/java/com/stampcrush/backend/application/manager/event/StampAccumulatingEventHandler.java
+++ b/backend/src/main/java/com/stampcrush/backend/application/manager/event/StampAccumulatingEventHandler.java
@@ -1,0 +1,57 @@
+package com.stampcrush.backend.application.manager.event;
+
+import com.slack.api.Slack;
+import com.slack.api.model.Attachment;
+import com.slack.api.model.Field;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+import static com.slack.api.webhook.WebhookPayloads.payload;
+
+@Component
+//@RequiredArgsConstructor
+public class StampAccumulatingEventHandler {
+
+    @Value("${slack.webhook.url}")
+    private String webHookUrl;
+
+    private final Slack slackClient = Slack.getInstance();
+
+    @TransactionalEventListener
+    public void process(StampCreateEvent stampCreateEvent) {
+        try {
+            slackClient.send(webHookUrl, payload(p -> p
+                    .text("스탬프 적립 발생")
+                    .attachments(List.of(createStampInfo(stampCreateEvent.getUserPhone(), stampCreateEvent.getStampCount())))
+            ));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private Attachment createStampInfo(String phone, int stampCount) {
+        String requestTime = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS").format(LocalDateTime.now());
+        return Attachment.builder()
+                .title("스탬프 적립 시간" + requestTime)
+                .fields(List.of(
+                                generateField("유저 핸드폰", phone),
+                                generateField("적립 스탬프", String.valueOf(stampCount))
+                        )
+                )
+                .build();
+    }
+
+    private Field generateField(String title, String value) {
+        return Field.builder()
+                .title(title)
+                .value(value)
+                .valueShortEnough(true)
+                .build();
+    }
+}

--- a/backend/src/main/java/com/stampcrush/backend/application/manager/event/StampAccumulatingEventHandler.java
+++ b/backend/src/main/java/com/stampcrush/backend/application/manager/event/StampAccumulatingEventHandler.java
@@ -15,7 +15,6 @@ import java.util.List;
 import static com.slack.api.webhook.WebhookPayloads.payload;
 
 @Component
-//@RequiredArgsConstructor
 public class StampAccumulatingEventHandler {
 
     @Value("${slack.webhook.url}")
@@ -25,13 +24,15 @@ public class StampAccumulatingEventHandler {
 
     @TransactionalEventListener
     public void process(StampCreateEvent stampCreateEvent) {
+        String userPhone = stampCreateEvent.getUserPhone();
+        int stampCount = stampCreateEvent.getStampCount();
         try {
             slackClient.send(webHookUrl, payload(p -> p
                     .text("스탬프 적립 발생")
-                    .attachments(List.of(createStampInfo(stampCreateEvent.getUserPhone(), stampCreateEvent.getStampCount())))
+                    .attachments(List.of(createStampInfo(userPhone, stampCount)))
             ));
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            throw new RuntimeException(String.format("%s 번호 스탬프 %d개 적립 알림 전송 실패", userPhone, stampCount), e);
         }
     }
 

--- a/backend/src/main/java/com/stampcrush/backend/application/manager/event/StampCreateEvent.java
+++ b/backend/src/main/java/com/stampcrush/backend/application/manager/event/StampCreateEvent.java
@@ -1,0 +1,20 @@
+package com.stampcrush.backend.application.manager.event;
+
+public class StampCreateEvent {
+
+    private final String userPhone;
+    private final int stampCount;
+
+    public StampCreateEvent(String userPhone, int stampCount) {
+        this.userPhone = userPhone;
+        this.stampCount = stampCount;
+    }
+
+    public String getUserPhone() {
+        return userPhone;
+    }
+
+    public int getStampCount() {
+        return stampCount;
+    }
+}

--- a/backend/src/main/java/com/stampcrush/backend/config/PersistenceConfig.java
+++ b/backend/src/main/java/com/stampcrush/backend/config/PersistenceConfig.java
@@ -2,8 +2,10 @@ package com.stampcrush.backend.config;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableAsync;
 
 @Configuration(proxyBeanMethods = false)
 @EnableJpaAuditing
+@EnableAsync
 public class PersistenceConfig {
 }

--- a/backend/src/main/java/com/stampcrush/backend/config/RequestLoggingFilter.java
+++ b/backend/src/main/java/com/stampcrush/backend/config/RequestLoggingFilter.java
@@ -23,7 +23,6 @@ public class RequestLoggingFilter extends OncePerRequestFilter {
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
-        System.out.println("????");
         log.info("thread-id : {}, thread-name: {}, pool-size: {}", Thread.currentThread().getId(), Thread.currentThread().getName(), executor.getPoolSize());
         MDC.put("requestId", UUID.randomUUID().toString());
         MDC.put("requestMethod", request.getMethod());

--- a/backend/src/main/resources/application-test.yml
+++ b/backend/src/main/resources/application-test.yml
@@ -26,3 +26,7 @@ s3:
   bucket: test
   base-url: test
   dir: test
+
+slack:
+  webhook:
+    url: test


### PR DESCRIPTION
## 주요 변경사항

- stamp 적립 service 로직에서 stamp적립 이벤트를 발생시켰습니다.
    - 로직 초반부에 위치 시켰는데 모든 로직이 끝나고 발생시키기 어려웠던 이유가 분기문 때문인데요 112, 116 로직에서 바로 return 을 하고 있습니다. (코드에 코멘트 달아놨습니다)
    - 그래서 TransactionalEvenentListner를 활용해 스탬프 적립 트랜잭션이 commit 된 시점에 슬랙으로 메시지를 보내도록 했습니다.
        - 해당 어노테이션의 기본 옵션이 기존 트랜잭션이 커밋되는 시점에 메서드 로직을 수행하는 옵션입니다 

## 리뷰어에게...

- 시간이 부족해서 슬랙으로 메시지 보내는 기능만 구현했습니다. 메시지 보내는 부분 추상화, 이벤트 유실 까진 아직 구현을 못했네요..

## 관련 이슈

closes #751 

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [x] `milestone` 설정
