### PR TITLE
[FE] refactor: 핫픽스한 `Input`의 싱크를 맞춘다

### DIFF
--- a/frontend/src/components/Input/index.tsx
+++ b/frontend/src/components/Input/index.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, HTMLInputTypeAttribute, InputHTMLAttributes } from 'react';
+import { forwardRef, InputHTMLAttributes } from 'react';
 import { BaseInput, InputContainer, InputWidth, Label, LabelWrapper, Required } from './style';
 
 const REQUIRED = '*' as const;
@@ -6,23 +6,43 @@ const REQUIRED = '*' as const;
 interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
   id: string;
   label?: string;
-  type?: HTMLInputTypeAttribute;
   width?: InputWidth;
-  placeholder?: string;
-  maxLength?: number;
-  required?: boolean;
 }
 
-export const Input = forwardRef<HTMLInputElement, InputProps>((props, ref) => {
-  return (
-    <InputContainer>
-      <LabelWrapper>
-        <Label htmlFor={props.id}>{props.label}</Label>
-        {props.required && <Required>{REQUIRED}</Required>}
-      </LabelWrapper>
-      <BaseInput ref={ref} $width={props.width} {...props} />
-    </InputContainer>
-  );
-});
+export const Input = forwardRef<HTMLInputElement, InputProps>(
+  (
+    {
+      id,
+      label,
+      type,
+      width = 'fill',
+      placeholder,
+      maxLength,
+      required = false,
+      ...props
+    }: InputProps,
+    ref,
+  ) => {
+    return (
+      <InputContainer>
+        <LabelWrapper>
+          <Label htmlFor={id}>{label}</Label>
+          {required && <Required>{REQUIRED}</Required>}
+        </LabelWrapper>
+        <BaseInput
+          ref={ref}
+          id={id}
+          $width={width}
+          type={type}
+          placeholder={placeholder}
+          maxLength={maxLength}
+          required={required}
+          autoComplete="off"
+          {...props}
+        />
+      </InputContainer>
+    );
+  },
+);
 
 Input.displayName = 'Input';


### PR DESCRIPTION
## 주요 변경사항

- 지난 금요일 발견한 오류에 대해 `main` 브랜치에 핫픽스했던 부분이 `develop` 브랜치와 달라 이후 충돌이 있을 것으로 예상됩니다. 따라서 두 브랜치 간 싱크를 맞추기 위해 해당 커밋을 `develop`에 머지 요청합니다.

## 리뷰어에게...

## 관련 이슈

closes #759 

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [x] `milestone` 설정
