### PR TITLE
[BE] feat: 임시회원, 가입회원 조회 api 구현 + 고객 목록 조회 시 최근 방문 일자 데이터 추가

### DIFF
--- a/backend/src/main/java/com/stampcrush/backend/api/manager/coupon/ManagerCouponFindApiController.java
+++ b/backend/src/main/java/com/stampcrush/backend/api/manager/coupon/ManagerCouponFindApiController.java
@@ -38,13 +38,13 @@ public class ManagerCouponFindApiController {
         return ResponseEntity.ok(new CafeCustomersFindResponse(cafeCustomerFindResponses));
     }
 
-    @GetMapping(value = "/cafes/{cafeId}/customers", params = "status")
+    @GetMapping(value = "/cafes/{cafeId}/customers", params = "customer-type")
     public ResponseEntity<CafeCustomersFindResponse> findCustomersByCafeAndStatus(
             OwnerAuth owner,
             @PathVariable("cafeId") Long cafeId,
-            @RequestParam("status") String status
+            @RequestParam("customer-type") String customerType
     ) {
-        List<CafeCustomerFindResultDto> coupons = managerCouponFindService.findCouponsByCafeAndCustomerType(owner.getId(), cafeId, status);
+        List<CafeCustomerFindResultDto> coupons = managerCouponFindService.findCouponsByCafeAndCustomerType(owner.getId(), cafeId, customerType);
         List<CafeCustomerFindResponse> cafeCustomerFindResponses = coupons.stream()
                 .map(CafeCustomerFindResponse::from)
                 .toList();

--- a/backend/src/main/java/com/stampcrush/backend/api/manager/coupon/ManagerCouponFindApiController.java
+++ b/backend/src/main/java/com/stampcrush/backend/api/manager/coupon/ManagerCouponFindApiController.java
@@ -10,7 +10,11 @@ import com.stampcrush.backend.application.manager.coupon.dto.CustomerAccumulatin
 import com.stampcrush.backend.config.resolver.OwnerAuth;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
@@ -27,6 +31,20 @@ public class ManagerCouponFindApiController {
             @PathVariable("cafeId") Long cafeId
     ) {
         List<CafeCustomerFindResultDto> coupons = managerCouponFindService.findCouponsByCafe(owner.getId(), cafeId);
+        List<CafeCustomerFindResponse> cafeCustomerFindResponses = coupons.stream()
+                .map(CafeCustomerFindResponse::from)
+                .toList();
+
+        return ResponseEntity.ok(new CafeCustomersFindResponse(cafeCustomerFindResponses));
+    }
+
+    @GetMapping(value = "/cafes/{cafeId}/customers", params = "status")
+    public ResponseEntity<CafeCustomersFindResponse> findCustomersByCafeAndStatus(
+            OwnerAuth owner,
+            @PathVariable("cafeId") Long cafeId,
+            @RequestParam("status") String status
+    ) {
+        List<CafeCustomerFindResultDto> coupons = managerCouponFindService.findCouponsByCafeAndCustomerType(owner.getId(), cafeId, status);
         List<CafeCustomerFindResponse> cafeCustomerFindResponses = coupons.stream()
                 .map(CafeCustomerFindResponse::from)
                 .toList();

--- a/backend/src/main/java/com/stampcrush/backend/api/manager/coupon/response/CafeCustomerFindResponse.java
+++ b/backend/src/main/java/com/stampcrush/backend/api/manager/coupon/response/CafeCustomerFindResponse.java
@@ -20,6 +20,7 @@ public class CafeCustomerFindResponse {
     private final int maxStampCount;
     private final String firstVisitDate;
     private final Boolean isRegistered;
+    private final String recentVisitDate;
 
     public static CafeCustomerFindResponse from(CafeCustomerFindResultDto serviceDto) {
         return new CafeCustomerFindResponse(
@@ -30,7 +31,8 @@ public class CafeCustomerFindResponse {
                 serviceDto.getVisitCount(),
                 serviceDto.getMaxStampCount(),
                 serviceDto.getFirstVisitDate().format(DateTimeFormatter.ofPattern("yyyy:MM:dd")),
-                serviceDto.isRegistered()
+                serviceDto.isRegistered(),
+                serviceDto.getRecentVisitDate().format(DateTimeFormatter.ofPattern("yyyy:MM:dd"))
         );
     }
 }

--- a/backend/src/main/java/com/stampcrush/backend/application/manager/coupon/CustomerCouponStatistics.java
+++ b/backend/src/main/java/com/stampcrush/backend/application/manager/coupon/CustomerCouponStatistics.java
@@ -8,6 +8,5 @@ import lombok.RequiredArgsConstructor;
 public class CustomerCouponStatistics {
 
     private final int stampCount;
-    private final int rewardCount;
     private final int maxStampCount;
 }

--- a/backend/src/main/java/com/stampcrush/backend/application/manager/coupon/ManagerCouponFindService.java
+++ b/backend/src/main/java/com/stampcrush/backend/application/manager/coupon/ManagerCouponFindService.java
@@ -13,7 +13,6 @@ import com.stampcrush.backend.entity.visithistory.VisitHistory;
 import com.stampcrush.backend.exception.CafeNotFoundException;
 import com.stampcrush.backend.exception.CustomerNotFoundException;
 import com.stampcrush.backend.exception.OwnerNotFoundException;
-import com.stampcrush.backend.repository.cafe.CafePolicyRepository;
 import com.stampcrush.backend.repository.cafe.CafeRepository;
 import com.stampcrush.backend.repository.coupon.CouponRepository;
 import com.stampcrush.backend.repository.reward.RewardRepository;
@@ -38,7 +37,6 @@ public class ManagerCouponFindService {
     private final CouponRepository couponRepository;
     private final CafeRepository cafeRepository;
     private final CustomerRepository customerRepository;
-    private final CafePolicyRepository cafePolicyRepository;
     private final VisitHistoryRepository visitHistoryRepository;
     private final RewardRepository rewardRepository;
     private final OwnerRepository ownerRepository;

--- a/backend/src/main/java/com/stampcrush/backend/application/manager/coupon/ManagerCouponFindService.java
+++ b/backend/src/main/java/com/stampcrush/backend/application/manager/coupon/ManagerCouponFindService.java
@@ -44,13 +44,17 @@ public class ManagerCouponFindService {
 
     public List<CafeCustomerFindResultDto> findCouponsByCafe(Long ownerId, Long cafeId) {
         Cafe cafe = findExistingCafe(cafeId);
-        Owner owner = ownerRepository.findById(ownerId)
-                .orElseThrow(() -> new OwnerNotFoundException("사장을 찾지 못했습니다."));
+        Owner owner = findOwner(ownerId);
         cafe.validateOwnership(owner);
 
         List<Coupon> allCustomerCoupons = couponRepository.findByCafe(cafe);
         Map<Customer, List<Coupon>> customerCoupons = mapCouponsByCustomer(allCustomerCoupons);
         return produceCouponStatistics(cafe, customerCoupons);
+    }
+
+    private Owner findOwner(Long ownerId) {
+        return ownerRepository.findById(ownerId)
+                .orElseThrow(() -> new OwnerNotFoundException(String.format("%d id 사장을 찾지 못했습니다.", ownerId)));
     }
 
     private Map<Customer, List<Coupon>> mapCouponsByCustomer(List<Coupon> coupons) {
@@ -60,7 +64,7 @@ public class ManagerCouponFindService {
 
     private Cafe findExistingCafe(Long cafeId) {
         return cafeRepository.findById(cafeId)
-                .orElseThrow(() -> new CafeNotFoundException("존재하지 않는 카페 입니다."));
+                .orElseThrow(() -> new CafeNotFoundException(String.format("%d id는 존재하지 않는 카페 입니다.", cafeId)));
     }
 
     private VisitHistories findVisitHistories(Cafe cafe, Customer customer) {
@@ -88,8 +92,7 @@ public class ManagerCouponFindService {
 
     public List<CafeCustomerFindResultDto> findCouponsByCafeAndCustomerType(Long ownerId, Long cafeId, String customerType) {
         Cafe cafe = findExistingCafe(cafeId);
-        Owner owner = ownerRepository.findById(ownerId)
-                .orElseThrow(() -> new OwnerNotFoundException("사장을 찾지 못했습니다."));
+        Owner owner = findOwner(ownerId);
         cafe.validateOwnership(owner);
 
         List<Coupon> allCustomerCoupons = couponRepository.findByCafeAndCustomerType(cafe, CustomerType.from(customerType));
@@ -98,9 +101,8 @@ public class ManagerCouponFindService {
     }
 
     public List<CustomerAccumulatingCouponFindResultDto> findAccumulatingCoupon(Long ownerId, Long cafeId, Long customerId) {
-        Cafe cafe = cafeRepository.findById(cafeId).orElseThrow(() -> new CustomerNotFoundException("존재하지 않는 카페 입니다."));
-        Owner owner = ownerRepository.findById(ownerId)
-                .orElseThrow(() -> new OwnerNotFoundException("사장을 찾지 못했습니다."));
+        Cafe cafe = findExistingCafe(cafeId);
+        Owner owner = findOwner(ownerId);
         cafe.validateOwnership(owner);
 
         Customer customer = customerRepository.findById(customerId).orElseThrow(() -> new CustomerNotFoundException("존재하지 않는 고객 입니다."));

--- a/backend/src/main/java/com/stampcrush/backend/application/manager/coupon/ManagerCouponFindService.java
+++ b/backend/src/main/java/com/stampcrush/backend/application/manager/coupon/ManagerCouponFindService.java
@@ -72,7 +72,8 @@ public class ManagerCouponFindService {
                             visitHistories.getVisitCount(),
                             visitHistories.getFirstVisitDate(),
                             customerCoupon.customer.isRegistered(),
-                            customerCouponStatistics.getMaxStampCount()
+                            customerCouponStatistics.getMaxStampCount(),
+                            visitHistories.getRecentVisitDate()
                     )
             );
         }

--- a/backend/src/main/java/com/stampcrush/backend/application/manager/coupon/dto/CafeCustomerFindResultDto.java
+++ b/backend/src/main/java/com/stampcrush/backend/application/manager/coupon/dto/CafeCustomerFindResultDto.java
@@ -2,6 +2,7 @@ package com.stampcrush.backend.application.manager.coupon.dto;
 
 import com.stampcrush.backend.application.manager.coupon.CustomerCouponStatistics;
 import com.stampcrush.backend.entity.user.Customer;
+import com.stampcrush.backend.entity.visithistory.VisitHistories;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
@@ -29,17 +30,17 @@ public class CafeCustomerFindResultDto {
     private LocalDateTime recentVisitDate;
 
     public static CafeCustomerFindResultDto of(Customer customer, CustomerCouponStatistics customerCouponStatistics,
-                                               int visitCount, LocalDateTime firstVisitDate, LocalDateTime recentVisitDate) {
+                                               VisitHistories visitHistories, int unusedRewards) {
         return new CafeCustomerFindResultDto(
                 customer.getId(),
                 customer.getNickname(),
                 customerCouponStatistics.getStampCount(),
-                customerCouponStatistics.getRewardCount(),
-                visitCount,
-                firstVisitDate,
+                unusedRewards,
+                visitHistories.getVisitCount(),
+                visitHistories.getFirstVisitDate(),
                 customer.isRegistered(),
                 customerCouponStatistics.getMaxStampCount(),
-                recentVisitDate
+                visitHistories.getRecentVisitDate()
         );
     }
 }

--- a/backend/src/main/java/com/stampcrush/backend/application/manager/coupon/dto/CafeCustomerFindResultDto.java
+++ b/backend/src/main/java/com/stampcrush/backend/application/manager/coupon/dto/CafeCustomerFindResultDto.java
@@ -2,7 +2,12 @@ package com.stampcrush.backend.application.manager.coupon.dto;
 
 import com.stampcrush.backend.application.manager.coupon.CustomerCouponStatistics;
 import com.stampcrush.backend.entity.user.Customer;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 import java.time.LocalDateTime;
 

--- a/backend/src/main/java/com/stampcrush/backend/application/manager/coupon/dto/CafeCustomerFindResultDto.java
+++ b/backend/src/main/java/com/stampcrush/backend/application/manager/coupon/dto/CafeCustomerFindResultDto.java
@@ -26,9 +26,10 @@ public class CafeCustomerFindResultDto {
     private LocalDateTime firstVisitDate;
     private boolean isRegistered;
     private int maxStampCount;
+    private LocalDateTime recentVisitDate;
 
     public static CafeCustomerFindResultDto of(Customer customer, CustomerCouponStatistics customerCouponStatistics,
-                                               int visitCount, LocalDateTime firstVisitDate) {
+                                               int visitCount, LocalDateTime firstVisitDate, LocalDateTime recentVisitDate) {
         return new CafeCustomerFindResultDto(
                 customer.getId(),
                 customer.getNickname(),
@@ -37,7 +38,8 @@ public class CafeCustomerFindResultDto {
                 visitCount,
                 firstVisitDate,
                 customer.isRegistered(),
-                customerCouponStatistics.getMaxStampCount()
+                customerCouponStatistics.getMaxStampCount(),
+                recentVisitDate
         );
     }
 }

--- a/backend/src/main/java/com/stampcrush/backend/entity/coupon/Coupon.java
+++ b/backend/src/main/java/com/stampcrush/backend/entity/coupon/Coupon.java
@@ -5,7 +5,16 @@ import com.stampcrush.backend.entity.cafe.Cafe;
 import com.stampcrush.backend.entity.cafe.CafePolicy;
 import com.stampcrush.backend.entity.user.Customer;
 import com.stampcrush.backend.exception.CafePolicyNotFoundException;
-import jakarta.persistence.*;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLDelete;
@@ -99,13 +108,6 @@ public class Coupon extends BaseDate {
                 .map(date -> LocalDateTime.of(date.getYear(), date.getMonth(), date.getDayOfMonth(), date.getHour(), date.getMinute()))
                 .collect(Collectors.toSet())
                 .size();
-    }
-
-    public LocalDateTime compareCreatedAtAndReturnEarlier(LocalDateTime visitTime) {
-        if (this.getCreatedAt().isBefore(visitTime)) {
-            return this.getCreatedAt();
-        }
-        return visitTime;
     }
 
     public LocalDateTime calculateExpireDate() {

--- a/backend/src/main/java/com/stampcrush/backend/entity/coupon/Coupons.java
+++ b/backend/src/main/java/com/stampcrush/backend/entity/coupon/Coupons.java
@@ -12,15 +12,13 @@ public class Coupons {
 
     public CustomerCouponStatistics calculateStatistics() {
         int stampCount = 0;
-        int rewardCount = 0;
         int maxStampCount = 0;
 
         for (Coupon coupon : coupons) {
             stampCount = calculateCurrentStampWhenUsingCoupon(stampCount, coupon);
-            rewardCount += addRewardCouponCount(coupon);
             maxStampCount = coupon.calculateMaxStampCountWhenAccumulating();
         }
-        return new CustomerCouponStatistics(stampCount, rewardCount, maxStampCount);
+        return new CustomerCouponStatistics(stampCount, maxStampCount);
     }
 
     private int calculateCurrentStampWhenUsingCoupon(int stampCount, Coupon coupon) {
@@ -28,12 +26,5 @@ public class Coupons {
             return coupon.getStampCount();
         }
         return stampCount;
-    }
-
-    private int addRewardCouponCount(Coupon coupon) {
-        if (coupon.isRewarded()) {
-            return 1;
-        }
-        return 0;
     }
 }

--- a/backend/src/main/java/com/stampcrush/backend/entity/user/CustomerType.java
+++ b/backend/src/main/java/com/stampcrush/backend/entity/user/CustomerType.java
@@ -19,6 +19,6 @@ public enum CustomerType {
         return Arrays.stream(CustomerType.values())
                 .filter(value -> value.type.equals(input))
                 .findAny()
-                .orElseThrow(() -> new NotFoundException(String.format("%s 와 일치하는 CustomerType이 없습니다")));
+                .orElseThrow(() -> new NotFoundException(String.format("%s 와 일치하는 CustomerType이 없습니다", input)));
     }
 }

--- a/backend/src/main/java/com/stampcrush/backend/entity/user/CustomerType.java
+++ b/backend/src/main/java/com/stampcrush/backend/entity/user/CustomerType.java
@@ -1,7 +1,24 @@
 package com.stampcrush.backend.entity.user;
 
+import com.stampcrush.backend.exception.NotFoundException;
+
+import java.util.Arrays;
+
 public enum CustomerType {
 
-    TEMPORARY,
-    REGISTER;
+    TEMPORARY("temporary"),
+    REGISTER("register");
+
+    private final String type;
+
+    CustomerType(String type) {
+        this.type = type;
+    }
+
+    public static CustomerType from(String input) {
+        return Arrays.stream(CustomerType.values())
+                .filter(value -> value.type.equals(input))
+                .findAny()
+                .orElseThrow(() -> new NotFoundException(String.format("%s 와 일치하는 CustomerType이 없습니다")));
+    }
 }

--- a/backend/src/main/java/com/stampcrush/backend/entity/visithistory/VisitHistories.java
+++ b/backend/src/main/java/com/stampcrush/backend/entity/visithistory/VisitHistories.java
@@ -26,4 +26,15 @@ public class VisitHistories {
 
         return firstVisit.getCreatedAt();
     }
+
+    public LocalDateTime getRecentVisitDate() {
+        if (visitHistories.isEmpty()) {
+            return LocalDateTime.now();
+        }
+        VisitHistory recentVisit = visitHistories.stream()
+                .max(Comparator.comparing(BaseDate::getCreatedAt))
+                .get();
+
+        return recentVisit.getCreatedAt();
+    }
 }

--- a/backend/src/main/java/com/stampcrush/backend/repository/coupon/CouponRepository.java
+++ b/backend/src/main/java/com/stampcrush/backend/repository/coupon/CouponRepository.java
@@ -4,6 +4,7 @@ import com.stampcrush.backend.entity.cafe.Cafe;
 import com.stampcrush.backend.entity.coupon.Coupon;
 import com.stampcrush.backend.entity.coupon.CouponStatus;
 import com.stampcrush.backend.entity.user.Customer;
+import com.stampcrush.backend.entity.user.CustomerType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -16,6 +17,9 @@ public interface CouponRepository extends JpaRepository<Coupon, Long> {
     // TODO: coupon_policy, coupon_design을 같이 가져오자
     @Query("select distinct cp from Coupon cp left join fetch cp.stamps join fetch cp.cafe join fetch cp.customer where cp.cafe = :cafe")
     List<Coupon> findByCafe(@Param("cafe") Cafe cafe);
+
+    @Query("select distinct cp from Coupon cp left join fetch cp.stamps join fetch cp.cafe join fetch cp.customer c where cp.cafe = :cafe and c.customerType = :customerType")
+    List<Coupon> findByCafeAndCustomerType(@Param("cafe") Cafe cafe, @Param("customerType") CustomerType customerType);
 
     List<Coupon> findByCafeAndCustomerAndStatus(@Param("cafe") Cafe cafe, @Param("customer") Customer customer, @Param("status") CouponStatus status);
 

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/ManagerCouponCommandAcceptanceTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/ManagerCouponCommandAcceptanceTest.java
@@ -25,7 +25,9 @@ import static com.stampcrush.backend.acceptance.step.ManagerCouponCreateStep.쿠
 import static com.stampcrush.backend.acceptance.step.ManagerCouponFindStep.고객의_쿠폰_조회_요청;
 import static com.stampcrush.backend.acceptance.step.ManagerCouponFindStep.고객의_쿠폰_조회하고_결과_반환;
 import static com.stampcrush.backend.acceptance.step.ManagerCustomerFindStep.고객_목록_조회_요청;
-import static com.stampcrush.backend.acceptance.step.ManagerJoinStep.*;
+import static com.stampcrush.backend.acceptance.step.ManagerJoinStep.OWNER_CREATE_REQUEST;
+import static com.stampcrush.backend.acceptance.step.ManagerJoinStep.OWNER_CREATE_REQUEST_2;
+import static com.stampcrush.backend.acceptance.step.ManagerJoinStep.카페_사장_회원_가입_요청하고_액세스_토큰_반환;
 import static com.stampcrush.backend.acceptance.step.ManagerStampCreateStep.쿠폰에_스탬프를_적립_요청;
 import static com.stampcrush.backend.acceptance.step.VisitorJoinStep.가입_고객_회원_가입_요청하고_액세스_토큰_반환;
 import static io.restassured.RestAssured.given;
@@ -218,7 +220,8 @@ class ManagerCouponCommandAcceptanceTest extends AcceptanceTest {
                 1,
                 10,
                 null,
-                true);
+                true,
+                null);
 
         CafeCustomerFindResponse customer2Expected = new CafeCustomerFindResponse(
                 coupon2Id,
@@ -228,9 +231,10 @@ class ManagerCouponCommandAcceptanceTest extends AcceptanceTest {
                 1,
                 10,
                 null,
-                true);
+                true,
+                null);
 
-        assertThat(customers).usingRecursiveFieldByFieldElementComparatorIgnoringFields("visitCount", "firstVisitDate")
+        assertThat(customers).usingRecursiveFieldByFieldElementComparatorIgnoringFields("visitCount", "firstVisitDate", "recentVisitDate")
                 .containsExactlyInAnyOrder(customer1Expected, customer2Expected);
     }
 

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/ManagerCouponFindAcceptanceTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/ManagerCouponFindAcceptanceTest.java
@@ -1,10 +1,12 @@
 package com.stampcrush.backend.acceptance;
 
+import com.stampcrush.backend.acceptance.step.VisitorJoinStep;
 import com.stampcrush.backend.api.manager.coupon.request.CouponCreateRequest;
 import com.stampcrush.backend.api.manager.coupon.request.StampCreateRequest;
 import com.stampcrush.backend.api.manager.coupon.response.CafeCustomerFindResponse;
 import com.stampcrush.backend.api.manager.coupon.response.CafeCustomersFindResponse;
 import com.stampcrush.backend.api.manager.coupon.response.CustomerAccumulatingCouponFindResponse;
+import com.stampcrush.backend.api.manager.customer.request.TemporaryCustomerCreateRequest;
 import com.stampcrush.backend.auth.OAuthProvider;
 import com.stampcrush.backend.auth.api.request.OAuthRegisterCustomerCreateRequest;
 import com.stampcrush.backend.auth.api.request.OAuthRegisterOwnerCreateRequest;
@@ -12,6 +14,7 @@ import com.stampcrush.backend.entity.user.Customer;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
@@ -23,12 +26,12 @@ import static com.stampcrush.backend.acceptance.step.ManagerCouponCreateStep.쿠
 import static com.stampcrush.backend.acceptance.step.ManagerCouponFindStep.고객의_쿠폰_조회_요청;
 import static com.stampcrush.backend.acceptance.step.ManagerCouponFindStep.고객의_쿠폰_조회하고_결과_반환;
 import static com.stampcrush.backend.acceptance.step.ManagerCustomerFindStep.고객_목록_조회_요청;
+import static com.stampcrush.backend.acceptance.step.ManagerCustomerFindStep.고객_타입_별_목록_조회_요청;
 import static com.stampcrush.backend.acceptance.step.ManagerJoinStep.OWNER_CREATE_REQUEST;
 import static com.stampcrush.backend.acceptance.step.ManagerJoinStep.OWNER_CREATE_REQUEST_2;
 import static com.stampcrush.backend.acceptance.step.ManagerJoinStep.카페_사장_회원_가입_요청하고_액세스_토큰_반환;
 import static com.stampcrush.backend.acceptance.step.ManagerStampCreateStep.쿠폰에_스탬프를_적립_요청;
 import static com.stampcrush.backend.acceptance.step.VisitorJoinStep.가입_고객_회원_가입_요청하고_액세스_토큰_반환;
-import static com.stampcrush.backend.fixture.CustomerFixture.REGISTER_CUSTOMER_GITCHAN;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.http.HttpStatus.UNAUTHORIZED;
 
@@ -81,13 +84,133 @@ class ManagerCouponFindAcceptanceTest extends AcceptanceTest {
     }
 
     @Test
+    void 가입고객_목록을_조회한다() {
+        // given
+        String ownerAccessToken = 카페_사장_회원_가입_요청하고_액세스_토큰_반환(OWNER_CREATE_REQUEST);
+
+        Long savedCafeId = 카페_생성_요청하고_아이디_반환(ownerAccessToken, CAFE_CREATE_REQUEST);
+
+        OAuthRegisterCustomerCreateRequest regCustomerRequest1 =
+                new OAuthRegisterCustomerCreateRequest("youngho", "e", OAuthProvider.KAKAO, 293827L);
+        OAuthRegisterCustomerCreateRequest regCustomerRequest2 =
+                new OAuthRegisterCustomerCreateRequest("gitchan", "m", OAuthProvider.KAKAO, 483726L);
+        TemporaryCustomerCreateRequest temporaryCustomerCreateRequest = new TemporaryCustomerCreateRequest("01012345678");
+
+        Long tempCustomerId = VisitorJoinStep.임시_고객_회원_가입_요청하고_아이디_반환(ownerAccessToken, temporaryCustomerCreateRequest);
+        Customer tempCustomer = customerRepository.findById(tempCustomerId).get();
+
+        String younghoToken = 가입_고객_회원_가입_요청하고_액세스_토큰_반환(regCustomerRequest1);
+        Long younghoId = authTokensGenerator.extractMemberId(younghoToken);
+        Customer youngho = customerRepository.findById(younghoId).get();
+
+        String gitchanToken = 가입_고객_회원_가입_요청하고_액세스_토큰_반환(regCustomerRequest2);
+        Long gitchanId = authTokensGenerator.extractMemberId(gitchanToken);
+        Customer gitchan = customerRepository.findById(gitchanId).get();
+
+        CouponCreateRequest request = new CouponCreateRequest(savedCafeId);
+
+        Long couponId1 = 쿠폰_생성_요청하고_아이디_반환(ownerAccessToken, request, younghoId);
+        Long couponId2 = 쿠폰_생성_요청하고_아이디_반환(ownerAccessToken, request, gitchanId);
+        Long couponId3 = 쿠폰_생성_요청하고_아이디_반환(ownerAccessToken, request, tempCustomerId);
+
+        StampCreateRequest stampCreateRequest1 = new StampCreateRequest(7);
+        StampCreateRequest stampCreateRequest2 = new StampCreateRequest(5);
+        StampCreateRequest stampCreateRequest3 = new StampCreateRequest(2);
+
+        쿠폰에_스탬프를_적립_요청(ownerAccessToken, younghoId, couponId1, stampCreateRequest1);
+        쿠폰에_스탬프를_적립_요청(ownerAccessToken, younghoId, couponId1, stampCreateRequest2);
+        쿠폰에_스탬프를_적립_요청(ownerAccessToken, gitchanId, couponId2, stampCreateRequest1);
+        쿠폰에_스탬프를_적립_요청(ownerAccessToken, tempCustomerId, couponId3, stampCreateRequest3);
+
+        String firstVisitDate = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy:MM:dd"));
+
+        // when
+        CafeCustomerFindResponse expected1 = new CafeCustomerFindResponse(1L, youngho.getNickname(), 2, 1, 2, 10, firstVisitDate, true, null);
+        CafeCustomerFindResponse expected2 = new CafeCustomerFindResponse(2L, gitchan.getNickname(), 7, 0, 1, 10, firstVisitDate, true, null);
+
+        ExtractableResponse<Response> response = 고객_타입_별_목록_조회_요청(ownerAccessToken, savedCafeId, "register");
+
+        CafeCustomersFindResponse actual = response.body().as(CafeCustomersFindResponse.class);
+        // then
+        assertThat(actual.getCustomers()).usingRecursiveFieldByFieldElementComparatorIgnoringFields("recentVisitDate", "firstVisitDate", "id").containsExactlyInAnyOrder(expected1, expected2);
+    }
+
+    @Test
+    void 임시고객_목록을_조회한다() {
+        // given
+        String ownerAccessToken = 카페_사장_회원_가입_요청하고_액세스_토큰_반환(OWNER_CREATE_REQUEST);
+
+        Long savedCafeId = 카페_생성_요청하고_아이디_반환(ownerAccessToken, CAFE_CREATE_REQUEST);
+
+        OAuthRegisterCustomerCreateRequest regCustomerRequest1 =
+                new OAuthRegisterCustomerCreateRequest("youngho", "e", OAuthProvider.KAKAO, 293827L);
+        OAuthRegisterCustomerCreateRequest regCustomerRequest2 =
+                new OAuthRegisterCustomerCreateRequest("gitchan", "m", OAuthProvider.KAKAO, 483726L);
+        TemporaryCustomerCreateRequest temporaryCustomerCreateRequest = new TemporaryCustomerCreateRequest("01012345678");
+
+        Long tempCustomerId = VisitorJoinStep.임시_고객_회원_가입_요청하고_아이디_반환(ownerAccessToken, temporaryCustomerCreateRequest);
+        Customer tempCustomer = customerRepository.findById(tempCustomerId).get();
+
+        String younghoToken = 가입_고객_회원_가입_요청하고_액세스_토큰_반환(regCustomerRequest1);
+        Long younghoId = authTokensGenerator.extractMemberId(younghoToken);
+        Customer youngho = customerRepository.findById(younghoId).get();
+
+        String gitchanToken = 가입_고객_회원_가입_요청하고_액세스_토큰_반환(regCustomerRequest2);
+        Long gitchanId = authTokensGenerator.extractMemberId(gitchanToken);
+        Customer gitchan = customerRepository.findById(gitchanId).get();
+
+        CouponCreateRequest request = new CouponCreateRequest(savedCafeId);
+
+        Long couponId1 = 쿠폰_생성_요청하고_아이디_반환(ownerAccessToken, request, younghoId);
+        Long couponId2 = 쿠폰_생성_요청하고_아이디_반환(ownerAccessToken, request, gitchanId);
+        Long couponId3 = 쿠폰_생성_요청하고_아이디_반환(ownerAccessToken, request, tempCustomerId);
+
+        StampCreateRequest stampCreateRequest1 = new StampCreateRequest(7);
+        StampCreateRequest stampCreateRequest2 = new StampCreateRequest(5);
+        StampCreateRequest stampCreateRequest3 = new StampCreateRequest(2);
+
+        쿠폰에_스탬프를_적립_요청(ownerAccessToken, younghoId, couponId1, stampCreateRequest1);
+        쿠폰에_스탬프를_적립_요청(ownerAccessToken, younghoId, couponId1, stampCreateRequest2);
+        쿠폰에_스탬프를_적립_요청(ownerAccessToken, gitchanId, couponId2, stampCreateRequest1);
+        쿠폰에_스탬프를_적립_요청(ownerAccessToken, tempCustomerId, couponId3, stampCreateRequest3);
+
+        String firstVisitDate = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy:MM:dd"));
+
+        // when
+        CafeCustomerFindResponse expected = new CafeCustomerFindResponse(1L, tempCustomer.getNickname(), 2, 0, 1, 10, firstVisitDate, false, null);
+
+        ExtractableResponse<Response> response = 고객_타입_별_목록_조회_요청(ownerAccessToken, savedCafeId, "temporary");
+
+        CafeCustomersFindResponse actual = response.body().as(CafeCustomersFindResponse.class);
+        // then
+        assertThat(actual.getCustomers()).usingRecursiveFieldByFieldElementComparatorIgnoringFields("recentVisitDate", "firstVisitDate", "id").containsExactlyInAnyOrder(expected);
+    }
+
+    @Test
+    void 고객_타입_별_조회_시_존재하지_않는_타입으로_조회_시_예외발생() {
+        // given
+        String ownerAccessToken = 카페_사장_회원_가입_요청하고_액세스_토큰_반환(OWNER_CREATE_REQUEST);
+        Long savedCafeId = 카페_생성_요청하고_아이디_반환(ownerAccessToken, CAFE_CREATE_REQUEST);
+
+        // when
+        ExtractableResponse<Response> response = 고객_타입_별_목록_조회_요청(ownerAccessToken, savedCafeId, "invalid");
+        System.out.println(response.body().toString());
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.NOT_FOUND.value());
+    }
+
+    @Test
     void 내_카페가_아닌_고객의_고객목록_조회_불가능() {
         // given
         String ownerAccessToken = 카페_사장_회원_가입_요청하고_액세스_토큰_반환(OWNER_CREATE_REQUEST);
         String notOwnerAccessToken = 카페_사장_회원_가입_요청하고_액세스_토큰_반환(OWNER_CREATE_REQUEST_2);
 
         Long savedCafeId = 카페_생성_요청하고_아이디_반환(ownerAccessToken, CAFE_CREATE_REQUEST);
-        Customer gitchan = customerRepository.save(REGISTER_CUSTOMER_GITCHAN);
+        OAuthRegisterCustomerCreateRequest regCustomerRequest =
+                new OAuthRegisterCustomerCreateRequest("gitchan", "m", OAuthProvider.KAKAO, 483726L);
+        String regCustomerAccessToken = 가입_고객_회원_가입_요청하고_액세스_토큰_반환(regCustomerRequest);
+        Long regCustomerId = authTokensGenerator.extractMemberId(regCustomerAccessToken);
+        Customer gitchan = customerRepository.findById(regCustomerId).get();
 
         CouponCreateRequest request = new CouponCreateRequest(savedCafeId);
 
@@ -95,7 +218,6 @@ class ManagerCouponFindAcceptanceTest extends AcceptanceTest {
 
         // when
         ExtractableResponse<Response> response = 고객_목록_조회_요청(notOwnerAccessToken, savedCafeId);
-
         // then
         assertThat(response.statusCode()).isEqualTo(UNAUTHORIZED.value());
     }

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/ManagerCouponFindAcceptanceTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/ManagerCouponFindAcceptanceTest.java
@@ -260,7 +260,10 @@ class ManagerCouponFindAcceptanceTest extends AcceptanceTest {
         String notOwnerAccessToken = 카페_사장_회원_가입_요청하고_액세스_토큰_반환(OWNER_CREATE_REQUEST_2);
 
         Long savedCafeId = 카페_생성_요청하고_아이디_반환(ownerAccessToken, CAFE_CREATE_REQUEST);
-        Customer youngho = customerRepository.save(Customer.registeredCustomerBuilder().nickname("youngho").build());
+
+        String leoVisitorToken = 가입_고객_회원_가입_요청하고_액세스_토큰_반환(new OAuthRegisterCustomerCreateRequest("leo", "email", OAuthProvider.KAKAO, 123L));
+        Long leoVisitorId = authTokensGenerator.extractMemberId(leoVisitorToken);
+        Customer youngho = customerRepository.findById(leoVisitorId).get();
 
         CouponCreateRequest request = new CouponCreateRequest(savedCafeId);
         Long couponId = 쿠폰_생성_요청하고_아이디_반환(ownerAccessToken, request, youngho.getId());

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/ManagerCouponFindAcceptanceTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/ManagerCouponFindAcceptanceTest.java
@@ -23,7 +23,9 @@ import static com.stampcrush.backend.acceptance.step.ManagerCouponCreateStep.쿠
 import static com.stampcrush.backend.acceptance.step.ManagerCouponFindStep.고객의_쿠폰_조회_요청;
 import static com.stampcrush.backend.acceptance.step.ManagerCouponFindStep.고객의_쿠폰_조회하고_결과_반환;
 import static com.stampcrush.backend.acceptance.step.ManagerCustomerFindStep.고객_목록_조회_요청;
-import static com.stampcrush.backend.acceptance.step.ManagerJoinStep.*;
+import static com.stampcrush.backend.acceptance.step.ManagerJoinStep.OWNER_CREATE_REQUEST;
+import static com.stampcrush.backend.acceptance.step.ManagerJoinStep.OWNER_CREATE_REQUEST_2;
+import static com.stampcrush.backend.acceptance.step.ManagerJoinStep.카페_사장_회원_가입_요청하고_액세스_토큰_반환;
 import static com.stampcrush.backend.acceptance.step.ManagerStampCreateStep.쿠폰에_스탬프를_적립_요청;
 import static com.stampcrush.backend.acceptance.step.VisitorJoinStep.가입_고객_회원_가입_요청하고_액세스_토큰_반환;
 import static com.stampcrush.backend.fixture.CustomerFixture.REGISTER_CUSTOMER_GITCHAN;
@@ -67,15 +69,15 @@ class ManagerCouponFindAcceptanceTest extends AcceptanceTest {
         String firstVisitDate = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy:MM:dd"));
 
         // when
-        CafeCustomerFindResponse expected1 = new CafeCustomerFindResponse(1L, youngho.getNickname(), 2, 1, 2, 10, firstVisitDate, true);
-        CafeCustomerFindResponse expected2 = new CafeCustomerFindResponse(2L, gitchan.getNickname(), 7, 0, 1, 10, firstVisitDate, true);
+        CafeCustomerFindResponse expected1 = new CafeCustomerFindResponse(1L, youngho.getNickname(), 2, 1, 2, 10, firstVisitDate, true, null);
+        CafeCustomerFindResponse expected2 = new CafeCustomerFindResponse(2L, gitchan.getNickname(), 7, 0, 1, 10, firstVisitDate, true, null);
 
         ExtractableResponse<Response> response = 고객_목록_조회_요청(ownerAccessToken, savedCafeId);
 
         CafeCustomersFindResponse actual = response.body().as(CafeCustomersFindResponse.class);
 
         // then
-        assertThat(actual.getCustomers()).containsExactlyInAnyOrder(expected1, expected2);
+        assertThat(actual.getCustomers()).usingRecursiveFieldByFieldElementComparatorIgnoringFields("recentVisitDate").containsExactlyInAnyOrder(expected1, expected2);
     }
 
     @Test

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/step/ManagerCustomerFindStep.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/step/ManagerCustomerFindStep.java
@@ -25,6 +25,20 @@ public class ManagerCustomerFindStep {
                 .extract();
     }
 
+    public static ExtractableResponse<Response> 고객_타입_별_목록_조회_요청(String accessToken, Long cafeId, String status) {
+        return given()
+                .log().all()
+                .contentType(JSON)
+                .auth().preemptive()
+                .oauth2(accessToken)
+                .queryParam("status", status)
+                .when()
+                .get("/api/admin/cafes/{cafeId}/customers", cafeId)
+                .then()
+                .log().all()
+                .extract();
+    }
+
     public static ExtractableResponse<Response> 전화번호로_고객_조회_요청(String accessToken, String phoneNumber) {
         return RestAssured.given()
                 .log().all()

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/step/ManagerCustomerFindStep.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/step/ManagerCustomerFindStep.java
@@ -25,13 +25,13 @@ public class ManagerCustomerFindStep {
                 .extract();
     }
 
-    public static ExtractableResponse<Response> 고객_타입_별_목록_조회_요청(String accessToken, Long cafeId, String status) {
+    public static ExtractableResponse<Response> 고객_타입_별_목록_조회_요청(String accessToken, Long cafeId, String customerType) {
         return given()
                 .log().all()
                 .contentType(JSON)
                 .auth().preemptive()
                 .oauth2(accessToken)
-                .queryParam("status", status)
+                .queryParam("customer-type", customerType)
                 .when()
                 .get("/api/admin/cafes/{cafeId}/customers", cafeId)
                 .then()

--- a/backend/src/test/java/com/stampcrush/backend/api/docs/manager/coupon/ManagerCouponFindApiDocsControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/docs/manager/coupon/ManagerCouponFindApiDocsControllerTest.java
@@ -110,4 +110,45 @@ class ManagerCouponFindApiDocsControllerTest extends DocsControllerTest {
                                         .build())))
                 .andExpect(status().isOk());
     }
+
+    @Test
+    void 고객_타입_별_목록_조회() throws Exception {
+        // given
+        Long cafeId = 1L;
+        Long ownerId = OWNER.getId();
+
+        when(ownerRepository.findByLoginId(OWNER.getLoginId())).thenReturn(Optional.of(OWNER));
+        when(ownerRepository.findById(ownerId)).thenReturn(Optional.of(OWNER));
+        when(cafeRepository.findById(CAFE_ID)).thenReturn(Optional.of(CAFE));
+        when(managerCouponFindService.findCouponsByCafeAndCustomerType(ownerId, cafeId, "register")).thenReturn(List.of(new CafeCustomerFindResultDto(1L, "레오", 3, 12, 30, LocalDateTime.MIN, true, 10, LocalDateTime.MIN)));
+        when(authTokensGenerator.isValidToken(anyString())).thenReturn(true);
+        when(authTokensGenerator.extractMemberId(anyString())).thenReturn(ownerId);
+
+        // when, then
+        mockMvc.perform(RestDocumentationRequestBuilders.get("/api/admin/cafes/{cafeId}/customers", cafeId)
+                        .param("status", "register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header(HttpHeaders.AUTHORIZATION, OWNER_BEARER_HEADER))
+                .andDo(document("manager/coupon/find-customer-type-list",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        resource(
+                                ResourceSnippetParameters.builder()
+                                        .tag("사장 모드")
+                                        .description("고객 타입 별 목록 조회")
+                                        .requestHeaders(headerWithName("Authorization").description("Bearer"))
+                                        .responseFields(
+                                                fieldWithPath("customers[].id").description("고객 ID"),
+                                                fieldWithPath("customers[].nickname").description("닉네임"),
+                                                fieldWithPath("customers[].stampCount").description("스탬프 개수"),
+                                                fieldWithPath("customers[].rewardCount").description("리워드 개수"),
+                                                fieldWithPath("customers[].visitCount").description("방문 횟수"),
+                                                fieldWithPath("customers[].firstVisitDate").description("첫 방문 날짜"),
+                                                fieldWithPath("customers[].isRegistered").description("임시/가입 회원 여부"),
+                                                fieldWithPath("customers[].maxStampCount").description("최대 스탬프 개수"),
+                                                fieldWithPath("customers[].recentVisitDate").description("최근 방문 일자"))
+                                        .responseSchema(Schema.schema("CafeCustomersFindResponse"))
+                                        .build())))
+                .andExpect(status().isOk());
+    }
 }

--- a/backend/src/test/java/com/stampcrush/backend/api/docs/manager/coupon/ManagerCouponFindApiDocsControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/docs/manager/coupon/ManagerCouponFindApiDocsControllerTest.java
@@ -20,7 +20,9 @@ import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -78,7 +80,7 @@ class ManagerCouponFindApiDocsControllerTest extends DocsControllerTest {
         when(ownerRepository.findByLoginId(OWNER.getLoginId())).thenReturn(Optional.of(OWNER));
         when(ownerRepository.findById(ownerId)).thenReturn(Optional.of(OWNER));
         when(cafeRepository.findById(CAFE_ID)).thenReturn(Optional.of(CAFE));
-        when(managerCouponFindService.findCouponsByCafe(ownerId, cafeId)).thenReturn(List.of(new CafeCustomerFindResultDto(1L, "레오", 3, 12, 30, LocalDateTime.MIN, true, 10)));
+        when(managerCouponFindService.findCouponsByCafe(ownerId, cafeId)).thenReturn(List.of(new CafeCustomerFindResultDto(1L, "레오", 3, 12, 30, LocalDateTime.MIN, true, 10, null)));
         when(authTokensGenerator.isValidToken(anyString())).thenReturn(true);
         when(authTokensGenerator.extractMemberId(anyString())).thenReturn(ownerId);
 

--- a/backend/src/test/java/com/stampcrush/backend/api/docs/manager/coupon/ManagerCouponFindApiDocsControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/docs/manager/coupon/ManagerCouponFindApiDocsControllerTest.java
@@ -126,7 +126,7 @@ class ManagerCouponFindApiDocsControllerTest extends DocsControllerTest {
 
         // when, then
         mockMvc.perform(RestDocumentationRequestBuilders.get("/api/admin/cafes/{cafeId}/customers", cafeId)
-                        .param("status", "register")
+                        .param("customer-type", "register")
                         .contentType(MediaType.APPLICATION_JSON)
                         .header(HttpHeaders.AUTHORIZATION, OWNER_BEARER_HEADER))
                 .andDo(document("manager/coupon/find-customer-type-list",

--- a/backend/src/test/java/com/stampcrush/backend/api/docs/manager/coupon/ManagerCouponFindApiDocsControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/docs/manager/coupon/ManagerCouponFindApiDocsControllerTest.java
@@ -80,7 +80,7 @@ class ManagerCouponFindApiDocsControllerTest extends DocsControllerTest {
         when(ownerRepository.findByLoginId(OWNER.getLoginId())).thenReturn(Optional.of(OWNER));
         when(ownerRepository.findById(ownerId)).thenReturn(Optional.of(OWNER));
         when(cafeRepository.findById(CAFE_ID)).thenReturn(Optional.of(CAFE));
-        when(managerCouponFindService.findCouponsByCafe(ownerId, cafeId)).thenReturn(List.of(new CafeCustomerFindResultDto(1L, "레오", 3, 12, 30, LocalDateTime.MIN, true, 10, null)));
+        when(managerCouponFindService.findCouponsByCafe(ownerId, cafeId)).thenReturn(List.of(new CafeCustomerFindResultDto(1L, "레오", 3, 12, 30, LocalDateTime.MIN, true, 10, LocalDateTime.MIN)));
         when(authTokensGenerator.isValidToken(anyString())).thenReturn(true);
         when(authTokensGenerator.extractMemberId(anyString())).thenReturn(ownerId);
 
@@ -104,7 +104,8 @@ class ManagerCouponFindApiDocsControllerTest extends DocsControllerTest {
                                                 fieldWithPath("customers[].visitCount").description("방문 횟수"),
                                                 fieldWithPath("customers[].firstVisitDate").description("첫 방문 날짜"),
                                                 fieldWithPath("customers[].isRegistered").description("임시/가입 회원 여부"),
-                                                fieldWithPath("customers[].maxStampCount").description("최대 스탬프 개수"))
+                                                fieldWithPath("customers[].maxStampCount").description("최대 스탬프 개수"),
+                                                fieldWithPath("customers[].recentVisitDate").description("최근 방문 일자"))
                                         .responseSchema(Schema.schema("CafeCustomersFindResponse"))
                                         .build())))
                 .andExpect(status().isOk());

--- a/backend/src/test/java/com/stampcrush/backend/api/manager/coupon/ManagerCouponFindApiControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/manager/coupon/ManagerCouponFindApiControllerTest.java
@@ -30,8 +30,8 @@ public class ManagerCouponFindApiControllerTest extends ControllerSliceTest {
     @Test
     void 카페에_방문한_고객들의_정보를_조회한다() throws Exception {
         // given, when
-        CafeCustomerFindResultDto customerInfo1 = new CafeCustomerFindResultDto(1L, "name1", 5, 0, 3, LocalDateTime.now(), false, 10);
-        CafeCustomerFindResultDto customerInfo2 = new CafeCustomerFindResultDto(2L, "name2", 6, 0, 6, LocalDateTime.now(), true, 10);
+        CafeCustomerFindResultDto customerInfo1 = new CafeCustomerFindResultDto(1L, "name1", 5, 0, 3, LocalDateTime.now(), false, 10, null);
+        CafeCustomerFindResultDto customerInfo2 = new CafeCustomerFindResultDto(2L, "name2", 6, 0, 6, LocalDateTime.now(), true, 10, null);
         given(managerCouponFindService.findCouponsByCafe(anyLong(), anyLong()))
                 .willReturn(List.of(customerInfo1, customerInfo2));
 

--- a/backend/src/test/java/com/stampcrush/backend/api/manager/coupon/ManagerCouponFindApiControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/manager/coupon/ManagerCouponFindApiControllerTest.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -37,6 +38,20 @@ public class ManagerCouponFindApiControllerTest extends ControllerSliceTest {
 
         // then
         mockMvc.perform(get(API_PREFIX + "/cafes/{cafeId}/customers", 1L))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void 카페에_방문한_고객들의_타입_별로_정보를_조회한다() throws Exception {
+        // given, when
+        CafeCustomerFindResultDto customerInfo1 = new CafeCustomerFindResultDto(1L, "name1", 5, 0, 3, LocalDateTime.now(), false, 10, null);
+        CafeCustomerFindResultDto customerInfo2 = new CafeCustomerFindResultDto(2L, "name2", 6, 0, 6, LocalDateTime.now(), false, 10, null);
+        given(managerCouponFindService.findCouponsByCafeAndCustomerType(anyLong(), anyLong(), anyString()))
+                .willReturn(List.of(customerInfo1, customerInfo2));
+
+        // then
+        mockMvc.perform(get(API_PREFIX + "/cafes/{cafeId}/customers", 1L)
+                        .param("status", "temporary"))
                 .andExpect(status().isOk());
     }
 

--- a/backend/src/test/java/com/stampcrush/backend/application/manager/coupon/ManagerCouponFindServiceTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/application/manager/coupon/ManagerCouponFindServiceTest.java
@@ -13,6 +13,7 @@ import com.stampcrush.backend.entity.visithistory.VisitHistories;
 import com.stampcrush.backend.entity.visithistory.VisitHistory;
 import com.stampcrush.backend.repository.cafe.CafeRepository;
 import com.stampcrush.backend.repository.coupon.CouponRepository;
+import com.stampcrush.backend.repository.reward.RewardRepository;
 import com.stampcrush.backend.repository.user.CustomerRepository;
 import com.stampcrush.backend.repository.user.OwnerRepository;
 import com.stampcrush.backend.repository.visithistory.VisitHistoryRepository;
@@ -58,6 +59,9 @@ public class ManagerCouponFindServiceTest {
 
     @Mock
     private OwnerRepository ownerRepository;
+
+    @Mock
+    private RewardRepository rewardRepository;
 
     @BeforeAll
     static void setUp() {

--- a/backend/src/test/java/com/stampcrush/backend/application/manager/coupon/ManagerCouponFindServiceTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/application/manager/coupon/ManagerCouponFindServiceTest.java
@@ -109,11 +109,13 @@ public class ManagerCouponFindServiceTest {
                 .willReturn(List.of(visitHistory2));
 
         // when
+        VisitHistories customer1VisitHistories = new VisitHistories(List.of(visitHistory1));
+        VisitHistories customer2VisitHistories = new VisitHistories(List.of(visitHistory2));
         CustomerCouponStatistics customer1Statics = new CustomerCouponStatistics(0, 0, 10);
         CustomerCouponStatistics customer2Statics = new CustomerCouponStatistics(0, 0, 15);
 
-        CafeCustomerFindResultDto customer1Result = CafeCustomerFindResultDto.of(customer1, customer1Statics, 1, coupon1CreatedAt, coupon1CreatedAt);
-        CafeCustomerFindResultDto customer2Result = CafeCustomerFindResultDto.of(customer2, customer2Statics, 1, coupon2CreatedAt, coupon2CreatedAt);
+        CafeCustomerFindResultDto customer1Result = CafeCustomerFindResultDto.of(customer1, customer1Statics, customer1VisitHistories, 0);
+        CafeCustomerFindResultDto customer2Result = CafeCustomerFindResultDto.of(customer2, customer2Statics, customer2VisitHistories, 0);
         List<CafeCustomerFindResultDto> couponsByCafe = managerCouponFindService.findCouponsByCafe(owner.getId(), cafe.getId());
 
         // then
@@ -138,8 +140,9 @@ public class ManagerCouponFindServiceTest {
         given(visitHistoryRepository.findByCafeAndCustomer(cafe, customer1))
                 .willReturn(List.of(visitHistory));
 
+        VisitHistories visitHistories = new VisitHistories(List.of(visitHistory));
         CustomerCouponStatistics customer1Statistics = new CustomerCouponStatistics(0, 0, 0);
-        CafeCustomerFindResultDto customer1Result = CafeCustomerFindResultDto.of(customer1, customer1Statistics, 1, coupon1CreatedAt, coupon1CreatedAt);
+        CafeCustomerFindResultDto customer1Result = CafeCustomerFindResultDto.of(customer1, customer1Statistics, visitHistories, 0);
         List<CafeCustomerFindResultDto> couponsByCafe = managerCouponFindService.findCouponsByCafe(owner.getId(), cafe.getId());
 
         // then
@@ -258,13 +261,16 @@ public class ManagerCouponFindServiceTest {
                 .willReturn(Optional.of(cafe.getOwner()));
 
         // when
+        VisitHistories customer1VisitHistories = new VisitHistories(List.of(customer1VisitHistory1, customer1VisitHistory2));
+        VisitHistories customer2VisitHistories = new VisitHistories(List.of(customer2visitHistory1));
+
         CustomerCouponStatistics customer1Statics = new CustomerCouponStatistics(customer1EarningStampCount1 + customer1EarningStampCount2
                 , rewardCount, couponPolicy1.getMaxStampCount());
         CustomerCouponStatistics customer2Statics = new CustomerCouponStatistics(customer2EarningStampCount, rewardCount,
                 couponPolicy2.getMaxStampCount());
 
-        CafeCustomerFindResultDto customer1Result = CafeCustomerFindResultDto.of(customer1, customer1Statics, 2, coupon1CreatedAt, coupon1UpdatedAt);
-        CafeCustomerFindResultDto customer2Result = CafeCustomerFindResultDto.of(customer2, customer2Statics, 1, coupon2CreatedAt, coupon2CreatedAt);
+        CafeCustomerFindResultDto customer1Result = CafeCustomerFindResultDto.of(customer1, customer1Statics, customer1VisitHistories, 0);
+        CafeCustomerFindResultDto customer2Result = CafeCustomerFindResultDto.of(customer2, customer2Statics, customer2VisitHistories, 0);
         List<CafeCustomerFindResultDto> couponsByCafe = managerCouponFindService.findCouponsByCafe(owner.getId(), cafe.getId());
 
         // then
@@ -308,7 +314,7 @@ public class ManagerCouponFindServiceTest {
         CustomerCouponStatistics customer1Statics = new CustomerCouponStatistics(customer1EarningStampCount1 + customer1EarningStampCount2
                 , rewardCount, couponPolicy1.getMaxStampCount());
 
-        CafeCustomerFindResultDto customer1Result = CafeCustomerFindResultDto.of(customer1, customer1Statics, 2, coupon1CreatedAt, secondVisit);
+        CafeCustomerFindResultDto customer1Result = CafeCustomerFindResultDto.of(customer1, customer1Statics, visitHistories, 0);
         List<CafeCustomerFindResultDto> couponsByCafe = managerCouponFindService.findCouponsByCafe(owner.getId(), cafe.getId());
 
         // then

--- a/backend/src/test/java/com/stampcrush/backend/application/manager/coupon/ManagerCouponFindServiceTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/application/manager/coupon/ManagerCouponFindServiceTest.java
@@ -107,8 +107,8 @@ public class ManagerCouponFindServiceTest {
         // when
         VisitHistories customer1VisitHistories = new VisitHistories(List.of(visitHistory1));
         VisitHistories customer2VisitHistories = new VisitHistories(List.of(visitHistory2));
-        CustomerCouponStatistics customer1Statics = new CustomerCouponStatistics(0, 0, 10);
-        CustomerCouponStatistics customer2Statics = new CustomerCouponStatistics(0, 0, 15);
+        CustomerCouponStatistics customer1Statics = new CustomerCouponStatistics(0, 10);
+        CustomerCouponStatistics customer2Statics = new CustomerCouponStatistics(0, 15);
 
         CafeCustomerFindResultDto customer1Result = CafeCustomerFindResultDto.of(customer1, customer1Statics, customer1VisitHistories, 0);
         CafeCustomerFindResultDto customer2Result = CafeCustomerFindResultDto.of(customer2, customer2Statics, customer2VisitHistories, 0);
@@ -137,7 +137,7 @@ public class ManagerCouponFindServiceTest {
                 .willReturn(List.of(visitHistory));
 
         VisitHistories visitHistories = new VisitHistories(List.of(visitHistory));
-        CustomerCouponStatistics customer1Statistics = new CustomerCouponStatistics(0, 0, 0);
+        CustomerCouponStatistics customer1Statistics = new CustomerCouponStatistics(0, 0);
         CafeCustomerFindResultDto customer1Result = CafeCustomerFindResultDto.of(customer1, customer1Statistics, visitHistories, 0);
         List<CafeCustomerFindResultDto> couponsByCafe = managerCouponFindService.findCouponsByCafe(owner.getId(), cafe.getId());
 
@@ -260,10 +260,8 @@ public class ManagerCouponFindServiceTest {
         VisitHistories customer1VisitHistories = new VisitHistories(List.of(customer1VisitHistory1, customer1VisitHistory2));
         VisitHistories customer2VisitHistories = new VisitHistories(List.of(customer2visitHistory1));
 
-        CustomerCouponStatistics customer1Statics = new CustomerCouponStatistics(customer1EarningStampCount1 + customer1EarningStampCount2
-                , rewardCount, couponPolicy1.getMaxStampCount());
-        CustomerCouponStatistics customer2Statics = new CustomerCouponStatistics(customer2EarningStampCount, rewardCount,
-                couponPolicy2.getMaxStampCount());
+        CustomerCouponStatistics customer1Statics = new CustomerCouponStatistics(customer1EarningStampCount1 + customer1EarningStampCount2, couponPolicy1.getMaxStampCount());
+        CustomerCouponStatistics customer2Statics = new CustomerCouponStatistics(customer2EarningStampCount, couponPolicy2.getMaxStampCount());
 
         CafeCustomerFindResultDto customer1Result = CafeCustomerFindResultDto.of(customer1, customer1Statics, customer1VisitHistories, 0);
         CafeCustomerFindResultDto customer2Result = CafeCustomerFindResultDto.of(customer2, customer2Statics, customer2VisitHistories, 0);
@@ -307,8 +305,7 @@ public class ManagerCouponFindServiceTest {
         // when
         VisitHistories visitHistories = new VisitHistories(List.of(customer1VisitHistory1, customer1VisitHistory2));
 
-        CustomerCouponStatistics customer1Statics = new CustomerCouponStatistics(customer1EarningStampCount1 + customer1EarningStampCount2
-                , rewardCount, couponPolicy1.getMaxStampCount());
+        CustomerCouponStatistics customer1Statics = new CustomerCouponStatistics(customer1EarningStampCount1 + customer1EarningStampCount2, couponPolicy1.getMaxStampCount());
 
         CafeCustomerFindResultDto customer1Result = CafeCustomerFindResultDto.of(customer1, customer1Statics, visitHistories, 0);
         List<CafeCustomerFindResultDto> couponsByCafe = managerCouponFindService.findCouponsByCafe(owner.getId(), cafe.getId());

--- a/backend/src/test/java/com/stampcrush/backend/application/manager/coupon/ManagerCouponFindServiceTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/application/manager/coupon/ManagerCouponFindServiceTest.java
@@ -11,10 +11,8 @@ import com.stampcrush.backend.entity.user.Customer;
 import com.stampcrush.backend.entity.user.Owner;
 import com.stampcrush.backend.entity.visithistory.VisitHistories;
 import com.stampcrush.backend.entity.visithistory.VisitHistory;
-import com.stampcrush.backend.repository.cafe.CafePolicyRepository;
 import com.stampcrush.backend.repository.cafe.CafeRepository;
 import com.stampcrush.backend.repository.coupon.CouponRepository;
-import com.stampcrush.backend.repository.reward.RewardRepository;
 import com.stampcrush.backend.repository.user.CustomerRepository;
 import com.stampcrush.backend.repository.user.OwnerRepository;
 import com.stampcrush.backend.repository.visithistory.VisitHistoryRepository;
@@ -56,13 +54,7 @@ public class ManagerCouponFindServiceTest {
     private CustomerRepository customerRepository;
 
     @Mock
-    private CafePolicyRepository cafePolicyRepository;
-
-    @Mock
     private VisitHistoryRepository visitHistoryRepository;
-
-    @Mock
-    private RewardRepository rewardRepository;
 
     @Mock
     private OwnerRepository ownerRepository;
@@ -71,7 +63,7 @@ public class ManagerCouponFindServiceTest {
     static void setUp() {
         owner = new Owner(1L, "owner", "ownerId", "ownerPassword", "01010010");
         cafe = new Cafe(1L, "name", "road", "detailAddress", "phone", owner);
-//        customer1 = new TemporaryCustomer(1L, "customer1", "phone");
+
         customer1 = Customer.temporaryCustomerBuilder()
                 .id(1L)
                 .phoneNumber("01012345678")

--- a/backend/src/test/java/com/stampcrush/backend/application/manager/coupon/ManagerCouponFindServiceTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/application/manager/coupon/ManagerCouponFindServiceTest.java
@@ -9,6 +9,7 @@ import com.stampcrush.backend.entity.coupon.Coupon;
 import com.stampcrush.backend.entity.coupon.CouponPolicy;
 import com.stampcrush.backend.entity.user.Customer;
 import com.stampcrush.backend.entity.user.Owner;
+import com.stampcrush.backend.entity.visithistory.VisitHistories;
 import com.stampcrush.backend.entity.visithistory.VisitHistory;
 import com.stampcrush.backend.repository.cafe.CafePolicyRepository;
 import com.stampcrush.backend.repository.cafe.CafeRepository;
@@ -268,5 +269,49 @@ public class ManagerCouponFindServiceTest {
 
         // then
         assertThat(couponsByCafe).containsExactlyInAnyOrder(customer1Result, customer2Result);
+    }
+
+    @Test
+    void 카페의_고객_목록_조회_시_최근_방문_일을_계산한다() {
+        // given
+        int rewardCount = 0;
+
+        LocalDateTime coupon1CreatedAt = LocalDateTime.of(2023, 5, 13, 4, 23);
+        LocalDateTime coupon1UpdatedAt = LocalDateTime.of(2023, 5, 13, 4, 23);
+
+        int customer1EarningStampCount1 = 3;
+        int customer1EarningStampCount2 = 2;
+
+        Coupon coupon = new Coupon(coupon1CreatedAt, coupon1UpdatedAt, LocalDate.EPOCH, customer1, cafe, null, couponPolicy1);
+        coupon.accumulate(customer1EarningStampCount1);
+        LocalDateTime firstVisit = LocalDateTime.of(2023, 5, 13, 4, 23);
+        VisitHistory customer1VisitHistory1 = new VisitHistory(firstVisit, null, cafe, customer1, customer1EarningStampCount1);
+
+        coupon.accumulate(customer1EarningStampCount2);
+        LocalDateTime secondVisit = LocalDateTime.of(2023, 6, 13, 4, 23);
+        VisitHistory customer1VisitHistory2 = new VisitHistory(secondVisit, null, cafe, customer1, customer1EarningStampCount2);
+
+        given(ownerRepository.findById(anyLong()))
+                .willReturn(Optional.of(owner));
+        given(cafeRepository.findById(anyLong()))
+                .willReturn(Optional.of(cafe));
+        given(couponRepository.findByCafe(any()))
+                .willReturn(List.of(coupon));
+        given(visitHistoryRepository.findByCafeAndCustomer(cafe, customer1))
+                .willReturn(List.of(customer1VisitHistory1, customer1VisitHistory2));
+        given(ownerRepository.findById(anyLong()))
+                .willReturn(Optional.of(cafe.getOwner()));
+
+        // when
+        VisitHistories visitHistories = new VisitHistories(List.of(customer1VisitHistory1, customer1VisitHistory2));
+
+        CustomerCouponStatistics customer1Statics = new CustomerCouponStatistics(customer1EarningStampCount1 + customer1EarningStampCount2
+                , rewardCount, couponPolicy1.getMaxStampCount());
+
+        CafeCustomerFindResultDto customer1Result = CafeCustomerFindResultDto.of(customer1, customer1Statics, 2, coupon1CreatedAt, secondVisit);
+        List<CafeCustomerFindResultDto> couponsByCafe = managerCouponFindService.findCouponsByCafe(owner.getId(), cafe.getId());
+
+        // then
+        assertThat(couponsByCafe).containsExactlyInAnyOrder(customer1Result);
     }
 }

--- a/backend/src/test/java/com/stampcrush/backend/application/manager/coupon/ManagerCouponFindServiceTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/application/manager/coupon/ManagerCouponFindServiceTest.java
@@ -111,8 +111,8 @@ public class ManagerCouponFindServiceTest {
         CustomerCouponStatistics customer1Statics = new CustomerCouponStatistics(0, 0, 10);
         CustomerCouponStatistics customer2Statics = new CustomerCouponStatistics(0, 0, 15);
 
-        CafeCustomerFindResultDto customer1Result = CafeCustomerFindResultDto.of(customer1, customer1Statics, 1, coupon1CreatedAt);
-        CafeCustomerFindResultDto customer2Result = CafeCustomerFindResultDto.of(customer2, customer2Statics, 1, coupon2CreatedAt);
+        CafeCustomerFindResultDto customer1Result = CafeCustomerFindResultDto.of(customer1, customer1Statics, 1, coupon1CreatedAt, coupon1CreatedAt);
+        CafeCustomerFindResultDto customer2Result = CafeCustomerFindResultDto.of(customer2, customer2Statics, 1, coupon2CreatedAt, coupon2CreatedAt);
         List<CafeCustomerFindResultDto> couponsByCafe = managerCouponFindService.findCouponsByCafe(owner.getId(), cafe.getId());
 
         // then
@@ -138,7 +138,7 @@ public class ManagerCouponFindServiceTest {
                 .willReturn(List.of(visitHistory));
 
         CustomerCouponStatistics customer1Statistics = new CustomerCouponStatistics(0, 0, 0);
-        CafeCustomerFindResultDto customer1Result = CafeCustomerFindResultDto.of(customer1, customer1Statistics, 1, coupon1CreatedAt);
+        CafeCustomerFindResultDto customer1Result = CafeCustomerFindResultDto.of(customer1, customer1Statistics, 1, coupon1CreatedAt, coupon1CreatedAt);
         List<CafeCustomerFindResultDto> couponsByCafe = managerCouponFindService.findCouponsByCafe(owner.getId(), cafe.getId());
 
         // then
@@ -220,7 +220,6 @@ public class ManagerCouponFindServiceTest {
     @Test
     void 카페의_고객_목록_조회_시_방문횟수와_첫_방문일을_계산한다() {
         // given
-
         int rewardCount = 0;
 
         LocalDateTime coupon1CreatedAt = LocalDateTime.now();
@@ -263,8 +262,8 @@ public class ManagerCouponFindServiceTest {
         CustomerCouponStatistics customer2Statics = new CustomerCouponStatistics(customer2EarningStampCount, rewardCount,
                 couponPolicy2.getMaxStampCount());
 
-        CafeCustomerFindResultDto customer1Result = CafeCustomerFindResultDto.of(customer1, customer1Statics, 2, coupon1CreatedAt);
-        CafeCustomerFindResultDto customer2Result = CafeCustomerFindResultDto.of(customer2, customer2Statics, 1, coupon2CreatedAt);
+        CafeCustomerFindResultDto customer1Result = CafeCustomerFindResultDto.of(customer1, customer1Statics, 2, coupon1CreatedAt, coupon1UpdatedAt);
+        CafeCustomerFindResultDto customer2Result = CafeCustomerFindResultDto.of(customer2, customer2Statics, 1, coupon2CreatedAt, coupon2CreatedAt);
         List<CafeCustomerFindResultDto> couponsByCafe = managerCouponFindService.findCouponsByCafe(owner.getId(), cafe.getId());
 
         // then

--- a/backend/src/test/java/com/stampcrush/backend/entity/visithistory/VisitHistoriesTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/entity/visithistory/VisitHistoriesTest.java
@@ -26,4 +26,21 @@ class VisitHistoriesTest {
         LocalDateTime expected = LocalDateTime.of(2023, 5, 12, 4, 30);
         Assertions.assertThat(firstVisitDateResult).isEqualTo(expected);
     }
+
+    @Test
+    void 최근_방문_일자를_계산한다() {
+        // given
+        LocalDateTime firstVisitDate = LocalDateTime.of(2023, 5, 12, 4, 30);
+        LocalDateTime secondVisitDate = LocalDateTime.of(2023, 6, 12, 4, 30);
+        VisitHistory firstVisitHistory = new VisitHistory(firstVisitDate, null, null, null, 1);
+        VisitHistory secondVisitHistory = new VisitHistory(secondVisitDate, null, null, null, 1);
+
+        // when
+        VisitHistories visitHistories = new VisitHistories(List.of(firstVisitHistory, secondVisitHistory));
+        LocalDateTime recentVisitDateResult = visitHistories.getRecentVisitDate();
+
+        // then
+        LocalDateTime expected = LocalDateTime.of(2023, 6, 12, 4, 30);
+        Assertions.assertThat(recentVisitDateResult).isEqualTo(expected);
+    }
 }

--- a/backend/src/test/java/com/stampcrush/backend/entity/visithistory/VisitHistoriesTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/entity/visithistory/VisitHistoriesTest.java
@@ -1,0 +1,29 @@
+package com.stampcrush.backend.entity.visithistory;
+
+import com.stampcrush.backend.common.KorNamingConverter;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@KorNamingConverter
+class VisitHistoriesTest {
+
+    @Test
+    void 첫_방문_일자를_계산한다() {
+        // given
+        LocalDateTime firstVisitDate = LocalDateTime.of(2023, 5, 12, 4, 30);
+        LocalDateTime secondVisitDate = LocalDateTime.of(2023, 6, 12, 4, 30);
+        VisitHistory firstVisitHistory = new VisitHistory(firstVisitDate, null, null, null, 1);
+        VisitHistory secondVisitHistory = new VisitHistory(secondVisitDate, null, null, null, 1);
+
+        // when
+        VisitHistories visitHistories = new VisitHistories(List.of(firstVisitHistory, secondVisitHistory));
+        LocalDateTime firstVisitDateResult = visitHistories.getFirstVisitDate();
+
+        // then
+        LocalDateTime expected = LocalDateTime.of(2023, 5, 12, 4, 30);
+        Assertions.assertThat(firstVisitDateResult).isEqualTo(expected);
+    }
+}

--- a/backend/src/test/java/com/stampcrush/backend/fixture/CouponPolicyFixture.java
+++ b/backend/src/test/java/com/stampcrush/backend/fixture/CouponPolicyFixture.java
@@ -8,6 +8,7 @@ public final class CouponPolicyFixture {
 
     public static final CouponPolicy COUPON_POLICY_1 = new CouponPolicy(10, "아메리카노", 8);
     public static final CouponPolicy COUPON_POLICY_2 = new CouponPolicy(10, "아메리카노", 8);
+    public static final CouponPolicy COUPON_POLICY_3 = new CouponPolicy(10, "아메리카노", 8);
 
     public static CafePolicy cafePolicyOfSavedCafe(Cafe savedCafe) {
         return new CafePolicy(

--- a/backend/src/test/java/com/stampcrush/backend/repository/coupon/CouponRepositoryTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/repository/coupon/CouponRepositoryTest.java
@@ -13,7 +13,6 @@ import com.stampcrush.backend.repository.cafe.CafeRepository;
 import com.stampcrush.backend.repository.user.CustomerRepository;
 import com.stampcrush.backend.repository.user.OwnerRepository;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -138,7 +137,7 @@ class CouponRepositoryTest {
         couponPolicy4 = couponPolicyRepository.save(new CouponPolicy(10, "아메리카노", 8));
         couponPolicy5 = couponPolicyRepository.save(new CouponPolicy(10, "아메리카노", 8));
 
-        coupon1 = new Coupon(LocalDateTime.now(), LocalDateTime.now(), LocalDate.EPOCH, tmpCustomer1, cafe1, couponDesign1, couponPolicy1);
+        coupon1 = new Coupon(LocalDateTime.of(2023, 9, 5, 22, 4), LocalDateTime.now(), LocalDate.EPOCH, tmpCustomer1, cafe1, couponDesign1, couponPolicy1);
         Stamp stamp1 = new Stamp();
         Stamp stamp2 = new Stamp();
         stamp1.registerCoupon(coupon1);
@@ -159,7 +158,7 @@ class CouponRepositoryTest {
         coupon4 = new Coupon(LocalDate.EPOCH, tmpCustomer3, cafe2, couponDesign4, couponPolicy4);
         couponRepository.save(coupon4);
 
-        coupon5 = new Coupon(LocalDate.EPOCH, registerCustomer2, cafe2, couponDesign5, couponPolicy5);
+        coupon5 = new Coupon(LocalDateTime.MIN, LocalDateTime.MIN, LocalDate.EPOCH, registerCustomer2, cafe2, couponDesign5, couponPolicy5);
         couponRepository.save(coupon5);
     }
 
@@ -208,22 +207,16 @@ class CouponRepositoryTest {
     }
 
     @Test
-    @Disabled
-        // TODO: 영호씨 이거 갑자기 깨지는데 확인좀 해주세요.
-    void 쿠폰들의_createdAt을_비교한다() {
-        // given, when
-        LocalDateTime visitTime = coupon1.compareCreatedAtAndReturnEarlier(coupon5.getCreatedAt());
-
-        // then
-        assertThat(visitTime).isEqualTo(coupon1.getCreatedAt());
-    }
-
-    @Test
     void 쿠폰의_아이디와_고객의_아이디로_쿠폰을_조회한다() {
         // given, when
         Optional<Coupon> coupon = couponRepository.findByIdAndCustomerId(coupon1.getId(), tmpCustomer1.getId());
 
         // then
         assertThat(coupon).isPresent();
+    }
+
+    @Test
+    void 임시회원의_쿠폰만_조회한다() {
+
     }
 }

--- a/backend/src/test/java/com/stampcrush/backend/repository/coupon/CouponRepositoryTest2.java
+++ b/backend/src/test/java/com/stampcrush/backend/repository/coupon/CouponRepositoryTest2.java
@@ -8,6 +8,7 @@ import com.stampcrush.backend.entity.coupon.CouponPolicy;
 import com.stampcrush.backend.entity.coupon.CouponStampCoordinate;
 import com.stampcrush.backend.entity.coupon.CouponStatus;
 import com.stampcrush.backend.entity.user.Customer;
+import com.stampcrush.backend.entity.user.CustomerType;
 import com.stampcrush.backend.entity.user.Owner;
 import com.stampcrush.backend.fixture.CouponDesignFixture;
 import com.stampcrush.backend.fixture.CouponPolicyFixture;
@@ -191,6 +192,48 @@ class CouponRepositoryTest2 {
 
         // then
         assertThat(findCoupon).containsOnly(jenaCafeCoupon);
+    }
+
+    @Test
+    void 임시회원의_쿠폰만_조회한다() {
+        // given, when
+        Cafe gitchanCafe = createCafe(OwnerFixture.GITCHAN);
+
+        Customer regGit = customerRepository.save(CustomerFixture.REGISTER_CUSTOMER_GITCHAN);
+        Customer tmpCustomer1 = customerRepository.save(CustomerFixture.TEMPORARY_CUSTOMER_1);
+        Customer tmpCustomer2 = customerRepository.save(CustomerFixture.TEMPORARY_CUSTOMER_2);
+
+        Coupon regGitCoupon = saveCoupon(gitchanCafe, regGit, couponDesignRepository.save(CouponDesignFixture.COUPON_DESIGN_1), couponPolicyRepository.save(CouponPolicyFixture.COUPON_POLICY_1));
+        Coupon tmpCoupon1 = saveCoupon(gitchanCafe, tmpCustomer1, couponDesignRepository.save(CouponDesignFixture.COUPON_DESIGN_2), couponPolicyRepository.save(CouponPolicyFixture.COUPON_POLICY_2));
+        Coupon tmpCoupon2 = saveCoupon(gitchanCafe, tmpCustomer2, couponDesignRepository.save(CouponDesignFixture.COUPON_DESIGN_3), couponPolicyRepository.save(CouponPolicyFixture.COUPON_POLICY_3));
+
+        // then
+        List<Coupon> tmpCustomerCoupons = couponRepository.findByCafeAndCustomerType(gitchanCafe, CustomerType.TEMPORARY);
+        assertAll(
+                () -> assertThat(tmpCustomerCoupons).containsExactlyInAnyOrder(tmpCoupon1, tmpCoupon2),
+                () -> assertThat(tmpCustomerCoupons).doesNotContain(regGitCoupon)
+        );
+    }
+
+    @Test
+    void 가입회원의_쿠폰만_조회한다() {
+        // given, when
+        Cafe gitchanCafe = createCafe(OwnerFixture.GITCHAN);
+
+        Customer regGit = customerRepository.save(CustomerFixture.REGISTER_CUSTOMER_GITCHAN);
+        Customer tmpCustomer1 = customerRepository.save(CustomerFixture.TEMPORARY_CUSTOMER_1);
+        Customer tmpCustomer2 = customerRepository.save(CustomerFixture.TEMPORARY_CUSTOMER_2);
+
+        Coupon regGitCoupon = saveCoupon(gitchanCafe, regGit, couponDesignRepository.save(CouponDesignFixture.COUPON_DESIGN_1), couponPolicyRepository.save(CouponPolicyFixture.COUPON_POLICY_1));
+        Coupon tmpCoupon1 = saveCoupon(gitchanCafe, tmpCustomer1, couponDesignRepository.save(CouponDesignFixture.COUPON_DESIGN_2), couponPolicyRepository.save(CouponPolicyFixture.COUPON_POLICY_2));
+        Coupon tmpCoupon2 = saveCoupon(gitchanCafe, tmpCustomer2, couponDesignRepository.save(CouponDesignFixture.COUPON_DESIGN_3), couponPolicyRepository.save(CouponPolicyFixture.COUPON_POLICY_3));
+
+        // then
+        List<Coupon> regCustomerCoupons = couponRepository.findByCafeAndCustomerType(gitchanCafe, CustomerType.REGISTER);
+        assertAll(
+                () -> assertThat(regCustomerCoupons).containsExactlyInAnyOrder(regGitCoupon),
+                () -> assertThat(regCustomerCoupons).doesNotContain(tmpCoupon1, tmpCoupon2)
+        );
     }
 
     private Cafe createCafe(Owner owner) {


### PR DESCRIPTION
## 주요 변경사항
- 기존 사장님이 고객목록 조회 api에 최근 방문일자 데이터도 추가했습니다.
- 임시회원, 가입회원을 조회할 수 있는 api 작성했습니다.

## 리뷰어에게...
- 코드 조금 수정하니까 이전보다는 깔끔해진 것 같아서 CustomerStatistics 는 아직 안없앴습니다. 

## 관련 이슈

closes #767 

## 체크리스트

- [ ] `reviewers` 설정
- [ ] `label` 설정
- [ ] `milestone` 설정
