### PR TITLE
[FE] feat: 임시, 회원 구분 및 최근방문순 추가

### DIFF
--- a/frontend/src/api/get.ts
+++ b/frontend/src/api/get.ts
@@ -9,6 +9,7 @@ import {
   UsedParams,
   OAuthTokenParams,
   CouponIdParams,
+  CustomerTypeParams,
 } from '../types/api/request';
 import {
   CafeRes,
@@ -63,9 +64,12 @@ export const getCustomer = async ({ params }: QueryReq<PhoneNumberParams>) => {
   );
 };
 
-export const getCustomers = async ({ params }: QueryReq<CafeIdParams>) => {
+export const getCustomers = async ({ params }: QueryReq<CafeIdParams & CustomerTypeParams>) => {
   if (!params) throw new Error(PARAMS_ERROR_MESSAGE);
-  return await api.get<CustomersRes>(`/admin/cafes/${params.cafeId}/customers`, ownerHeader());
+  const requestUrl = params.customerType
+    ? `/admin/cafes/${params.cafeId}/customers?customer-type=${params.customerType}`
+    : `/admin/cafes/${params.cafeId}/customers`;
+  return await api.get<CustomersRes>(requestUrl, ownerHeader());
 };
 
 export const getCoupon = async ({ params }: QueryReq<CustomerIdParams & CafeIdParams>) => {

--- a/frontend/src/components/Header/SubHeader/style.tsx
+++ b/frontend/src/components/Header/SubHeader/style.tsx
@@ -9,7 +9,7 @@ export const ArrowIconWrapper = styled.button`
   background: transparent;
 `;
 
-export const HeaderContainer = styled.title`
+export const HeaderContainer = styled.header`
   display: flex;
   position: relative;
   align-items: center;

--- a/frontend/src/constants/index.ts
+++ b/frontend/src/constants/index.ts
@@ -1,5 +1,5 @@
 import { StampCountOption } from '../types/domain/coupon';
-import { RouterPath, TemplateMenu } from '../types/utils';
+import { Option, RouterPath, TemplateMenu } from '../types/utils';
 
 export const REGEX = {
   number: /^[0-9]+$/,
@@ -45,6 +45,13 @@ export const CUSTOMERS_ORDER_OPTIONS = [
     key: 'visitCount',
     value: '방문횟수순',
   },
+  { key: 'recentVisitDate', value: '최근방문순' },
+];
+
+export const REGISTER_TYPE_OPTION: Option[] = [
+  { key: 'register', value: '회원' },
+  { key: 'temporary', value: '임시' },
+  { key: 'all', value: '전체' },
 ];
 
 export const STAMP_COUNT_OPTIONS: StampCountOption[] = [

--- a/frontend/src/pages/Admin/CustomerList/Customers/index.tsx
+++ b/frontend/src/pages/Admin/CustomerList/Customers/index.tsx
@@ -28,7 +28,7 @@ const Customers = ({ customers }: CustomersProps) => {
           maxStampCount,
           rewardCount,
           isRegistered,
-          firstVisitDate,
+          recentVisitDate,
           visitCount,
         }: Customer) => (
           <CustomerBox key={id}>
@@ -44,7 +44,7 @@ const Customers = ({ customers }: CustomersProps) => {
             </LeftInfo>
             <RightInfo>
               <InfoContainer>
-                최근 방문일: {formatDate(firstVisitDate)}
+                최근 방문일: {formatDate(recentVisitDate)}
                 <br /> 방문 횟수: {visitCount}번
               </InfoContainer>
             </RightInfo>

--- a/frontend/src/pages/Admin/CustomerList/Customers/index.tsx
+++ b/frontend/src/pages/Admin/CustomerList/Customers/index.tsx
@@ -1,5 +1,6 @@
-import { CustomersRes } from '../../../../types/api/response';
 import { Customer } from '../../../../types/domain/customer';
+import { Option } from '../../../../types/utils';
+import { formatDate } from '../../../../utils';
 import {
   Container,
   Badge,
@@ -12,6 +13,7 @@ import {
 } from './style';
 
 interface CustomersProps {
+  registerTypeOption: Option;
   customers: Customer[];
 }
 
@@ -42,7 +44,7 @@ const Customers = ({ customers }: CustomersProps) => {
             </LeftInfo>
             <RightInfo>
               <InfoContainer>
-                첫 방문일: {firstVisitDate}
+                최근 방문일: {formatDate(firstVisitDate)}
                 <br /> 방문 횟수: {visitCount}번
               </InfoContainer>
             </RightInfo>

--- a/frontend/src/pages/Admin/CustomerList/hooks/useGetCustomers.ts
+++ b/frontend/src/pages/Admin/CustomerList/hooks/useGetCustomers.ts
@@ -2,20 +2,25 @@ import { useQuery } from '@tanstack/react-query';
 import { getCustomers } from '../../../../api/get';
 import { INVALID_CAFE_ID } from '../../../../constants';
 import { CustomersRes } from '../../../../types/api/response';
-import { Customer } from '../../../../types/domain/customer';
+import { Customer, RegisterType } from '../../../../types/domain/customer';
 import { Option } from '../../../../types/utils';
 
 export interface CustomerOrderOption extends Omit<Option, 'key'> {
   key: keyof Customer;
 }
 
-const useGetCustomers = (cafeId: number, orderOption: CustomerOrderOption) => {
+const useGetCustomers = (
+  cafeId: number,
+  orderOption: CustomerOrderOption,
+  customerType?: RegisterType,
+) => {
   return useQuery<CustomersRes, Error, Customer[]>({
-    queryKey: ['customers'],
+    queryKey: ['customers', customerType],
     queryFn: () =>
       getCustomers({
         params: {
           cafeId,
+          customerType,
         },
       }),
     select: (data) =>

--- a/frontend/src/pages/Admin/CustomerList/index.tsx
+++ b/frontend/src/pages/Admin/CustomerList/index.tsx
@@ -23,7 +23,7 @@ const CustomerList = () => {
     key: 'stampCount',
     value: '스탬프순',
   });
-  const registerTypeKey = registerType.key === 'all' ? undefined : registerType.key;
+  const registerTypeKey = registerType.key === 'all' ? null : registerType.key;
   const { data: customers, status } = useGetCustomers(
     cafeId,
     orderOption as CustomerOrderOption,

--- a/frontend/src/pages/Admin/CustomerList/index.tsx
+++ b/frontend/src/pages/Admin/CustomerList/index.tsx
@@ -1,20 +1,38 @@
-import { CustomerContainer, Container, EmptyCustomers } from './style';
+import {
+  CustomerContainer,
+  Container,
+  EmptyCustomers,
+  TabContainer,
+  RegisterTypeTab,
+} from './style';
 import Text from '../../../components/Text';
 import { useState } from 'react';
 import SelectBox from '../../../components/SelectBox';
-import { CUSTOMERS_ORDER_OPTIONS } from '../../../constants';
+import { CUSTOMERS_ORDER_OPTIONS, REGISTER_TYPE_OPTION } from '../../../constants';
 import LoadingSpinner from '../../../components/LoadingSpinner';
 import Customers from './Customers';
 import { useRedirectRegisterPage } from '../../../hooks/useRedirectRegisterPage';
 import useGetCustomers, { CustomerOrderOption } from './hooks/useGetCustomers';
+import { Option } from '../../../types/utils';
+import { RegisterType } from '../../../types/domain/customer';
 
 const CustomerList = () => {
   const cafeId = useRedirectRegisterPage();
+  const [registerType, setRegisterType] = useState<Option>({ key: 'register', value: '회원' });
   const [orderOption, setOrderOption] = useState({
     key: 'stampCount',
     value: '스탬프순',
   });
-  const { data: customers, status } = useGetCustomers(cafeId, orderOption as CustomerOrderOption);
+  const registerTypeKey = registerType.key === 'all' ? undefined : registerType.key;
+  const { data: customers, status } = useGetCustomers(
+    cafeId,
+    orderOption as CustomerOrderOption,
+    registerTypeKey as RegisterType,
+  );
+
+  const changeRegisterType = (registerType: Option) => () => {
+    setRegisterType(registerType);
+  };
 
   if (status === 'loading') return <LoadingSpinner />;
   if (status === 'error') return <CustomerContainer>Error</CustomerContainer>;
@@ -34,13 +52,24 @@ const CustomerList = () => {
     <CustomerContainer>
       <Text variant="pageTitle">내 고객 목록</Text>
       <Container>
+        <TabContainer>
+          {REGISTER_TYPE_OPTION.map((option) => (
+            <RegisterTypeTab
+              key={option.key}
+              $isSelected={registerType.key === option.key}
+              onClick={changeRegisterType(option)}
+            >
+              {option.value}
+            </RegisterTypeTab>
+          ))}
+        </TabContainer>
         <SelectBox
           options={CUSTOMERS_ORDER_OPTIONS}
           checkedOption={orderOption}
           setCheckedOption={setOrderOption}
         />
       </Container>
-      <Customers customers={customers} />
+      <Customers registerTypeOption={registerType} customers={customers} />
     </CustomerContainer>
   );
 };

--- a/frontend/src/pages/Admin/CustomerList/style.tsx
+++ b/frontend/src/pages/Admin/CustomerList/style.tsx
@@ -21,9 +21,30 @@ export const EmptyCustomers = styled.p`
 
 export const Container = styled.div`
   display: flex;
-  align-self: flex-end;
+  justify-content: space-between;
   align-items: center;
   gap: 20px;
-  margin-top: 30px;
-  margin-right: 30px;
+  margin-top: 40px;
+  padding: 0 20px;
+`;
+
+export const TabContainer = styled.div`
+  display: flex;
+  gap: 10px;
+`;
+
+export const RegisterTypeTab = styled.button<{ $isSelected: boolean }>`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: ${({ $isSelected, theme }) => ($isSelected ? 'none' : `1px solid ${theme.colors.main}`)};
+  border-radius: 5px;
+  width: 60px;
+  height: 30px;
+  color: ${({ $isSelected }) => ($isSelected ? 'white' : '#222')};
+  background: ${({ $isSelected, theme }) => ($isSelected ? theme.colors.main : 'transparent')};
+
+  &:hover {
+    opacity: 70%;
+  }
 `;

--- a/frontend/src/types/api/request.ts
+++ b/frontend/src/types/api/request.ts
@@ -1,4 +1,5 @@
 import { CouponDesign } from '../domain/coupon';
+import { RegisterType } from '../domain/customer';
 
 /** react-query request query 추상화 타입 */
 export interface QueryReq<K = unknown> {
@@ -12,6 +13,10 @@ export interface MutateReq<T = unknown, K = unknown> {
 }
 
 // params 타입
+export interface CustomerTypeParams {
+  customerType?: RegisterType;
+}
+
 export interface CouponIdParams {
   couponId: number;
 }

--- a/frontend/src/types/domain/customer.ts
+++ b/frontend/src/types/domain/customer.ts
@@ -7,6 +7,7 @@ export interface Customer {
   visitCount: number;
   firstVisitDate: string;
   isRegistered: boolean;
+  recentVisitDate: string;
 }
 
 export interface CustomerPhoneNumber {

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -11,7 +11,7 @@ export const formatDate = (dateString: string) => {
 
   const date = new Date(year, month, day);
 
-  const formattedDate = `${date.getFullYear()}년 ${date.getMonth() + 1}월 ${date.getDate()}일`;
+  const formattedDate = `${date.getFullYear()}년 ${date.getMonth()}월 ${date.getDate()}일`;
 
   return formattedDate;
 };


### PR DESCRIPTION
## 주요 변경사항

- 임시/회원 탭으로 구분
- 최근방문순 정렬 기능

<img width="1506" alt="스크린샷 2023-09-27 오전 10 38 51" src="https://github.com/woowacourse-teams/2023-stamp-crush/assets/62367797/4e8097bc-812e-4bd0-88b9-70b190c0e496">


## 리뷰어에게...

## 관련 이슈

closes #783 

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [x] `milestone` 설정
