### PR TITLE
[FE] fix: 이미지 비율이 다른 문제 수정과 쿠폰 제작및 변경 ui 개선 

### DIFF
--- a/frontend/src/pages/Admin/CouponDesign/ChoiceTemplate/style.tsx
+++ b/frontend/src/pages/Admin/CouponDesign/ChoiceTemplate/style.tsx
@@ -7,12 +7,13 @@ export const ChoiceTemplateContainer = styled.div`
 export const SampleImageContainer = styled.div`
   display: flex;
   flex-direction: column;
-  padding: 42px;
+  padding: 20px;
   width: 100%;
   align-items: center;
   gap: 42px;
   overflow: scroll;
-  height: 80vh;
+  height: 87vh;
+  background: white;
 `;
 
 export const WarnMsg = styled.p`

--- a/frontend/src/pages/Admin/CouponDesign/CouponPreviewSection/index.tsx
+++ b/frontend/src/pages/Admin/CouponDesign/CouponPreviewSection/index.tsx
@@ -2,14 +2,15 @@ import { Spacing } from '../../../../style/layout/common';
 import FlippedCoupon, {
   FlippedCouponProps,
 } from '../../../Customer/CouponList/components/FlippedCoupon';
+import { CustomCouponLabel } from '../CustomCouponSection/style';
 
 type CouponPreviewSectionProps = FlippedCouponProps;
 
 const CouponPreviewSection = (props: CouponPreviewSectionProps) => {
   return (
     <div>
-      <label>쿠폰 미리보기</label>
-      <Spacing $size={12} />
+      <CustomCouponLabel>완성된 쿠폰 미리보기</CustomCouponLabel>
+      <Spacing $size={20} />
       <FlippedCoupon {...props} />
     </div>
   );

--- a/frontend/src/pages/Admin/CouponDesign/CustomCouponDesign/index.tsx
+++ b/frontend/src/pages/Admin/CouponDesign/CustomCouponDesign/index.tsx
@@ -68,64 +68,53 @@ const CustomCouponDesign = () => {
 
   return (
     <>
-      <Spacing $size={40} />
       <CustomCouponDesignContainer>
-        <div>
-          <Text variant="pageTitle">쿠폰 제작 및 변경</Text>
-          <Spacing $size={40} />
-          <Text variant="subTitle">예상 쿠폰 이미지</Text>
-          <Spacing $size={20} />
-          <ImageUploadContainer>
-            <div>
-              <CustomCouponSection
-                label="쿠폰 앞면"
-                uploadImageInputId="coupon-front-image-input"
-                imgFileUrl={frontImageUrl}
-                isCustom={isCustom}
-                uploadImageFile={uploadFrontImageUrl}
-              />
-              <Spacing $size={32} />
-              <CustomCouponSection
-                label="쿠폰 뒷면"
-                uploadImageInputId="coupon-back-image-input"
-                imgFileUrl={backImageUrl}
-                isCustom={isCustom}
-                uploadImageFile={uploadBackImageUrl}
-              />
-            </div>
-            <RowSpacing $size={72} />
-            <div>
-              <CouponPreviewSection
-                isShown={true}
-                frontImageUrl={frontImageUrl}
-                backImageUrl={backImageUrl}
-                stampImageUrl={stampImageUrl}
-                stampCount={maxStampCount}
-                coordinates={stampCoordinates}
-              />
-              <Spacing $size={32} />
-              <CustomStampSection
-                label="스탬프"
-                uploadImageInputId="stamp-image-input"
-                imgFileUrl={stampImageUrl}
-                isCustom={isCustom}
-                uploadImageFile={uploadStampImage}
-              />
-            </div>
-          </ImageUploadContainer>
-          <StampCustomButtonWrapper>
+        <Text variant="pageTitle">쿠폰 제작 및 변경 - 커스텀</Text>
+        <ImageUploadContainer>
+          <div>
+            <CustomCouponSection
+              label="쿠폰 앞면"
+              uploadImageInputId="coupon-front-image-input"
+              imgFileUrl={frontImageUrl}
+              isCustom={isCustom}
+              uploadImageFile={uploadFrontImageUrl}
+            />
+            <Spacing $size={40} />
+            <CustomCouponSection
+              label="쿠폰 뒷면"
+              uploadImageInputId="coupon-back-image-input"
+              imgFileUrl={backImageUrl}
+              isCustom={isCustom}
+              uploadImageFile={uploadBackImageUrl}
+            />
+          </div>
+          <div>
+            <CustomStampSection
+              label="스탬프"
+              uploadImageInputId="stamp-image-input"
+              imgFileUrl={stampImageUrl}
+              isCustom={isCustom}
+              uploadImageFile={uploadStampImage}
+            />
+            <Spacing $size={40} />
             <Button variant="secondary" size="medium" onClick={customStampPosition}>
-              스탬프 위치 커스텀하기
+              스탬프 위치 설정하기
             </Button>
-          </StampCustomButtonWrapper>
-          <Spacing $size={40} />
-          <SaveButtonWrapper>
-            <Button variant="primary" size="medium" onClick={changeCouponDesignAndPolicy}>
-              저장하기
-            </Button>
-          </SaveButtonWrapper>
-        </div>
-        <RowSpacing $size={100} />
+          </div>
+          <CouponPreviewSection
+            isShown={true}
+            frontImageUrl={frontImageUrl}
+            backImageUrl={backImageUrl}
+            stampImageUrl={stampImageUrl}
+            stampCount={maxStampCount}
+            coordinates={stampCoordinates}
+          />
+        </ImageUploadContainer>
+        <SaveButtonWrapper>
+          <Button variant="primary" size="medium" onClick={changeCouponDesignAndPolicy}>
+            저장하기
+          </Button>
+        </SaveButtonWrapper>
       </CustomCouponDesignContainer>
       <StampCustomModal
         isOpen={isModalOpen}

--- a/frontend/src/pages/Admin/CouponDesign/CustomCouponDesign/style.tsx
+++ b/frontend/src/pages/Admin/CouponDesign/CustomCouponDesign/style.tsx
@@ -3,17 +3,24 @@ import { PageContainer } from '../../../../style/layout/common';
 
 export const CustomCouponDesignContainer = styled(PageContainer)`
   display: flex;
+  flex-direction: column;
+  margin: 40px 0;
+  width: 100%;
+  height: 100%;
+  position: relative;
 `;
 
 export const ImageUploadContainer = styled.div`
   display: flex;
+  max-width: 80%;
   justify-content: space-between;
+  margin-top: 40px;
 `;
 
 export const SaveButtonWrapper = styled.div`
-  display: flex;
-  flex-direction: row-reverse;
-  width: 100%;
+  position: absolute;
+  right: 20px;
+  bottom: 20px;
 `;
 
 export const PreviewImageWrapper = styled.div<{
@@ -31,7 +38,6 @@ export const PreviewImage = styled.img<{ $width: number; $height: number; $opaci
   width: ${({ $width }) => `${$width}px`};
   height: ${({ $height }) => `${$height}px`};
   opacity: ${({ $opacity }) => ($opacity ? $opacity : '1')};
-  object-fit: cover;
 `;
 
 export const ImageUpLoadInputLabel = styled.label`
@@ -57,6 +63,4 @@ export const ImageUpLoadInput = styled.input`
 
 export const StampCustomButtonWrapper = styled.div`
   display: flex;
-  flex-direction: row-reverse;
-  width: 100%;
 `;

--- a/frontend/src/pages/Admin/CouponDesign/CustomCouponSection/index.tsx
+++ b/frontend/src/pages/Admin/CouponDesign/CustomCouponSection/index.tsx
@@ -1,4 +1,4 @@
-import { CouponPreviewHeader } from './style';
+import { CouponPreviewHeader, CustomCouponLabel } from './style';
 import { Spacing } from '../../../../style/layout/common';
 import {
   ImageUpLoadInput,
@@ -32,7 +32,7 @@ const CustomCouponSection = ({
   return (
     <>
       <CouponPreviewHeader>
-        <label>{label}</label>
+        <CustomCouponLabel>💳 {label}</CustomCouponLabel>
         <ImageUpLoadInput
           id={uploadImageInputId}
           type="file"

--- a/frontend/src/pages/Admin/CouponDesign/CustomCouponSection/style.tsx
+++ b/frontend/src/pages/Admin/CouponDesign/CustomCouponSection/style.tsx
@@ -3,4 +3,11 @@ import { styled } from 'styled-components';
 export const CouponPreviewHeader = styled.div`
   display: flex;
   justify-content: space-between;
+  align-items: center;
+  gap: 20px;
+`;
+
+export const CustomCouponLabel = styled.label`
+  font-size: 20px;
+  font-weight: 900;
 `;

--- a/frontend/src/pages/Admin/CouponDesign/CustomStampSection/index.tsx
+++ b/frontend/src/pages/Admin/CouponDesign/CustomStampSection/index.tsx
@@ -9,6 +9,7 @@ import {
 import { selectImgUrl, useLoadImg } from '../hooks/useLoadImg';
 import StampLoadImg from '../../../../assets/stamp_load_img.png';
 import StampPreviewImg from '../../../../assets/stamp_preview.png';
+import { CouponPreviewHeader, CustomCouponLabel } from '../CustomCouponSection/style';
 
 interface CustomStampSectionProps {
   label: string;
@@ -29,17 +30,20 @@ const CustomStampSection = ({
 
   return (
     <>
-      <label>{label}</label>
-      <Spacing $size={4} />
-      <ImageUpLoadInput
-        id={uploadImageInputId}
-        type="file"
-        accept="image/jpg,image/png,image/jpeg,image/gif"
-        onChange={uploadImageFile}
-      />
-      {isCustom && (
-        <ImageUpLoadInputLabel htmlFor={uploadImageInputId}>이미지 업로드 +</ImageUpLoadInputLabel>
-      )}
+      <CouponPreviewHeader>
+        <CustomCouponLabel>💮 {label}</CustomCouponLabel>
+        <ImageUpLoadInput
+          id={uploadImageInputId}
+          type="file"
+          accept="image/jpg,image/png,image/jpeg,image/gif"
+          onChange={uploadImageFile}
+        />
+        {isCustom && (
+          <ImageUpLoadInputLabel htmlFor={uploadImageInputId}>
+            이미지 업로드 +
+          </ImageUpLoadInputLabel>
+        )}
+      </CouponPreviewHeader>
       <Spacing $size={8} />
       <PreviewImageWrapper $height={50} $width={50}>
         <PreviewImage

--- a/frontend/src/pages/Admin/CouponDesign/TemplateCouponDesign/index.tsx
+++ b/frontend/src/pages/Admin/CouponDesign/TemplateCouponDesign/index.tsx
@@ -1,11 +1,7 @@
 import { useLocation } from 'react-router-dom';
 import Text from '../../../../components/Text';
-import { RowSpacing, Spacing } from '../../../../style/layout/common';
-import {
-  CustomCouponDesignContainer,
-  ImageUploadContainer,
-  SaveButtonWrapper,
-} from '../CustomCouponDesign/style';
+import { Spacing } from '../../../../style/layout/common';
+import { CustomCouponDesignContainer } from '../CustomCouponDesign/style';
 import useUploadImage from '../../../../hooks/useUploadImage';
 import { useState } from 'react';
 import { parseExpireDate, parseStampCount } from '../../../../utils';
@@ -20,6 +16,7 @@ import StampPreviewImg from '../../../../assets/stamp_preview.png';
 import { useRedirectRegisterPage } from '../../../../hooks/useRedirectRegisterPage';
 import { CouponSettingReqBody } from '../../../../types/api/request';
 import { CouponDesignLocation, StampCoordinate } from '../../../../types/domain/coupon';
+import { ImageUploadContainer, PreviewContainer, TemplateTabsContainer } from './style';
 
 const TemplateCouponDesign = () => {
   const cafeId = useRedirectRegisterPage();
@@ -53,69 +50,59 @@ const TemplateCouponDesign = () => {
 
   return (
     <>
-      <Spacing $size={40} />
       <CustomCouponDesignContainer>
-        <div>
-          <Text variant="pageTitle">쿠폰 템플릿으로 제작</Text>
-          <Spacing $size={40} />
-          <Text variant="subTitle">예상 쿠폰 이미지</Text>
-          <Spacing $size={20} />
-
-          <ImageUploadContainer>
-            <div>
-              <CustomCouponSection
-                label="쿠폰 앞면"
-                uploadImageInputId="coupon-front-image-input"
-                imgFileUrl={frontImageUrl}
-                isCustom={isCustom}
-                uploadImageFile={uploadFrontImageUrl}
-              />
-              <Spacing $size={32} />
-              <CustomCouponSection
-                label="쿠폰 뒷면"
-                uploadImageInputId="coupon-back-image-input"
-                imgFileUrl={backImageUrl}
-                isCustom={isCustom}
-                uploadImageFile={uploadBackImageUrl}
-              />
-            </div>
-            <RowSpacing $size={72} />
-            <div>
-              <CouponPreviewSection
-                isShown={true}
-                frontImageUrl={frontImageUrl}
-                backImageUrl={backImageUrl}
-                stampImageUrl={stampImageUrl}
-                stampCount={maxStampCount}
-                coordinates={stampCoordinates}
-              />
-              <Spacing $size={32} />
-              <CustomStampSection
-                label="스탬프"
-                uploadImageInputId="stamp-image-input"
-                imgFileUrl={stampImageUrl}
-                isCustom={isCustom}
-                uploadImageFile={uploadStampImageUrl}
-              />
-            </div>
-          </ImageUploadContainer>
-          <Spacing $size={40} />
-          <SaveButtonWrapper>
+        <Text variant="pageTitle">쿠폰 제작 및 변경 - 템플릿</Text>
+        <ImageUploadContainer>
+          <div>
+            <CustomCouponSection
+              label="쿠폰 앞면"
+              uploadImageInputId="coupon-front-image-input"
+              imgFileUrl={frontImageUrl}
+              isCustom={isCustom}
+              uploadImageFile={uploadFrontImageUrl}
+            />
+            <Spacing $size={32} />
+            <CustomCouponSection
+              label="쿠폰 뒷면"
+              uploadImageInputId="coupon-back-image-input"
+              imgFileUrl={backImageUrl}
+              isCustom={isCustom}
+              uploadImageFile={uploadBackImageUrl}
+            />
+            <Spacing $size={32} />
+            <CustomStampSection
+              label="스탬프"
+              uploadImageInputId="stamp-image-input"
+              imgFileUrl={stampImageUrl}
+              isCustom={isCustom}
+              uploadImageFile={uploadStampImageUrl}
+            />
+          </div>
+          <PreviewContainer>
+            <CouponPreviewSection
+              isShown={true}
+              frontImageUrl={frontImageUrl}
+              backImageUrl={backImageUrl}
+              stampImageUrl={stampImageUrl}
+              stampCount={maxStampCount}
+              coordinates={stampCoordinates}
+            />
             <Button variant="primary" size="medium" onClick={changeCouponDesignAndPolicy}>
               저장하기
             </Button>
-          </SaveButtonWrapper>
-        </div>
-        <RowSpacing $size={100} />
-        <ChoiceTemplate
-          frontImageUrl={frontImageUrl}
-          backImageUrl={backImageUrl}
-          stampImageUrl={stampImageUrl}
-          setFrontImageUrl={setFrontImageUrl}
-          setBackImageUrl={setBackImageUrl}
-          setStampImageUrl={setStampImageUrl}
-          setStampCoordinates={setStampCoordinates}
-        />
+          </PreviewContainer>
+        </ImageUploadContainer>
+        <TemplateTabsContainer>
+          <ChoiceTemplate
+            frontImageUrl={frontImageUrl}
+            backImageUrl={backImageUrl}
+            stampImageUrl={stampImageUrl}
+            setFrontImageUrl={setFrontImageUrl}
+            setBackImageUrl={setBackImageUrl}
+            setStampImageUrl={setStampImageUrl}
+            setStampCoordinates={setStampCoordinates}
+          />
+        </TemplateTabsContainer>
       </CustomCouponDesignContainer>
     </>
   );

--- a/frontend/src/pages/Admin/CouponDesign/TemplateCouponDesign/style.tsx
+++ b/frontend/src/pages/Admin/CouponDesign/TemplateCouponDesign/style.tsx
@@ -1,0 +1,20 @@
+import { styled } from 'styled-components';
+
+export const TemplateTabsContainer = styled.section`
+  position: absolute;
+  top: -40px;
+  right: 0;
+`;
+
+export const ImageUploadContainer = styled.div`
+  display: flex;
+  max-width: 55%;
+  justify-content: space-between;
+  margin-top: 40px;
+`;
+
+export const PreviewContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+`;

--- a/frontend/src/pages/Customer/CouponList/components/Coupon/style.tsx
+++ b/frontend/src/pages/Customer/CouponList/components/Coupon/style.tsx
@@ -7,6 +7,7 @@ export const CouponWrapper = styled.button<{ $src: string }>`
   top: 60%;
   background-image: url(${({ $src }) => $src});
   background-size: cover;
+  background-position: center;
   transform: translate(50%, -50%);
   transition: transform 0.1s;
   box-shadow: 0px -5px 10px -7px #aaa;


### PR DESCRIPTION
## 주요 변경사항

### 1. 쿠폰 미리보기와 쿠폰리스트 내의 이미지 비율이 다른 문제 수정

쿠폰 미리보기는 img 태그이므로 `object-fit: cover`속성으로 이미지 비율을 맞추고
쿠폰 리스트의 이미지는 button 태그이므로 `background-size: cover`속성으로 이미지 비율을 맞추고 있었습니다.

둘 다 원본비율을 망가뜨리지 않으면서 이미지를 꽉채우기 위해 남는 부분을 "자르는데"
전자는 위 아래를 같이 자르고, 후자는 아래만 잘라서 이미지가 다르게 보였습니다.

후자에 `background-position: center`속성을 추가하여 문제를 해결하였습니다.

[ 해결된 상황 캡쳐 사진 ]
<img width="1512" alt="스크린샷 2023-09-30 오전 10 29 10" src="https://github.com/woowacourse-teams/2023-stamp-crush/assets/62367797/75cc0d82-0c1a-4ede-8c1c-bfffeb921979">
<img width="343" alt="스크린샷 2023-09-30 오전 10 44 25" src="https://github.com/woowacourse-teams/2023-stamp-crush/assets/62367797/70fb2f79-de75-4c46-bad1-548a885e9416">

### 2. 쿠폰 제작 및 변경 - 커스텀 페이지에서 페이지 규격이 안맞는 문제
전
<img width="1507" alt="스크린샷 2023-09-30 오전 11 18 03" src="https://github.com/woowacourse-teams/2023-stamp-crush/assets/62367797/ff106883-17c7-4546-b9a3-5ddb6b805517">
후
<img width="1512" alt="스크린샷 2023-09-30 오전 10 29 10" src="https://github.com/woowacourse-teams/2023-stamp-crush/assets/62367797/5492e604-1223-4eb4-879e-a81d56171a67">

### 3. 쿠폰 제작 및 변경 - 템플릿 페이지에서 템플릿 선택 탭바가 아이패드 환경에서 보이지 않던 문제 
전
<img width="707" alt="스크린샷 2023-09-30 오전 11 19 42" src="https://github.com/woowacourse-teams/2023-stamp-crush/assets/62367797/c2a17cf5-ff46-474d-982d-70f110e965a4">
후
<img width="704" alt="스크린샷 2023-09-30 오전 11 20 02" src="https://github.com/woowacourse-teams/2023-stamp-crush/assets/62367797/01706e0f-b08a-45dc-b3c7-070ce64c0ee9">

## 리뷰어에게...

이 또한 서비스 런칭 초반 부에 보여지는 내용이므로 빠르게 머지되면 좋을 듯 합니다!

## 관련 이슈

closes #724

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [x] `milestone` 설정
