### PR TITLE
[FE] feat: 고객모드에서도 사장모드처럼 전화번호 미등록시 사용하지 못하게 한다.

### DIFF
--- a/frontend/src/hooks/useCustomerRedirectRegisterPage.ts
+++ b/frontend/src/hooks/useCustomerRedirectRegisterPage.ts
@@ -1,0 +1,20 @@
+import { useNavigate } from 'react-router-dom';
+import { useCustomerProfile } from './useCustomerProfile';
+import { ROUTER_PATH } from '../constants';
+import { useEffect } from 'react';
+
+const useCustomerRedirectRegisterPage = () => {
+  const navigate = useNavigate();
+  const { customerProfile, status } = useCustomerProfile();
+
+  useEffect(() => {
+    if (!customerProfile?.profile.phoneNumber && status === 'success') {
+      alert('전화번호 등록 후 사용해주세요.');
+      navigate(ROUTER_PATH.inputPhoneNumber);
+    }
+  }, [customerProfile]);
+
+  return { customerProfile };
+};
+
+export default useCustomerRedirectRegisterPage;

--- a/frontend/src/pages/Customer/CouponList/index.tsx
+++ b/frontend/src/pages/Customer/CouponList/index.tsx
@@ -16,8 +16,10 @@ import usePostIsFavorites from './hooks/usePostIsFavorites';
 import useCouponDetail from './hooks/useCouponDetail';
 import useCouponList from './hooks/useCouponList';
 import HomeTemplate from './components/HomeTemplate';
+import useCustomerRedirectRegisterPage from '../../../hooks/useCustomerRedirectRegisterPage';
 
 const CouponList = () => {
+  useCustomerRedirectRegisterPage();
   const navigate = useNavigate();
   const { customerProfile } = useCustomerProfile();
   const { isOpen, openModal, closeModal } = useModal();
@@ -35,7 +37,6 @@ const CouponList = () => {
   useEffect(() => {
     if (localStorage.getItem('login-token') === '' || !localStorage.getItem('login-token'))
       navigate(ROUTER_PATH.login);
-    if (!customerProfile?.profile.phoneNumber) navigate(ROUTER_PATH.phoneNumber);
     if (coupons && isNotEmptyArray(coupons)) {
       setCurrentIndex(coupons.length - 1);
     }

--- a/frontend/src/pages/Customer/HistoryPage/RewardHistory/index.tsx
+++ b/frontend/src/pages/Customer/HistoryPage/RewardHistory/index.tsx
@@ -6,6 +6,7 @@ import { RewardHistoryDateProperties, RewardHistoryType } from '../../../../type
 import { DATE_PARSE_OPTION } from '../../../../constants';
 import HistoryPage from '../HistoryPage';
 import CustomerLoadingSpinner from '../../../../components/LoadingSpinner/CustomerLoadingSpinner';
+import useCustomerRedirectRegisterPage from '../../../../hooks/useCustomerRedirectRegisterPage';
 
 export const concatHistoryDate = (
   reward: RewardHistoryType,
@@ -44,6 +45,7 @@ const RewardHistoryPage = () => {
     queryFn: () => getMyRewards({ params: { used: true } }),
   });
   const title = '리워드 사용 내역';
+  useCustomerRedirectRegisterPage();
 
   if (rewardStatus === 'loading') {
     return (

--- a/frontend/src/pages/Customer/HistoryPage/StampHistory/index.tsx
+++ b/frontend/src/pages/Customer/HistoryPage/StampHistory/index.tsx
@@ -7,6 +7,7 @@ import { DATE_PARSE_OPTION } from '../../../../constants';
 import HistoryPage from '../HistoryPage';
 import CustomerLoadingSpinner from '../../../../components/LoadingSpinner/CustomerLoadingSpinner';
 import { StampHistoryType } from '../../../../types/domain/stamp';
+import useCustomerRedirectRegisterPage from '../../../../hooks/useCustomerRedirectRegisterPage';
 
 // TODO: RewardHistory와 타입 선언을 잘만 하면 재사용하게 만들 수 있을 것 같다.
 export const concatStampHistoryDate = (stamp: StampHistoryType) => {
@@ -47,6 +48,8 @@ const StampHistoryPage = () => {
     queryFn: () => getStampHistories(),
   });
   const title = '스탬프 적립 내역';
+
+  useCustomerRedirectRegisterPage();
 
   if (stampStatus === 'loading') {
     return (

--- a/frontend/src/pages/Customer/MyPage/index.tsx
+++ b/frontend/src/pages/Customer/MyPage/index.tsx
@@ -5,6 +5,7 @@ import { useCustomerProfile } from '../../../hooks/useCustomerProfile';
 import { AiOutlineUnorderedList } from '@react-icons/all-files/ai/AiOutlineUnorderedList';
 import { AiOutlineLogout } from '@react-icons/all-files/ai/AiOutlineLogout';
 import { AiOutlineFileText } from '@react-icons/all-files/ai/AiOutlineFileText';
+import useCustomerRedirectRegisterPage from '../../../hooks/useCustomerRedirectRegisterPage';
 
 const ICONS = [
   <AiOutlineUnorderedList key="rewardHistory" />,
@@ -28,7 +29,7 @@ const MYPAGE_NAV_OPTIONS = [
 ];
 
 const MyPage = () => {
-  const { customerProfile } = useCustomerProfile();
+  const { customerProfile } = useCustomerRedirectRegisterPage();
   const navigate = useNavigate();
 
   const navigatePage = (key: string) => () => {

--- a/frontend/src/pages/Customer/RewardList/index.tsx
+++ b/frontend/src/pages/Customer/RewardList/index.tsx
@@ -2,11 +2,13 @@ import { useQuery } from '@tanstack/react-query';
 import { getMyRewards } from '../../../api/get';
 import SubHeader from '../../../components/Header/SubHeader';
 import { CafeName, RewardContainer, RewardName, RewardWrapper } from './style';
+import useCustomerRedirectRegisterPage from '../../../hooks/useCustomerRedirectRegisterPage';
 
 const RewardList = () => {
   const { data: rewardData, status: rewardStatus } = useQuery(['myRewards'], {
     queryFn: () => getMyRewards({ params: { used: false } }),
   });
+  useCustomerRedirectRegisterPage();
 
   if (rewardStatus === 'error') return <>에러가 발생했습니다.</>;
   if (rewardStatus === 'loading') return <>로딩 중입니다.</>;


### PR DESCRIPTION
## 주요 변경사항

- 리다이렉션하는 훅을 생성하였습니다. 
- 다른 훅들과 다르게 return하는 값을 잘 쓰지 않아서 컴포넌트가 마운트됐을때 곧장 실행되도록했는데, 훅을 이런 식으로 사용한 적이 없다보니 어색하더라구요. 그렇다고 매번 검증하기 위해 보일러 플레이트를 작성하는 것도 낭비라는 생각이 들어 현재의 형태

```ts
useCustomerRedirectRegisterPage();
```
가 되었는데, 너무너무 어색합니다..

이 훅을 어떻게 해야 좀 자연스럽게 사용할 수 있을까요?

## 리뷰어에게...

## 관련 이슈

closes #803 

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [x] `milestone` 설정
