### PR TITLE
[FE] refactor: 카페 관리 페이지 내부의 미리보기 UI가 실제와 다른 부분 수정

### DIFF
--- a/frontend/src/components/Template/style.tsx
+++ b/frontend/src/components/Template/style.tsx
@@ -22,6 +22,7 @@ export const PageContainer = styled.div`
   background: white;
   border-radius: 20px;
   box-shadow: 7px 5px 5px 3px rgba(0, 0, 0, 0.25);
+  overflow: scroll;
 `;
 
 export const Footer = styled.div`

--- a/frontend/src/pages/Admin/EarnStamp/components/CouponIndicator.tsx
+++ b/frontend/src/pages/Admin/EarnStamp/components/CouponIndicator.tsx
@@ -1,0 +1,56 @@
+import Text from '../../../../components/Text';
+import { Spacing } from '../../../../style/layout/common';
+import { IssuedCouponsRes } from '../../../../types/api/response';
+import { CouponDesign } from '../../../../types/domain/coupon';
+import { formatDate } from '../../../../utils';
+import FlippedCoupon from '../../../Customer/CouponList/components/FlippedCoupon';
+import { CouponIndicatorWrapper, TextWrapper } from '../style';
+
+interface CouponIndicatorProps {
+  couponDesignData: CouponDesign;
+  coupon: IssuedCouponsRes;
+  stamp: number;
+}
+
+const CouponIndicator = ({ couponDesignData, coupon, stamp }: CouponIndicatorProps) => {
+  return (
+    <CouponIndicatorWrapper>
+      <TextWrapper>
+        <Text>현재 스탬프 개수:</Text>
+        <Text>
+          {coupon.coupons[0].stampCount} / {coupon.coupons[0].maxStampCount}
+        </Text>
+      </TextWrapper>
+      <TextWrapper>
+        <Text>스탬프 적립: </Text>
+        <Text>{stamp}개</Text>
+      </TextWrapper>
+      <Spacing $size={8} />
+      <FlippedCoupon
+        frontImageUrl={couponDesignData.frontImageUrl}
+        backImageUrl={couponDesignData.backImageUrl}
+        stampImageUrl={couponDesignData.stampImageUrl}
+        stampCount={coupon.coupons[0].stampCount + stamp}
+        coordinates={couponDesignData.coordinates}
+        isShown={true}
+      />
+      <span>쿠폰 유효기간: {formatDate(coupon.coupons[0].expireDate)}까지</span>
+      {coupon.coupons[0].stampCount + stamp > coupon.coupons[0].maxStampCount && (
+        <>
+          <FlippedCoupon
+            frontImageUrl={couponDesignData.frontImageUrl}
+            backImageUrl={couponDesignData.backImageUrl}
+            stampImageUrl={couponDesignData.stampImageUrl}
+            stampCount={coupon.coupons[0].stampCount + stamp - coupon.coupons[0].maxStampCount}
+            coordinates={couponDesignData.coordinates}
+            isShown={true}
+          />
+          <p>새로 발급되는 쿠폰입니다.</p>
+        </>
+      )}
+      <Spacing $size={5} />
+    </CouponIndicatorWrapper>
+  );
+};
+
+export default CouponIndicator;

--- a/frontend/src/pages/Admin/EarnStamp/index.tsx
+++ b/frontend/src/pages/Admin/EarnStamp/index.tsx
@@ -1,7 +1,12 @@
 import { useLocation } from 'react-router-dom';
 import { Spacing } from '../../../style/layout/common';
 import { useEffect, useState } from 'react';
-import { CouponSelectorContainer, CouponSelectorWrapper } from './style';
+import {
+  CouponSelectorContainer,
+  CouponSelectorWrapper,
+  StepperWrapper,
+  TextWrapper,
+} from './style';
 import FlippedCoupon from '../../Customer/CouponList/components/FlippedCoupon';
 import { useRedirectRegisterPage } from '../../../hooks/useRedirectRegisterPage';
 import LoadingSpinner from '../../../components/LoadingSpinner';
@@ -13,7 +18,7 @@ import { CustomerPhoneNumber } from '../../../types/domain/customer';
 import usePostIssueCoupon from './hooks/usePostIssueCoupon';
 import useGetCoupon from './hooks/useGetCoupon';
 import useGetCurrentCouponDesign from './hooks/useGetCurrentCouponDesign';
-import { isNotEmptyArray } from '../../../utils';
+import { formatDate, isNotEmptyArray } from '../../../utils';
 
 const EarnStamp = () => {
   const cafeId = useRedirectRegisterPage();
@@ -59,12 +64,17 @@ const EarnStamp = () => {
       <Spacing $size={40} />
       <Text variant="subTitle">{state.nickname} 고객에게 적립할 스탬프 갯수를 입력해주세요.</Text>
       <CouponSelectorContainer>
-        <Stepper value={stamp} setValue={setStamp} />
         <CouponSelectorWrapper>
-          <Text>
-            현재 스탬프 개수: {coupon.coupons[0].stampCount}/{coupon.coupons[0].maxStampCount}
-          </Text>
-          <Text>스탬프 적립: {stamp}개</Text>
+          <TextWrapper>
+            <Text>현재 스탬프 개수:</Text>
+            <Text>
+              {coupon.coupons[0].stampCount} / {coupon.coupons[0].maxStampCount}
+            </Text>
+          </TextWrapper>
+          <TextWrapper>
+            <Text>스탬프 적립: </Text>
+            <Text>{stamp}개</Text>
+          </TextWrapper>
           <Spacing $size={8} />
           <FlippedCoupon
             frontImageUrl={couponDesignData.frontImageUrl}
@@ -75,8 +85,14 @@ const EarnStamp = () => {
             isShown={true}
           />
           <Spacing $size={5} />
-          <span>쿠폰 유효기간: {coupon.coupons[0].expireDate}까지</span>
+          <span>쿠폰 유효기간: {formatDate(coupon.coupons[0].expireDate)}까지</span>
         </CouponSelectorWrapper>
+        <StepperWrapper>
+          <Stepper value={stamp} setValue={setStamp} />
+          {coupon.coupons[0].stampCount + stamp > coupon.coupons[0].maxStampCount && (
+            <p>[알림] 지금부터 적립하는 스탬프는 새 쿠폰에 적립됩니다.</p>
+          )}
+        </StepperWrapper>
         <Button onClick={earnStamp}>적립</Button>
       </CouponSelectorContainer>
     </>

--- a/frontend/src/pages/Admin/EarnStamp/index.tsx
+++ b/frontend/src/pages/Admin/EarnStamp/index.tsx
@@ -84,16 +84,30 @@ const EarnStamp = () => {
             coordinates={couponDesignData.coordinates}
             isShown={true}
           />
-          <Spacing $size={5} />
           <span>쿠폰 유효기간: {formatDate(coupon.coupons[0].expireDate)}까지</span>
+          {coupon.coupons[0].stampCount + stamp > coupon.coupons[0].maxStampCount && (
+            <>
+              <FlippedCoupon
+                frontImageUrl={couponDesignData.frontImageUrl}
+                backImageUrl={couponDesignData.backImageUrl}
+                stampImageUrl={couponDesignData.stampImageUrl}
+                stampCount={coupon.coupons[0].stampCount + stamp - coupon.coupons[0].maxStampCount}
+                coordinates={couponDesignData.coordinates}
+                isShown={true}
+              />
+              <p>새로 발급되는 쿠폰입니다.</p>
+            </>
+          )}
+          <Spacing $size={5} />
         </CouponSelectorWrapper>
         <StepperWrapper>
           <Stepper value={stamp} setValue={setStamp} />
           {coupon.coupons[0].stampCount + stamp > coupon.coupons[0].maxStampCount && (
             <p>[알림] 지금부터 적립하는 스탬프는 새 쿠폰에 적립됩니다.</p>
           )}
+          <Button onClick={earnStamp}>적립</Button>
         </StepperWrapper>
-        <Button onClick={earnStamp}>적립</Button>
+        {/**TODO: 보유 쿠폰의 발급 시기와 새 쿠폰의 발급 시기에 차이가 있는 케이스에 대한 대처가 필요 */}
       </CouponSelectorContainer>
     </>
   );

--- a/frontend/src/pages/Admin/EarnStamp/index.tsx
+++ b/frontend/src/pages/Admin/EarnStamp/index.tsx
@@ -1,13 +1,7 @@
 import { useLocation } from 'react-router-dom';
 import { Spacing } from '../../../style/layout/common';
 import { useEffect, useState } from 'react';
-import {
-  CouponSelectorContainer,
-  CouponSelectorWrapper,
-  StepperWrapper,
-  TextWrapper,
-} from './style';
-import FlippedCoupon from '../../Customer/CouponList/components/FlippedCoupon';
+import { EarnStampContainer, StepperWrapper } from './style';
 import { useRedirectRegisterPage } from '../../../hooks/useRedirectRegisterPage';
 import LoadingSpinner from '../../../components/LoadingSpinner';
 import Button from '../../../components/Button';
@@ -18,7 +12,8 @@ import { CustomerPhoneNumber } from '../../../types/domain/customer';
 import usePostIssueCoupon from './hooks/usePostIssueCoupon';
 import useGetCoupon from './hooks/useGetCoupon';
 import useGetCurrentCouponDesign from './hooks/useGetCurrentCouponDesign';
-import { formatDate, isNotEmptyArray } from '../../../utils';
+import { isNotEmptyArray } from '../../../utils';
+import CouponIndicator from './components/CouponIndicator';
 
 const EarnStamp = () => {
   const cafeId = useRedirectRegisterPage();
@@ -63,43 +58,8 @@ const EarnStamp = () => {
       <Text variant="pageTitle">스탬프 적립</Text>
       <Spacing $size={40} />
       <Text variant="subTitle">{state.nickname} 고객에게 적립할 스탬프 갯수를 입력해주세요.</Text>
-      <CouponSelectorContainer>
-        <CouponSelectorWrapper>
-          <TextWrapper>
-            <Text>현재 스탬프 개수:</Text>
-            <Text>
-              {coupon.coupons[0].stampCount} / {coupon.coupons[0].maxStampCount}
-            </Text>
-          </TextWrapper>
-          <TextWrapper>
-            <Text>스탬프 적립: </Text>
-            <Text>{stamp}개</Text>
-          </TextWrapper>
-          <Spacing $size={8} />
-          <FlippedCoupon
-            frontImageUrl={couponDesignData.frontImageUrl}
-            backImageUrl={couponDesignData.backImageUrl}
-            stampImageUrl={couponDesignData.stampImageUrl}
-            stampCount={coupon.coupons[0].stampCount + stamp}
-            coordinates={couponDesignData.coordinates}
-            isShown={true}
-          />
-          <span>쿠폰 유효기간: {formatDate(coupon.coupons[0].expireDate)}까지</span>
-          {coupon.coupons[0].stampCount + stamp > coupon.coupons[0].maxStampCount && (
-            <>
-              <FlippedCoupon
-                frontImageUrl={couponDesignData.frontImageUrl}
-                backImageUrl={couponDesignData.backImageUrl}
-                stampImageUrl={couponDesignData.stampImageUrl}
-                stampCount={coupon.coupons[0].stampCount + stamp - coupon.coupons[0].maxStampCount}
-                coordinates={couponDesignData.coordinates}
-                isShown={true}
-              />
-              <p>새로 발급되는 쿠폰입니다.</p>
-            </>
-          )}
-          <Spacing $size={5} />
-        </CouponSelectorWrapper>
+      <EarnStampContainer>
+        <CouponIndicator coupon={coupon} couponDesignData={couponDesignData} stamp={stamp} />
         <StepperWrapper>
           <Stepper value={stamp} setValue={setStamp} />
           {coupon.coupons[0].stampCount + stamp > coupon.coupons[0].maxStampCount && (
@@ -108,7 +68,7 @@ const EarnStamp = () => {
           <Button onClick={earnStamp}>적립</Button>
         </StepperWrapper>
         {/**TODO: 보유 쿠폰의 발급 시기와 새 쿠폰의 발급 시기에 차이가 있는 케이스에 대한 대처가 필요 */}
-      </CouponSelectorContainer>
+      </EarnStampContainer>
     </>
   );
 };

--- a/frontend/src/pages/Admin/EarnStamp/style.tsx
+++ b/frontend/src/pages/Admin/EarnStamp/style.tsx
@@ -13,7 +13,7 @@ export const StepperGuide = styled.p`
   line-height: 25px;
 `;
 
-export const CouponSelectorWrapper = styled.div`
+export const CouponIndicatorWrapper = styled.div`
   display: flex;
   flex-direction: column;
   height: 480px;
@@ -29,7 +29,7 @@ export const CouponSelectorWrapper = styled.div`
   }
 `;
 
-export const CouponSelectorContainer = styled.main`
+export const EarnStampContainer = styled.main`
   display: grid;
   grid-template-columns: repeat(2, 340px 150px);
   width: 700px;

--- a/frontend/src/pages/Admin/EarnStamp/style.tsx
+++ b/frontend/src/pages/Admin/EarnStamp/style.tsx
@@ -16,7 +16,7 @@ export const StepperGuide = styled.p`
 export const CouponSelectorWrapper = styled.div`
   display: flex;
   flex-direction: column;
-
+  height: 480px;
   gap: 10px;
 
   & > h1 {
@@ -38,27 +38,28 @@ export const CouponSelectorContainer = styled.main`
   margin-top: 20px;
 
   color: #777;
-
-  & > button {
-    grid-column: 2/3;
-    font-size: 18px;
-  }
 `;
 
 export const StepperWrapper = styled.div`
   position: relative;
   display: flex;
   flex-direction: column;
+  justify-content: space-around;
   width: 340px;
-  height: 80px;
-  gap: 10px;
+  height: 250px;
+  gap: 250px;
 
   p {
     position: absolute;
-    bottom: 0;
+    bottom: 220px;
     font-size: 14px;
     color: dodgerblue;
     line-height: 20px;
+  }
+
+  & > :last-child {
+    width: 140px;
+    font-size: 18px;
   }
 `;
 

--- a/frontend/src/pages/Admin/EarnStamp/style.tsx
+++ b/frontend/src/pages/Admin/EarnStamp/style.tsx
@@ -16,10 +16,8 @@ export const StepperGuide = styled.p`
 export const CouponSelectorWrapper = styled.div`
   display: flex;
   flex-direction: column;
-  position: absolute;
-  top: 0;
+
   gap: 10px;
-  right: -350px;
 
   & > h1 {
     font-size: 20px;
@@ -32,16 +30,51 @@ export const CouponSelectorWrapper = styled.div`
 `;
 
 export const CouponSelectorContainer = styled.main`
-  display: flex;
-  flex-direction: column;
-  width: 400px;
-  margin-top: 40px;
-  height: 400px;
-  position: relative;
+  display: grid;
+  grid-template-columns: repeat(2, 340px 150px);
+  width: 700px;
+  height: 450px;
+  align-items: center;
+  margin-top: 20px;
+
+  color: #777;
 
   & > button {
+    grid-column: 2/3;
+    font-size: 18px;
+  }
+`;
+
+export const StepperWrapper = styled.div`
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  width: 340px;
+  height: 80px;
+  gap: 10px;
+
+  p {
     position: absolute;
     bottom: 0;
-    right: 0;
+    font-size: 14px;
+    color: dodgerblue;
+    line-height: 20px;
+  }
+`;
+
+export const TextWrapper = styled.div`
+  display: flex;
+  width: 300px;
+  align-items: center;
+  gap: 8px;
+
+  & :nth-child(n) {
+    font-size: 18px;
+  }
+
+  & :nth-child(2) {
+    width: 100px;
+    color: dodgerblue;
+    font-weight: bold;
   }
 `;

--- a/frontend/src/pages/Admin/ManageCafe/components/PreviewContent/index.tsx
+++ b/frontend/src/pages/Admin/ManageCafe/components/PreviewContent/index.tsx
@@ -14,19 +14,20 @@ interface PreviewContentProps {
   cafeInfo: Cafe;
 }
 
+//TODO: cafes API에 리워드명 받을지 논의
 const PreviewContent = ({ openTime, closeTime, phoneNumber, cafeInfo }: PreviewContentProps) => {
   return (
     <PreviewContentContainer>
       <Text>
-        <FaRegClock size={25} />
+        <FaRegClock size={22} />
         {`${parseTime(openTime)} - ${parseTime(closeTime)}`}
       </Text>
       <Text>
-        <FaPhoneAlt size={25} />
+        <FaPhoneAlt size={22} />
         {parsePhoneNumber(phoneNumber)}
       </Text>
       <Text>
-        <FaLocationDot width={25} height={25} />
+        <FaLocationDot width={22} height={22} />
         {`${cafeInfo.roadAddress} ${cafeInfo.detailAddress}`}
       </Text>
     </PreviewContentContainer>

--- a/frontend/src/pages/Admin/ManageCafe/components/PreviewContent/style.tsx
+++ b/frontend/src/pages/Admin/ManageCafe/components/PreviewContent/style.tsx
@@ -16,5 +16,6 @@ export const PreviewContentContainer = styled.div`
     justify-content: flex-start;
     gap: 10px;
     overflow: hidden;
+    line-height: 150%;
   }
 `;

--- a/frontend/src/pages/Admin/ManageCafe/components/PreviewContent/style.tsx
+++ b/frontend/src/pages/Admin/ManageCafe/components/PreviewContent/style.tsx
@@ -4,9 +4,17 @@ export const PreviewContentContainer = styled.div`
   display: flex;
   flex-direction: column;
   position: absolute;
-  bottom: 80px;
-  left: 50px;
-  width: 200px;
-  height: 100px;
+  bottom: 15%;
+  left: 30px;
+  width: 240px;
+
   gap: 20px;
+
+  :nth-child(n) {
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+    gap: 10px;
+    overflow: hidden;
+  }
 `;

--- a/frontend/src/pages/Admin/ManageCafe/components/PreviewCoupon/style.tsx
+++ b/frontend/src/pages/Admin/ManageCafe/components/PreviewCoupon/style.tsx
@@ -12,7 +12,7 @@ export const PreviewCouponBackImage = styled.div`
   font-size: 16px;
   font-weight: 500;
   background: white;
-  border: 3px dotted black;
+  box-shadow: 0px -2px 15px -2px #888;
 `;
 
 export const PreviewBackImage = styled.img`

--- a/frontend/src/pages/Admin/ManageCafe/index.tsx
+++ b/frontend/src/pages/Admin/ManageCafe/index.tsx
@@ -1,12 +1,6 @@
 import Text from '../../../components/Text';
 import Button from '../../../components/Button';
-import {
-  ManageCafeForm,
-  ManageCafeGridContainer,
-  PageContainer,
-  PreviewContainer,
-  Wrapper,
-} from './style';
+import { ManageCafeForm, ManageCafeGridContainer, PreviewContainer, Wrapper } from './style';
 import { useMemo } from 'react';
 import { PreviewImageWrapper } from '../CouponDesign/CustomCouponDesign/style';
 import { DEFAULT_CAFE } from '../../../constants';

--- a/frontend/src/pages/Admin/ManageCafe/style.tsx
+++ b/frontend/src/pages/Admin/ManageCafe/style.tsx
@@ -1,13 +1,5 @@
 import styled from 'styled-components';
 
-export const PageContainer = styled.main`
-  display: flex;
-  justify-content: space-between;
-
-  width: 90%;
-  padding-top: 40px;
-`;
-
 export const StepTitle = styled.p`
   font-size: 18px;
   font-weight: 600;
@@ -18,7 +10,7 @@ export const StepTitle = styled.p`
 export const ManageCafeForm = styled.form`
   display: grid;
   grid-template-rows: repeat(6, auto);
-  width: 100%;
+  width: fit-content;
   height: fit-content;
   gap: 40px;
 

--- a/frontend/src/pages/Admin/ManageCafe/style.tsx
+++ b/frontend/src/pages/Admin/ManageCafe/style.tsx
@@ -19,6 +19,7 @@ export const ManageCafeForm = styled.form`
   display: grid;
   grid-template-rows: repeat(6, auto);
   width: 100%;
+  height: fit-content;
   gap: 40px;
 
   & > button {

--- a/frontend/src/pages/Admin/ManageCafe/style.tsx
+++ b/frontend/src/pages/Admin/ManageCafe/style.tsx
@@ -57,7 +57,7 @@ export const ManageCafeGridContainer = styled.div`
   display: grid;
   width: 100%;
   height: 90%;
-  grid-template-columns: repeat(2, 1fr);
+  grid-template-columns: repeat(2, 400px 400px);
   padding-top: 40px;
   gap: 40px;
 `;


### PR DESCRIPTION
## 주요 변경사항

- 카페 관리의 미리보기 콘텐츠가 실제 고객모드와 상이하여 해당 부분 동일하게 표시되도록 변경했습니다.
- 적립 페이지를 가장 많이 사용하게 될텐데 사용 빈도에 비해 완성도가 부실해보여서 레이아웃과 UX를 개선했습니다.
    - stepper와 쿠폰 간 여백을 줄였습니다.
    - 사용자가 적립할 때 가장 필요한 정보는 스탬프 개수(숫자)라고 생각하여 폰트 컬러를 눈에 띄도록 변경했습니다.
    - 현재 보유 스탬프 + 적립할 스탬프의 개수가 MaxCount보다 커지는 순간, 사용자에게 초과되는 스탬프는 새 쿠폰에 적립된다는 점을 고지하도록 했습니다.
- Template에 `overflow:scroll` 속성을 추가하였습니다.
-  이외에도 여러분이 생각하는 개선사항을 리뷰에 남겨주세요

## 리뷰어에게...
before　　　　　　　　　　　　　　　　after
<img width="200" alt="스크린샷 2023-09-30 오후 9 46 32" src="https://github.com/woowacourse-teams/2023-stamp-crush/assets/90092440/f1a861cd-85f4-4c73-8300-898f1d96d97d">　　<img width="200" alt="스크린샷 2023-09-30 오후 9 46 32" src="https://github.com/woowacourse-teams/2023-stamp-crush/assets/90092440/b439ba21-733e-4f2c-aa35-7b7f0636b888">



적립 페이지 UI/UX 개선
<img width="680" alt="스크린샷 2023-09-30 오후 9 46 32" src="https://github.com/woowacourse-teams/2023-stamp-crush/assets/90092440/faf7223d-b26d-4277-b14c-d58af6b7f02e">

## 관련 이슈

closes #802 

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [x] `milestone` 설정
