### PR TITLE
[FE] feat: '전체'를 기본값으로 변경

### DIFF
--- a/frontend/src/constants/index.ts
+++ b/frontend/src/constants/index.ts
@@ -49,9 +49,9 @@ export const CUSTOMERS_ORDER_OPTIONS = [
 ];
 
 export const REGISTER_TYPE_OPTION: Option[] = [
+  { key: 'all', value: '전체' },
   { key: 'register', value: '회원' },
   { key: 'temporary', value: '임시' },
-  { key: 'all', value: '전체' },
 ];
 
 export const STAMP_COUNT_OPTIONS: StampCountOption[] = [

--- a/frontend/src/pages/Admin/CustomerList/index.tsx
+++ b/frontend/src/pages/Admin/CustomerList/index.tsx
@@ -18,7 +18,7 @@ import { RegisterType } from '../../../types/domain/customer';
 
 const CustomerList = () => {
   const cafeId = useRedirectRegisterPage();
-  const [registerType, setRegisterType] = useState<Option>({ key: 'register', value: '회원' });
+  const [registerType, setRegisterType] = useState<Option>({ key: 'all', value: '전체' });
   const [orderOption, setOrderOption] = useState({
     key: 'stampCount',
     value: '스탬프순',


### PR DESCRIPTION
## 주요 변경사항

#814 깃짱의 제안을 반영하여, '전체'를 고객 필터링의 기본값으로 변경하였습니다.
저 또한 스탬프 적립 완료 후에 이동되는 고객리스트 페이지에서 즉시 새로 생성된 고객을 확인하려면 '회원'이 아닌 '전체' 탭이 먼저 보여야 한다고 생각이 들어 수정하였습니다~

## 리뷰어에게...

## 관련 이슈

closes #814

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [x] `milestone` 설정
