### PR TITLE
[FE] fix: 스탬프 이미지 object-fit: contain 수정

### DIFF
--- a/frontend/src/pages/Admin/CouponDesign/CustomCouponDesign/StampCustomModal/index.tsx
+++ b/frontend/src/pages/Admin/CouponDesign/CustomCouponDesign/StampCustomModal/index.tsx
@@ -1,6 +1,13 @@
 import { Dispatch, MouseEvent, SetStateAction, useEffect, useRef, useState } from 'react';
 import Modal from '../../../../../components/Modal';
-import { BackCouponWrapper, BackImage, ButtonContainer, Stamp, StampBadge } from './style';
+import {
+  BackCouponWrapper,
+  BackImage,
+  ButtonContainer,
+  Stamp,
+  StampBadge,
+  StampImage,
+} from './style';
 import Text from '../../../../../components/Text';
 import Button from '../../../../../components/Button';
 import { StampCoordinate } from '../../../../../types/domain/coupon';
@@ -80,7 +87,7 @@ const StampCustomModal = ({
             {drawStampCoordinates.map((coord, index) => (
               <Stamp key={index} $x={coord.xCoordinate} $y={coord.yCoordinate}>
                 <StampBadge>{index + 1}</StampBadge>
-                <img src={stampImgFileUrl} width={50} height={50} />
+                <StampImage src={stampImgFileUrl} />
               </Stamp>
             ))}
             <BackImage src={backImgFileUrl} />

--- a/frontend/src/pages/Admin/CouponDesign/CustomCouponDesign/StampCustomModal/style.tsx
+++ b/frontend/src/pages/Admin/CouponDesign/CustomCouponDesign/StampCustomModal/style.tsx
@@ -50,3 +50,9 @@ export const ButtonContainer = styled.div`
   justify-content: space-around;
   align-items: center;
 `;
+
+export const StampImage = styled.img`
+  object-fit: contain;
+  width: 70px;
+  height: 70px;
+`;

--- a/frontend/src/pages/Admin/CouponDesign/CustomCouponDesign/style.tsx
+++ b/frontend/src/pages/Admin/CouponDesign/CustomCouponDesign/style.tsx
@@ -38,6 +38,7 @@ export const PreviewImage = styled.img<{ $width: number; $height: number; $opaci
   width: ${({ $width }) => `${$width}px`};
   height: ${({ $height }) => `${$height}px`};
   opacity: ${({ $opacity }) => ($opacity ? $opacity : '1')};
+  object-fit: contain;
 `;
 
 export const ImageUpLoadInputLabel = styled.label`

--- a/frontend/src/pages/Customer/CouponList/components/FlippedCoupon/style.tsx
+++ b/frontend/src/pages/Customer/CouponList/components/FlippedCoupon/style.tsx
@@ -46,12 +46,12 @@ export const BackImage = styled(CouponImage)`
 `;
 
 export const StampImage = styled.img<{ $x: number; $y: number }>`
-  width: 25px;
-  height: 25px;
+  width: 35px;
+  height: 35px;
   position: absolute;
-  top: ${({ $y }) => `${$y - 12.5}px`};
-  right: ${({ $x }) => `${$x - 12.5}px`};
-  object-fit: cover;
+  top: ${({ $y }) => `${$y - 17.5}px`};
+  right: ${({ $x }) => `${$x - 17.5}px`};
+  object-fit: contain;
   backface-visibility: hidden;
   transform-style: preserve-3d;
   transform: rotateY(180deg);


### PR DESCRIPTION
## 주요 변경사항

스탬프 이미지는 비율이 다르더라도 찌그러뜨리면 안되기 때문에 contain으로 수정하였습니다. 

## 리뷰어에게...

## 관련 이슈

closes #832

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [x] `milestone` 설정
