### PR TITLE
[FE] fix: 배포환경에서 manifest 파일이 포함되지 않는 문제 수정

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -40,6 +40,7 @@
     "@typescript-eslint/eslint-plugin": "^5.61.0",
     "@typescript-eslint/parser": "^5.61.0",
     "color-thief-react": "^2.1.0",
+    "copy-webpack-plugin": "^11.0.0",
     "cypress": "^12.17.1",
     "dotenv": "^16.3.1",
     "eslint": "^8.44.0",

--- a/frontend/webpack.prod.js
+++ b/frontend/webpack.prod.js
@@ -2,7 +2,16 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 const { merge } = require('webpack-merge');
 const common = require('./webpack.common.js');
+const CopyPlugin = require('copy-webpack-plugin');
 
 module.exports = merge(common, {
   mode: 'production',
+  plugins: [
+    new CopyPlugin({
+      patterns: [
+        { from: 'public/assets', to: 'assets/' },
+        { from: 'public/manifest.webmanifest', to: './' },
+      ],
+    }),
+  ],
 });


### PR DESCRIPTION
## 주요 변경사항

새로운 버전 릴리즈 후에도 A2HS 적용이 되지 않는 걸 확인했습니다 😇
빌드된 dist 폴더를 확인하니 public 폴더에 넣어준, 앱로고파일과 manifest 설정 파일이 없더라구요 😇
dev환경에서는 아래처럼 public내용을 함께 빌드해주고 있어서 로컬에서 테스트할때는 A2HS 적용을 확인할 수 있었던 것이었어요 😇
```javascript
devServer: {
    static: {
      directory: path.join(__dirname, 'public'),
    },
    historyApiFallback: true,
    port: 3000,
    hot: true,
  },
```

[copy-webpack-plugin](https://webpack.js.org/plugins/copy-webpack-plugin/)을 webpack.prod.js에 추가해주어 해결하였습니다. 

빌드 폴더 전과 후
<p align="center">
<img width="30%" alt="스크린샷 2023-10-08 오후 5 34 05" src="https://github.com/woowacourse-teams/2023-stamp-crush/assets/62367797/0a6079af-f08d-403d-88f1-4319ffc088b4">
<img width="30%" alt="스크린샷 2023-10-08 오후 5 26 11" src="https://github.com/woowacourse-teams/2023-stamp-crush/assets/62367797/fdd407c2-0cd4-492c-9bcd-9349ad99f7e8">
</p>

[참고자료](https://pak-fuse.tistory.com/48)

## 리뷰어에게...

끝나지 않는 A2HS 관련 pr이네요.. 😓 송구스럽습니다~

## 관련 이슈

closes #849 

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [x] `milestone` 설정
