### PR TITLE
[BE] hotfix: stamp 최대 적립 개수 10개로 고정

### DIFF
--- a/backend/src/main/java/com/stampcrush/backend/api/manager/coupon/request/StampCreateRequest.java
+++ b/backend/src/main/java/com/stampcrush/backend/api/manager/coupon/request/StampCreateRequest.java
@@ -1,5 +1,6 @@
 package com.stampcrush.backend.api.manager.coupon.request;
 
+import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import lombok.AllArgsConstructor;
@@ -11,6 +12,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class StampCreateRequest {
 
+    @Max(value = 10)
     @NotNull
     @Positive
     private Integer earningStampCount;

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/ManagerCouponCommandAcceptanceTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/ManagerCouponCommandAcceptanceTest.java
@@ -214,18 +214,23 @@ class ManagerCouponCommandAcceptanceTest extends AcceptanceTest {
 
         Long coupon1Id = 쿠폰_생성_요청하고_아이디_반환(ownerToken, request1, customerId);
 
+        StampCreateRequest coupon1StampCreateRequest = new StampCreateRequest(5);
+        쿠폰에_스탬프를_적립_요청(ownerToken, customerId, coupon1Id, coupon1StampCreateRequest);
+
         String customerToken2 = 가입_고객_회원_가입_요청하고_액세스_토큰_반환(new OAuthRegisterCustomerCreateRequest("customer2", "email2", OAuthProvider.KAKAO, 1293L));
         Long customerId2 = authTokensGenerator.extractMemberId(customerToken2);
         Customer customer2 = customerRepository.findById(customerId2).get();
 
+        int customer2EarningStamp = 21;
+
         CouponCreateRequest request2 = new CouponCreateRequest(savedCafeId);
         Long coupon2Id = 쿠폰_생성_요청하고_아이디_반환(ownerToken, request2, customerId2);
+        쿠폰에_스탬프를_적립_요청(ownerToken, customerId2, coupon2Id, new StampCreateRequest(10));
+        Long coupon2Id2 = 쿠폰_생성_요청하고_아이디_반환(ownerToken, request2, customerId2);
+        쿠폰에_스탬프를_적립_요청(ownerToken, customerId2, coupon2Id2, new StampCreateRequest(10));
+        Long coupon2Id3 = 쿠폰_생성_요청하고_아이디_반환(ownerToken, request2, customerId2);
+        쿠폰에_스탬프를_적립_요청(ownerToken, customerId2, coupon2Id3, new StampCreateRequest(1));
 
-        StampCreateRequest coupon1StampCreateRequest = new StampCreateRequest(5);
-        쿠폰에_스탬프를_적립_요청(ownerToken, customerId, coupon1Id, coupon1StampCreateRequest);
-
-        StampCreateRequest coupon2StampCreateRequest = new StampCreateRequest(21);
-        쿠폰에_스탬프를_적립_요청(ownerToken, customerId2, coupon2Id, coupon2StampCreateRequest);
 
         // when
         List<CafeCustomerFindResponse> customers = 고객_목록_조회_요청(ownerToken, savedCafeId)
@@ -247,8 +252,8 @@ class ManagerCouponCommandAcceptanceTest extends AcceptanceTest {
         CafeCustomerFindResponse customer2Expected = new CafeCustomerFindResponse(
                 coupon2Id,
                 customer2.getNickname(),
-                coupon2StampCreateRequest.getEarningStampCount() % 10,
-                coupon2StampCreateRequest.getEarningStampCount() / 10,
+                customer2EarningStamp % 10,
+                customer2EarningStamp / 10,
                 1,
                 10,
                 null,

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/ManagerCouponCommandAcceptanceTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/ManagerCouponCommandAcceptanceTest.java
@@ -157,6 +157,27 @@ class ManagerCouponCommandAcceptanceTest extends AcceptanceTest {
     }
 
     @Test
+    void 스탬프_10개_초과해서_적립하면_예외_발생한다() {
+        // given
+        String ownerToken = 카페_사장_회원_가입_요청하고_액세스_토큰_반환(new OAuthRegisterOwnerCreateRequest("leo", OAuthProvider.KAKAO, 123L));
+
+        Long savedCafeId = 카페_생성_요청하고_아이디_반환(ownerToken, CAFE_CREATE_REQUEST);
+        String customerToken = 가입_고객_회원_가입_요청하고_액세스_토큰_반환(new OAuthRegisterCustomerCreateRequest("customer", "email", OAuthProvider.KAKAO, 123L));
+        Long customerId = authTokensGenerator.extractMemberId(customerToken);
+
+        CouponCreateRequest request = new CouponCreateRequest(savedCafeId);
+
+        Long couponId = 쿠폰_생성_요청하고_아이디_반환(ownerToken, request, customerId);
+
+        // when
+        StampCreateRequest stampCreateRequest = new StampCreateRequest(11);
+        ExtractableResponse<Response> response = 쿠폰에_스탬프를_적립_요청(ownerToken, customerId, couponId, stampCreateRequest);
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(BAD_REQUEST.value());
+    }
+
+    @Test
     void 사장님_인증_정보_없이_쿠폰을_생성하려고_하면_예외발생() {
         // given
         CouponCreateRequest request = new CouponCreateRequest(1L);
@@ -230,7 +251,6 @@ class ManagerCouponCommandAcceptanceTest extends AcceptanceTest {
         쿠폰에_스탬프를_적립_요청(ownerToken, customerId2, coupon2Id2, new StampCreateRequest(10));
         Long coupon2Id3 = 쿠폰_생성_요청하고_아이디_반환(ownerToken, request2, customerId2);
         쿠폰에_스탬프를_적립_요청(ownerToken, customerId2, coupon2Id3, new StampCreateRequest(1));
-
 
         // when
         List<CafeCustomerFindResponse> customers = 고객_목록_조회_요청(ownerToken, savedCafeId)

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/VisitorRewardFindAcceptanceTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/VisitorRewardFindAcceptanceTest.java
@@ -35,7 +35,7 @@ class VisitorRewardFindAcceptanceTest extends AcceptanceTest {
 
         Long couponId = 쿠폰_생성_요청하고_아이디_반환(ownerAccessToken, request, customerId);
 
-        int stampCountEnoughToCreateReward = 15;
+        int stampCountEnoughToCreateReward = 10;
         StampCreateRequest stampCreateRequest = new StampCreateRequest(stampCountEnoughToCreateReward);
 
         쿠폰에_스탬프를_적립_요청(ownerAccessToken, customerId, couponId, stampCreateRequest);


### PR DESCRIPTION
## 주요 변경사항

- 스탬프 적립요청 최대 개수 10개로 했습니다
- max 적립 개수는 변경이 잦을 거 같아서 Request 에서만 @Max 로 막았습니다

## 리뷰어에게...

## 관련 이슈

closes

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [x] `milestone` 설정
