### PR TITLE
[FE] feat: 고객의 수 추가

### DIFF
--- a/frontend/src/pages/Admin/CustomerList/index.tsx
+++ b/frontend/src/pages/Admin/CustomerList/index.tsx
@@ -4,6 +4,7 @@ import {
   EmptyCustomers,
   TabContainer,
   RegisterTypeTab,
+  CustomerCount,
 } from './style';
 import Text from '../../../components/Text';
 import { useState } from 'react';
@@ -60,7 +61,9 @@ const CustomerList = () => {
 
   return (
     <CustomerContainer>
-      <Text variant="pageTitle">내 고객 목록</Text>
+      <Text variant="pageTitle">
+        내 고객 목록 <CustomerCount>총 {customers.length}명</CustomerCount>
+      </Text>
       <Container>
         <TabContainer>
           {REGISTER_TYPE_OPTION.map((option) => (

--- a/frontend/src/pages/Admin/CustomerList/style.tsx
+++ b/frontend/src/pages/Admin/CustomerList/style.tsx
@@ -59,3 +59,10 @@ export const RegisterTypeTab = styled.button<{ $isSelected: boolean }>`
     opacity: 70%;
   }
 `;
+
+export const CustomerCount = styled.span`
+  font-size: 16px;
+  margin-left: 20px;
+  margin-top: 20px;
+  color: gray;
+`;


### PR DESCRIPTION
## 주요 변경사항

사장모드에서 고객이 현재 몇명인지 확인하기 어려운 불편함이 있었습니다.
따라서, 고객의 수를 ui에 추가하였습니다. 
<img width="1488" alt="스크린샷 2023-10-12 오후 3 39 28" src="https://github.com/woowacourse-teams/2023-stamp-crush/assets/62367797/8e118d5a-b359-47f2-927e-7797226869ab">


## 리뷰어에게...

## 관련 이슈

closes #857 

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [x] `milestone` 설정
