### PR TITLE
[BE] refactor: 인수테스트 Fixture 사용하도록, 모든 Bean AccpetanceTest 에서 상속받도록 리팩터링

### DIFF
--- a/backend/src/test/java/com/stampcrush/backend/acceptance/AcceptanceTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/AcceptanceTest.java
@@ -8,6 +8,11 @@ import com.stampcrush.backend.repository.cafe.CafeCouponDesignRepository;
 import com.stampcrush.backend.repository.cafe.CafePolicyRepository;
 import com.stampcrush.backend.repository.cafe.CafeRepository;
 import com.stampcrush.backend.repository.coupon.CouponRepository;
+import com.stampcrush.backend.repository.favorites.FavoritesRepository;
+import com.stampcrush.backend.repository.sample.SampleBackImageRepository;
+import com.stampcrush.backend.repository.sample.SampleFrontImageRepository;
+import com.stampcrush.backend.repository.sample.SampleStampCoordinateRepository;
+import com.stampcrush.backend.repository.sample.SampleStampImageRepository;
 import com.stampcrush.backend.repository.user.CustomerRepository;
 import com.stampcrush.backend.repository.user.OwnerRepository;
 import io.restassured.RestAssured;
@@ -45,6 +50,21 @@ public class AcceptanceTest {
 
     @Autowired
     protected CouponRepository couponRepository;
+
+    @Autowired
+    protected SampleFrontImageRepository sampleFrontImageRepository;
+
+    @Autowired
+    protected SampleBackImageRepository sampleBackImageRepository;
+
+    @Autowired
+    protected SampleStampCoordinateRepository sampleStampCoordinateRepository;
+
+    @Autowired
+    protected SampleStampImageRepository sampleStampImageRepository;
+
+    @Autowired
+    protected FavoritesRepository favoritesRepository;
 
     @LocalServerPort
     private int port;

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/ManagerCommandAcceptanceTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/ManagerCommandAcceptanceTest.java
@@ -12,7 +12,7 @@ import static com.stampcrush.backend.acceptance.step.ManagerCreateStep.사장_�
 import static com.stampcrush.backend.acceptance.step.ManagerLoginStep.사장_로그인;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ManagerCommandAcceptanceTest extends AcceptanceTest {
+class ManagerCommandAcceptanceTest extends AcceptanceTest {
 
     @Test
     void 사장을_생성한다() {

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/ManagerJoinAcceptanceTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/ManagerJoinAcceptanceTest.java
@@ -1,10 +1,9 @@
 package com.stampcrush.backend.acceptance;
 
-import com.stampcrush.backend.auth.OAuthProvider;
-import com.stampcrush.backend.auth.api.request.OAuthRegisterOwnerCreateRequest;
 import com.stampcrush.backend.entity.user.Owner;
 import org.junit.jupiter.api.Test;
 
+import static com.stampcrush.backend.acceptance.step.ManagerJoinStep.OWNER_CREATE_REQUEST;
 import static com.stampcrush.backend.acceptance.step.ManagerJoinStep.카페_사장_회원_가입_요청하고_액세스_토큰_반환;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -13,16 +12,15 @@ class ManagerJoinAcceptanceTest extends AcceptanceTest {
 
     @Test
     void 카페_사장이_회원가입_한다() {
-        OAuthRegisterOwnerCreateRequest request = new OAuthRegisterOwnerCreateRequest("깃짱", OAuthProvider.KAKAO, 12134L);
-        String accessToken = 카페_사장_회원_가입_요청하고_액세스_토큰_반환(request);
+        String accessToken = 카페_사장_회원_가입_요청하고_액세스_토큰_반환(OWNER_CREATE_REQUEST);
         Long ownerId = authTokensGenerator.extractMemberId(accessToken);
 
         Owner findOwner = ownerRepository.findById(ownerId).get();
 
         assertAll(
-                () -> assertEquals(findOwner.getNickname(), request.getNickname()),
-                () -> assertEquals(findOwner.getOAuthProvider(), request.getoAuthProvider()),
-                () -> assertEquals(findOwner.getOAuthId(), request.getoAuthId())
+                () -> assertEquals(findOwner.getNickname(), OWNER_CREATE_REQUEST.getNickname()),
+                () -> assertEquals(findOwner.getOAuthProvider(), OWNER_CREATE_REQUEST.getoAuthProvider()),
+                () -> assertEquals(findOwner.getOAuthId(), OWNER_CREATE_REQUEST.getoAuthId())
         );
     }
 }

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/ManagerRewardCommandAcceptanceTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/ManagerRewardCommandAcceptanceTest.java
@@ -7,9 +7,6 @@ import com.stampcrush.backend.api.manager.customer.request.TemporaryCustomerCrea
 import com.stampcrush.backend.api.manager.reward.request.RewardUsedUpdateRequest;
 import com.stampcrush.backend.api.manager.reward.response.RewardFindResponse;
 import com.stampcrush.backend.api.manager.reward.response.RewardsFindResponse;
-import com.stampcrush.backend.auth.OAuthProvider;
-import com.stampcrush.backend.auth.api.request.OAuthRegisterCustomerCreateRequest;
-import com.stampcrush.backend.auth.api.request.OAuthRegisterOwnerCreateRequest;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import org.assertj.core.api.SoftAssertions;
@@ -19,45 +16,23 @@ import java.util.List;
 
 import static com.stampcrush.backend.acceptance.step.ManagerCafeCreateStep.카페_생성_요청하고_아이디_반환;
 import static com.stampcrush.backend.acceptance.step.ManagerCouponCreateStep.쿠폰_생성_요청하고_아이디_반환;
-import static com.stampcrush.backend.acceptance.step.ManagerJoinStep.카페_사장_회원_가입_요청하고_액세스_토큰_반환;
+import static com.stampcrush.backend.acceptance.step.ManagerJoinStep.*;
 import static com.stampcrush.backend.acceptance.step.ManagerRewardStep.리워드_목록_조회;
 import static com.stampcrush.backend.acceptance.step.ManagerRewardStep.리워드_사용;
 import static com.stampcrush.backend.acceptance.step.ManagerStampCreateStep.쿠폰에_스탬프를_적립_요청;
-import static com.stampcrush.backend.acceptance.step.VisitorJoinStep.가입_고객_회원_가입_요청하고_액세스_토큰_반환;
-import static com.stampcrush.backend.acceptance.step.VisitorJoinStep.임시_고객_회원_가입_요청하고_아이디_반환;
+import static com.stampcrush.backend.acceptance.step.VisitorJoinStep.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.http.HttpStatus.UNAUTHORIZED;
 
 class ManagerRewardCommandAcceptanceTest extends AcceptanceTest {
 
-    public static final OAuthRegisterOwnerCreateRequest O_AUTH_OWNER_CREATE_REQUEST = new OAuthRegisterOwnerCreateRequest(
-            "owner",
-            OAuthProvider.KAKAO,
-            938273L
-    );
-
-    public static final OAuthRegisterOwnerCreateRequest O_AUTH_OWNER_CREATE_REQUEST_2 = new OAuthRegisterOwnerCreateRequest(
-            "notOwner",
-            OAuthProvider.KAKAO,
-            932862L
-    );
-
-    public static final OAuthRegisterCustomerCreateRequest O_AUTH_REGISTER_CUSTOMER_CREATE_REQUEST_JENA = new OAuthRegisterCustomerCreateRequest(
-            "jena",
-            "jena@gmail.com",
-            OAuthProvider.KAKAO,
-            938272L
-    );
-
     @Test
     void 카페사장이_가입_회원의_리워드를_사용한다() {
         // given
-        OAuthRegisterCustomerCreateRequest registerCustomerCreateRequest = O_AUTH_REGISTER_CUSTOMER_CREATE_REQUEST_JENA;
-        String accessTokenCustomer = 가입_고객_회원_가입_요청하고_액세스_토큰_반환(registerCustomerCreateRequest);
+        String accessTokenCustomer = 가입_고객_회원_가입_요청하고_액세스_토큰_반환(O_AUTH_REGISTER_CUSTOMER_CREATE_REQUEST_JENA);
         Long customerId = authTokensGenerator.extractMemberId(accessTokenCustomer);
 
-        OAuthRegisterOwnerCreateRequest registerOwnerCreateRequest = O_AUTH_OWNER_CREATE_REQUEST;
-        String accessTokenOwner = 카페_사장_회원_가입_요청하고_액세스_토큰_반환(registerOwnerCreateRequest);
+        String accessTokenOwner = 카페_사장_회원_가입_요청하고_액세스_토큰_반환(OWNER_CREATE_REQUEST);
 
         CafeCreateRequest cafeCreateRequest = new CafeCreateRequest("cafe", "잠실", "루터회관", "111111111");
         Long cafeId = 카페_생성_요청하고_아이디_반환(accessTokenOwner, cafeCreateRequest);
@@ -86,8 +61,7 @@ class ManagerRewardCommandAcceptanceTest extends AcceptanceTest {
     @Test
     void 카페사장이_임시_회원의_리워드를_사용할_수_있다() {
         // given
-        OAuthRegisterOwnerCreateRequest registerOwnerCreateRequest = O_AUTH_OWNER_CREATE_REQUEST;
-        String accessTokenOwner = 카페_사장_회원_가입_요청하고_액세스_토큰_반환(registerOwnerCreateRequest);
+        String accessTokenOwner = 카페_사장_회원_가입_요청하고_액세스_토큰_반환(OWNER_CREATE_REQUEST);
 
         Long customerId = 임시_고객_회원_가입_요청하고_아이디_반환(accessTokenOwner, new TemporaryCustomerCreateRequest("01011111111"));
 
@@ -117,15 +91,11 @@ class ManagerRewardCommandAcceptanceTest extends AcceptanceTest {
     @Test
     void 카페_사장이_자신의_카페_리워드가_아니면_사용할_수_없다() {
         // given
-        OAuthRegisterCustomerCreateRequest registerCustomerCreateRequest = O_AUTH_REGISTER_CUSTOMER_CREATE_REQUEST_JENA;
-        String accessTokenCustomer = 가입_고객_회원_가입_요청하고_액세스_토큰_반환(registerCustomerCreateRequest);
+        String accessTokenCustomer = 가입_고객_회원_가입_요청하고_액세스_토큰_반환(O_AUTH_REGISTER_CUSTOMER_CREATE_REQUEST_JENA);
         Long customerId = authTokensGenerator.extractMemberId(accessTokenCustomer);
 
-        OAuthRegisterOwnerCreateRequest registerOwnerCreateRequest = O_AUTH_OWNER_CREATE_REQUEST;
-        String accessTokenOwner = 카페_사장_회원_가입_요청하고_액세스_토큰_반환(registerOwnerCreateRequest);
-
-        OAuthRegisterOwnerCreateRequest registerNotOwnerCreateRequest = O_AUTH_OWNER_CREATE_REQUEST_2;
-        String accessTokenNotOwner = 카페_사장_회원_가입_요청하고_액세스_토큰_반환(registerNotOwnerCreateRequest);
+        String accessTokenOwner = 카페_사장_회원_가입_요청하고_액세스_토큰_반환(OWNER_CREATE_REQUEST);
+        String accessTokenNotOwner = 카페_사장_회원_가입_요청하고_액세스_토큰_반환(OWNER_CREATE_REQUEST_2);
 
         CafeCreateRequest cafeCreateRequest = new CafeCreateRequest("cafe", "잠실", "루터회관", "111111111");
         Long cafeId = 카페_생성_요청하고_아이디_반환(accessTokenOwner, cafeCreateRequest);

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/ManagerRewardFindAcceptanceTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/ManagerRewardFindAcceptanceTest.java
@@ -6,19 +6,20 @@ import com.stampcrush.backend.api.manager.coupon.request.StampCreateRequest;
 import com.stampcrush.backend.api.manager.reward.response.RewardFindResponse;
 import com.stampcrush.backend.api.manager.reward.response.RewardsFindResponse;
 import com.stampcrush.backend.auth.api.request.OAuthRegisterCustomerCreateRequest;
-import com.stampcrush.backend.auth.api.request.OAuthRegisterOwnerCreateRequest;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static com.stampcrush.backend.acceptance.ManagerRewardCommandAcceptanceTest.*;
 import static com.stampcrush.backend.acceptance.step.ManagerCafeCreateStep.카페_생성_요청하고_아이디_반환;
 import static com.stampcrush.backend.acceptance.step.ManagerCouponCreateStep.쿠폰_생성_요청하고_아이디_반환;
+import static com.stampcrush.backend.acceptance.step.ManagerJoinStep.OWNER_CREATE_REQUEST;
+import static com.stampcrush.backend.acceptance.step.ManagerJoinStep.OWNER_CREATE_REQUEST_2;
 import static com.stampcrush.backend.acceptance.step.ManagerJoinStep.카페_사장_회원_가입_요청하고_액세스_토큰_반환;
 import static com.stampcrush.backend.acceptance.step.ManagerRewardStep.리워드_목록_조회;
 import static com.stampcrush.backend.acceptance.step.ManagerStampCreateStep.쿠폰에_스탬프를_적립_요청;
+import static com.stampcrush.backend.acceptance.step.VisitorJoinStep.O_AUTH_REGISTER_CUSTOMER_CREATE_REQUEST_JENA;
 import static com.stampcrush.backend.acceptance.step.VisitorJoinStep.가입_고객_회원_가입_요청하고_액세스_토큰_반환;
 import static com.stampcrush.backend.auth.OAuthProvider.KAKAO;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -30,12 +31,10 @@ class ManagerRewardFindAcceptanceTest extends AcceptanceTest {
     @Test
     void 카페사장이_가입_회원의_리워드를_조회한다() {
         // given
-        OAuthRegisterCustomerCreateRequest registerCustomerCreateRequest = O_AUTH_REGISTER_CUSTOMER_CREATE_REQUEST_JENA;
-        String accessTokenCustomer = 가입_고객_회원_가입_요청하고_액세스_토큰_반환(registerCustomerCreateRequest);
+        String accessTokenCustomer = 가입_고객_회원_가입_요청하고_액세스_토큰_반환(O_AUTH_REGISTER_CUSTOMER_CREATE_REQUEST_JENA);
         Long customerId = authTokensGenerator.extractMemberId(accessTokenCustomer);
 
-        OAuthRegisterOwnerCreateRequest registerOwnerCreateRequest = O_AUTH_OWNER_CREATE_REQUEST;
-        String accessTokenOwner = 카페_사장_회원_가입_요청하고_액세스_토큰_반환(registerOwnerCreateRequest);
+        String accessTokenOwner = 카페_사장_회원_가입_요청하고_액세스_토큰_반환(OWNER_CREATE_REQUEST);
 
         CafeCreateRequest cafeCreateRequest = new CafeCreateRequest("cafe", "잠실", "루터회관", "111111111");
         Long cafeId = 카페_생성_요청하고_아이디_반환(accessTokenOwner, cafeCreateRequest);
@@ -55,15 +54,11 @@ class ManagerRewardFindAcceptanceTest extends AcceptanceTest {
     @Test
     void 자신의_카페가_아니면_리워드_조회_불가능하다() {
         // given
-        OAuthRegisterCustomerCreateRequest registerCustomerCreateRequest = O_AUTH_REGISTER_CUSTOMER_CREATE_REQUEST_JENA;
-        String accessTokenCustomer = 가입_고객_회원_가입_요청하고_액세스_토큰_반환(registerCustomerCreateRequest);
+        String accessTokenCustomer = 가입_고객_회원_가입_요청하고_액세스_토큰_반환(O_AUTH_REGISTER_CUSTOMER_CREATE_REQUEST_JENA);
         Long customerId = authTokensGenerator.extractMemberId(accessTokenCustomer);
 
-        OAuthRegisterOwnerCreateRequest registerOwnerCreateRequest = O_AUTH_OWNER_CREATE_REQUEST;
-        String accessTokenOwner = 카페_사장_회원_가입_요청하고_액세스_토큰_반환(registerOwnerCreateRequest);
-
-        OAuthRegisterOwnerCreateRequest registerNotOwnerCreateRequest = O_AUTH_OWNER_CREATE_REQUEST_2;
-        String accessTokenNotOwner = 카페_사장_회원_가입_요청하고_액세스_토큰_반환(registerNotOwnerCreateRequest);
+        String accessTokenOwner = 카페_사장_회원_가입_요청하고_액세스_토큰_반환(OWNER_CREATE_REQUEST);
+        String accessTokenNotOwner = 카페_사장_회원_가입_요청하고_액세스_토큰_반환(OWNER_CREATE_REQUEST_2);
 
         CafeCreateRequest cafeCreateRequest = new CafeCreateRequest("cafe", "잠실", "루터회관", "111111111");
         Long cafeId = 카페_생성_요청하고_아이디_반환(accessTokenOwner, cafeCreateRequest);
@@ -82,8 +77,7 @@ class ManagerRewardFindAcceptanceTest extends AcceptanceTest {
     @Test
     void 자신의_카페_고객이_아니면_리워드_조회가_불가능하다() {
         // given
-        OAuthRegisterOwnerCreateRequest registerOwnerCreateRequest = O_AUTH_OWNER_CREATE_REQUEST;
-        String accessTokenOwner = 카페_사장_회원_가입_요청하고_액세스_토큰_반환(registerOwnerCreateRequest);
+        String accessTokenOwner = 카페_사장_회원_가입_요청하고_액세스_토큰_반환(OWNER_CREATE_REQUEST);
 
         OAuthRegisterCustomerCreateRequest registerNotCustomerCreateRequest =
                 new OAuthRegisterCustomerCreateRequest("notCustomer", "aa@naver.com", KAKAO, 392816L);

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/ManagerSampleCouponFindAcceptanceTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/ManagerSampleCouponFindAcceptanceTest.java
@@ -21,18 +21,6 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 class ManagerSampleCouponFindAcceptanceTest extends AcceptanceTest {
 
-    @Autowired
-    private SampleFrontImageRepository sampleFrontImageRepository;
-
-    @Autowired
-    private SampleBackImageRepository sampleBackImageRepository;
-
-    @Autowired
-    private SampleStampCoordinateRepository sampleStampCoordinateRepository;
-
-    @Autowired
-    private SampleStampImageRepository sampleStampImageRepository;
-
     @BeforeEach
     void setUp() {
         sampleFrontImageRepository.save(SAMPLE_FRONT_IMAGE);

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/VisitorCafeFindAcceptanceTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/VisitorCafeFindAcceptanceTest.java
@@ -3,19 +3,17 @@ package com.stampcrush.backend.acceptance;
 import com.stampcrush.backend.api.visitor.cafe.response.CafeInfoFindByCustomerResponse;
 import com.stampcrush.backend.api.visitor.cafe.response.CafeInfoFindResponse;
 import com.stampcrush.backend.application.visitor.cafe.dto.CafeInfoFindByCustomerResultDto;
-import com.stampcrush.backend.auth.api.request.OAuthRegisterCustomerCreateRequest;
-import com.stampcrush.backend.auth.api.request.OAuthRegisterOwnerCreateRequest;
 import com.stampcrush.backend.entity.cafe.Cafe;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import org.junit.jupiter.api.Test;
 
-import static com.stampcrush.backend.acceptance.ManagerRewardCommandAcceptanceTest.O_AUTH_OWNER_CREATE_REQUEST;
-import static com.stampcrush.backend.acceptance.ManagerRewardCommandAcceptanceTest.O_AUTH_REGISTER_CUSTOMER_CREATE_REQUEST_JENA;
 import static com.stampcrush.backend.acceptance.step.ManagerCafeCreateStep.CAFE_CREATE_REQUEST;
 import static com.stampcrush.backend.acceptance.step.ManagerCafeCreateStep.카페_생성_요청하고_아이디_반환;
+import static com.stampcrush.backend.acceptance.step.ManagerJoinStep.OWNER_CREATE_REQUEST;
 import static com.stampcrush.backend.acceptance.step.ManagerJoinStep.카페_사장_회원_가입_요청하고_액세스_토큰_반환;
 import static com.stampcrush.backend.acceptance.step.VisitorCafeFindStep.고객의_카페_정보_조회_요청;
+import static com.stampcrush.backend.acceptance.step.VisitorJoinStep.O_AUTH_REGISTER_CUSTOMER_CREATE_REQUEST_JENA;
 import static com.stampcrush.backend.acceptance.step.VisitorJoinStep.가입_고객_회원_가입_요청하고_액세스_토큰_반환;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
@@ -25,11 +23,9 @@ class VisitorCafeFindAcceptanceTest extends AcceptanceTest {
     @Test
     void 고객이_카페정보를_조회한다() {
         // given
-        OAuthRegisterCustomerCreateRequest registerCustomerCreateRequest = O_AUTH_REGISTER_CUSTOMER_CREATE_REQUEST_JENA;
-        String accessTokenCustomer = 가입_고객_회원_가입_요청하고_액세스_토큰_반환(registerCustomerCreateRequest);
+        String accessTokenCustomer = 가입_고객_회원_가입_요청하고_액세스_토큰_반환(O_AUTH_REGISTER_CUSTOMER_CREATE_REQUEST_JENA);
 
-        OAuthRegisterOwnerCreateRequest registerOwnerCreateRequest = O_AUTH_OWNER_CREATE_REQUEST;
-        String accessTokenOwner = 카페_사장_회원_가입_요청하고_액세스_토큰_반환(registerOwnerCreateRequest);
+        String accessTokenOwner = 카페_사장_회원_가입_요청하고_액세스_토큰_반환(OWNER_CREATE_REQUEST);
 
         Long cafeId = 카페_생성_요청하고_아이디_반환(accessTokenOwner, CAFE_CREATE_REQUEST);
         Cafe cafe = cafeRepository.findById(cafeId).get();
@@ -46,8 +42,7 @@ class VisitorCafeFindAcceptanceTest extends AcceptanceTest {
 
     @Test
     void 고객이_존재하지_않는_카페를_조회하면_에러가_발생한다() {
-        OAuthRegisterCustomerCreateRequest registerCustomerCreateRequest = O_AUTH_REGISTER_CUSTOMER_CREATE_REQUEST_JENA;
-        String accessTokenCustomer = 가입_고객_회원_가입_요청하고_액세스_토큰_반환(registerCustomerCreateRequest);
+        String accessTokenCustomer = 가입_고객_회원_가입_요청하고_액세스_토큰_반환(O_AUTH_REGISTER_CUSTOMER_CREATE_REQUEST_JENA);
 
         long NOT_EXIST_CAFE_ID = 1L;
         ExtractableResponse<Response> response = 고객의_카페_정보_조회_요청(accessTokenCustomer, NOT_EXIST_CAFE_ID);

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/VisitorFavoritesCommandAcceptanceTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/VisitorFavoritesCommandAcceptanceTest.java
@@ -22,9 +22,6 @@ import static org.springframework.http.HttpStatus.OK;
 
 class VisitorFavoritesCommandAcceptanceTest extends AcceptanceTest {
 
-    @Autowired
-    private FavoritesRepository favoritesRepository;
-
     @Test
     void 즐겨찾기를_등록한다() {
         // given

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/VisitorLinkDataAcceptanceTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/VisitorLinkDataAcceptanceTest.java
@@ -2,8 +2,6 @@ package com.stampcrush.backend.acceptance;
 
 import com.stampcrush.backend.api.manager.customer.request.TemporaryCustomerCreateRequest;
 import com.stampcrush.backend.api.visitor.profile.request.VisitorProfilesLinkDataRequest;
-import com.stampcrush.backend.auth.OAuthProvider;
-import com.stampcrush.backend.auth.api.request.OAuthRegisterCustomerCreateRequest;
 import com.stampcrush.backend.entity.user.Customer;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
@@ -14,18 +12,12 @@ import static com.stampcrush.backend.acceptance.step.ManagerJoinStep.OWNER_CREAT
 import static com.stampcrush.backend.acceptance.step.ManagerJoinStep.카페_사장_회원_가입_요청하고_액세스_토큰_반환;
 import static com.stampcrush.backend.acceptance.step.VisitorJoinStep.가입_고객_회원_가입_요청하고_액세스_토큰_반환;
 import static com.stampcrush.backend.acceptance.step.VisitorJoinStep.임시_고객_회원_가입_요청하고_아이디_반환;
+import static com.stampcrush.backend.acceptance.step.VisitorJoinStep.REGISTER_CUSTOMER_GITCHAN_CREATE_REQUEST;
 import static com.stampcrush.backend.acceptance.step.VisitorLinkDataStep.회원_데이터_연동_요청;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 class VisitorLinkDataAcceptanceTest extends AcceptanceTest {
-
-    private static final OAuthRegisterCustomerCreateRequest O_AUTH_REGISTER_CUSTOMER_CREATE_REQUEST = new OAuthRegisterCustomerCreateRequest(
-            "깃짱",
-            "gitchan@gmail.com",
-            OAuthProvider.KAKAO,
-            1235436L
-    );
 
     @Test
     void 기존_임시회원의_데이터와_연동한다() {
@@ -35,8 +27,7 @@ class VisitorLinkDataAcceptanceTest extends AcceptanceTest {
         Long temporaryCustomerId = 임시_고객_회원_가입_요청하고_아이디_반환(ownerAccessToken, temporaryCustomerCreateRequest);
         Customer temporaryCustomer = customerRepository.findById(temporaryCustomerId).get();
 
-        OAuthRegisterCustomerCreateRequest registerCustomerCreateRequest = O_AUTH_REGISTER_CUSTOMER_CREATE_REQUEST;
-        String accessToken = 가입_고객_회원_가입_요청하고_액세스_토큰_반환(registerCustomerCreateRequest);
+        String accessToken = 가입_고객_회원_가입_요청하고_액세스_토큰_반환(REGISTER_CUSTOMER_GITCHAN_CREATE_REQUEST);
         Long registerCustomerId = authTokensGenerator.extractMemberId(accessToken);
 
         ExtractableResponse<Response> response = 회원_데이터_연동_요청(accessToken, new VisitorProfilesLinkDataRequest(temporaryCustomer.getId()));
@@ -45,9 +36,9 @@ class VisitorLinkDataAcceptanceTest extends AcceptanceTest {
 
         assertAll(
                 () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
-                () -> assertThat(linkedCustomer.getNickname()).isEqualTo(registerCustomerCreateRequest.getNickname()),
-                () -> assertThat(linkedCustomer.getOAuthProvider()).isEqualTo(registerCustomerCreateRequest.getoAuthProvider()),
-                () -> assertThat(linkedCustomer.getOAuthId()).isEqualTo(registerCustomerCreateRequest.getoAuthId()),
+                () -> assertThat(linkedCustomer.getNickname()).isEqualTo(REGISTER_CUSTOMER_GITCHAN_CREATE_REQUEST.getNickname()),
+                () -> assertThat(linkedCustomer.getOAuthProvider()).isEqualTo(REGISTER_CUSTOMER_GITCHAN_CREATE_REQUEST.getoAuthProvider()),
+                () -> assertThat(linkedCustomer.getOAuthId()).isEqualTo(REGISTER_CUSTOMER_GITCHAN_CREATE_REQUEST.getoAuthId()),
                 () -> assertThat(customerRepository.findById(registerCustomerId)).isEmpty()
         );
     }

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/VisitorProfilesCommandAcceptanceTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/VisitorProfilesCommandAcceptanceTest.java
@@ -1,15 +1,11 @@
 package com.stampcrush.backend.acceptance;
 
 import com.stampcrush.backend.api.visitor.profile.request.VisitorProfilesPhoneNumberUpdateRequest;
-import com.stampcrush.backend.auth.OAuthProvider;
-import com.stampcrush.backend.auth.api.request.OAuthRegisterCustomerCreateRequest;
-import com.stampcrush.backend.entity.user.Customer;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
-import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 
+import static com.stampcrush.backend.acceptance.step.VisitorJoinStep.REGISTER_CUSTOMER_GITCHAN_CREATE_REQUEST;
 import static com.stampcrush.backend.acceptance.step.VisitorJoinStep.가입_고객_회원_가입_요청하고_액세스_토큰_반환;
 import static com.stampcrush.backend.acceptance.step.VisitorProfilesCommandStep.고객의_전화번호_등록_요청;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -17,54 +13,12 @@ import static org.springframework.http.HttpStatus.OK;
 
 class VisitorProfilesCommandAcceptanceTest extends AcceptanceTest {
 
-    private static final Customer OAUTH_REGISTER_CUSTOMER = Customer.registeredCustomerBuilder()
-            .nickname("깃짱")
-            .email("gitchan@naver.com")
-            .oAuthId(1L)
-            .oAuthProvider(OAuthProvider.KAKAO)
-            .loginId(null)
-            .encryptedPassword(null)
-            .build();
-
-    @Autowired
-    private EntityManager entityManager;
-
     @Test
     void 고객의_전화번호를_저장한다() {
-        Customer customer = OAUTH_REGISTER_CUSTOMER;
-        OAuthRegisterCustomerCreateRequest request = new OAuthRegisterCustomerCreateRequest(
-                customer.getNickname(),
-                customer.getEmail(),
-                customer.getOAuthProvider(),
-                customer.getOAuthId()
-        );
-
-        String accessToken = 가입_고객_회원_가입_요청하고_액세스_토큰_반환(request);
+        String accessToken = 가입_고객_회원_가입_요청하고_액세스_토큰_반환(REGISTER_CUSTOMER_GITCHAN_CREATE_REQUEST);
 
         ExtractableResponse<Response> response = 고객의_전화번호_등록_요청(accessToken, new VisitorProfilesPhoneNumberUpdateRequest("01012345678"));
 
         assertThat(response.statusCode()).isEqualTo(OK.value());
     }
-
-//    @Test
-//    @Disabled
-//        // TODO: 상황 연출이 어려움....!
-//    void 중복되는_전화번호로_요청하면_예외가_발생한다() {
-//        EntityTransaction transaction = entityManager.getTransaction();
-//
-//        transaction.begin();
-//        Customer recentCustomer = customerRepository.save(REGISTER_CUSTOMER_GITCHAN);
-//        transaction.commit();
-//
-//        transaction.begin();
-//        Customer newOAuthRegisterCustomer = OAUTH_REGISTER_CUSTOMER;
-//        newOAuthRegisterCustomer.registerLoginId("loginId");
-//        newOAuthRegisterCustomer.registerEncryptedPassword("password");
-//        Customer newCustomer = customerRepository.save(newOAuthRegisterCustomer);
-//        transaction.commit();
-//
-//        ExtractableResponse<Response> response = 고객의_전화번호_등록_요청(newCustomer, new VisitorProfilesPhoneNumberUpdateRequest(recentCustomer.getPhoneNumber()));
-//
-//        assertThat(response.statusCode()).isEqualTo(BAD_REQUEST.value());
-//    }
 }

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/step/VisitorJoinStep.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/step/VisitorJoinStep.java
@@ -16,6 +16,13 @@ public class VisitorJoinStep {
             "깃짱", "gitchan@naver.com", OAuthProvider.KAKAO, 123142L
     );
 
+    public static final OAuthRegisterCustomerCreateRequest O_AUTH_REGISTER_CUSTOMER_CREATE_REQUEST_JENA = new OAuthRegisterCustomerCreateRequest(
+            "jena",
+            "jena@gmail.com",
+            OAuthProvider.KAKAO,
+            938272L
+    );
+
     public static final TemporaryCustomerCreateRequest TEMPORARY_CUSTOMER_CREATE_REQUEST = new TemporaryCustomerCreateRequest("01012345678");
 
     public static Long 임시_고객_회원_가입_요청하고_아이디_반환(String accessToken, TemporaryCustomerCreateRequest request) {


### PR DESCRIPTION
## 주요 변경사항

- Acceptance 테스트에서 사용하는 모든 빈을 최상위 AcceptanceTest 에서 상속받게 다 상위로 올렸습니다
- 기존 존재하는 Fixture 사용 안하고 있는 메서드들 Fixture 사용하도록 수정했습니다

## 리뷰어에게...

## 관련 이슈

closes

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [x] `milestone` 설정
