### PR TITLE
[BE] refactor: Controller Test 코드를 리팩터링한다

### DIFF
--- a/backend/src/test/java/com/stampcrush/backend/acceptance/ManagerCouponCommandAcceptanceTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/ManagerCouponCommandAcceptanceTest.java
@@ -392,25 +392,4 @@ class ManagerCouponCommandAcceptanceTest extends AcceptanceTest {
         assertThat(coupons.getCoupons()).usingRecursiveFieldByFieldElementComparatorIgnoringFields("expireDate")
                 .containsExactlyInAnyOrder(expected);
     }
-
-    @Test
-    void 스탬프_10개_초과_적립_요청하면_예외_발생한다() {
-        // given
-        String ownerToken = 카페_사장_회원_가입_요청하고_액세스_토큰_반환(new OAuthRegisterOwnerCreateRequest("leo", OAuthProvider.KAKAO, 123L));
-
-        Long savedCafeId = 카페_생성_요청하고_아이디_반환(ownerToken, CAFE_CREATE_REQUEST);
-        String customerToken = 가입_고객_회원_가입_요청하고_액세스_토큰_반환(new OAuthRegisterCustomerCreateRequest("customer", "email", OAuthProvider.KAKAO, 123L));
-        Long customerId = authTokensGenerator.extractMemberId(customerToken);
-
-        CouponCreateRequest request = new CouponCreateRequest(savedCafeId);
-
-        Long couponId = 쿠폰_생성_요청하고_아이디_반환(ownerToken, request, customerId);
-
-        // when
-        StampCreateRequest stampCreateRequest = new StampCreateRequest(11);
-        ExtractableResponse<Response> response = 쿠폰에_스탬프를_적립_요청(ownerToken, customerId, couponId, stampCreateRequest);
-
-        // then
-        assertThat(response.statusCode()).isEqualTo(BAD_REQUEST.value());
-    }
 }

--- a/backend/src/test/java/com/stampcrush/backend/api/ControllerSliceTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/ControllerSliceTest.java
@@ -3,6 +3,21 @@ package com.stampcrush.backend.api;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.stampcrush.backend.api.manager.cafe.ManagerCafeCouponSettingCommandApiController;
 import com.stampcrush.backend.api.manager.cafe.ManagerCafeCouponSettingFindApiController;
+import com.stampcrush.backend.api.manager.cafe.ManagerCafeFindApiController;
+import com.stampcrush.backend.api.manager.coupon.ManagerCouponCommandApiController;
+import com.stampcrush.backend.api.manager.coupon.ManagerCouponFindApiController;
+import com.stampcrush.backend.api.manager.owner.ManagerCommandApiController;
+import com.stampcrush.backend.api.manager.reward.ManagerRewardCommandApiController;
+import com.stampcrush.backend.api.manager.reward.ManagerRewardFindApiController;
+import com.stampcrush.backend.api.manager.sample.ManagerSampleCouponFindApiController;
+import com.stampcrush.backend.api.visitor.cafe.VisitorCafeFindApiController;
+import com.stampcrush.backend.api.visitor.coupon.VisitorCouponCommandApiController;
+import com.stampcrush.backend.api.visitor.coupon.VisitorCouponFindApiController;
+import com.stampcrush.backend.api.visitor.favorites.VisitorFavoritesCommandApiController;
+import com.stampcrush.backend.api.visitor.profile.VisitorProfilesCommandApiController;
+import com.stampcrush.backend.api.visitor.profile.VisitorProfilesFindApiController;
+import com.stampcrush.backend.api.visitor.reward.VisitorRewardsFindController;
+import com.stampcrush.backend.api.visitor.visithistory.VisitorVisitHistoryFindApiController;
 import com.stampcrush.backend.application.manager.cafe.ManagerCafeCouponSettingCommandService;
 import com.stampcrush.backend.application.manager.cafe.ManagerCafeCouponSettingFindService;
 import com.stampcrush.backend.application.manager.cafe.ManagerCafeFindService;
@@ -38,8 +53,21 @@ import org.springframework.test.web.servlet.MockMvc;
 @KorNamingConverter
 @WebMvcTest(value = {ManagerCafeCouponSettingCommandApiController.class,
         ManagerCafeCouponSettingFindApiController.class,
-
-
+        ManagerCafeFindApiController.class,
+        ManagerCouponCommandApiController.class,
+        ManagerCouponFindApiController.class,
+        ManagerCommandApiController.class,
+        ManagerRewardFindApiController.class,
+        ManagerRewardCommandApiController.class,
+        ManagerSampleCouponFindApiController.class,
+        VisitorCafeFindApiController.class,
+        VisitorCouponCommandApiController.class,
+        VisitorCouponFindApiController.class,
+        VisitorFavoritesCommandApiController.class,
+        VisitorProfilesCommandApiController.class,
+        VisitorProfilesFindApiController.class,
+        VisitorRewardsFindController.class,
+        VisitorVisitHistoryFindApiController.class
 },
         excludeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebMvcConfig.class))
 public abstract class ControllerSliceTest {

--- a/backend/src/test/java/com/stampcrush/backend/api/ControllerSliceTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/ControllerSliceTest.java
@@ -1,8 +1,29 @@
 package com.stampcrush.backend.api;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.stampcrush.backend.api.manager.cafe.ManagerCafeCouponSettingCommandApiController;
+import com.stampcrush.backend.api.manager.cafe.ManagerCafeCouponSettingFindApiController;
+import com.stampcrush.backend.application.manager.cafe.ManagerCafeCouponSettingCommandService;
+import com.stampcrush.backend.application.manager.cafe.ManagerCafeCouponSettingFindService;
+import com.stampcrush.backend.application.manager.cafe.ManagerCafeFindService;
+import com.stampcrush.backend.application.manager.coupon.ManagerCouponCommandService;
+import com.stampcrush.backend.application.manager.coupon.ManagerCouponFindService;
+import com.stampcrush.backend.application.manager.owner.ManagerCommandService;
+import com.stampcrush.backend.application.manager.reward.ManagerRewardCommandService;
+import com.stampcrush.backend.application.manager.reward.ManagerRewardFindService;
+import com.stampcrush.backend.application.manager.sample.ManagerSampleCouponFindService;
+import com.stampcrush.backend.application.visitor.cafe.VisitorCafeFindService;
+import com.stampcrush.backend.application.visitor.coupon.VisitorCouponCommandService;
+import com.stampcrush.backend.application.visitor.coupon.VisitorCouponFindService;
+import com.stampcrush.backend.application.visitor.favorites.VisitorFavoritesCommandService;
+import com.stampcrush.backend.application.visitor.profile.VisitorProfilesCommandService;
+import com.stampcrush.backend.application.visitor.profile.VisitorProfilesFindService;
+import com.stampcrush.backend.application.visitor.reward.VisitorRewardsFindService;
+import com.stampcrush.backend.application.visitor.visithistory.VisitorVisitHistoryFindService;
 import com.stampcrush.backend.auth.application.util.AuthTokensGenerator;
 import com.stampcrush.backend.auth.application.util.JwtTokenProvider;
 import com.stampcrush.backend.common.KorNamingConverter;
+import com.stampcrush.backend.config.WebMvcConfig;
 import com.stampcrush.backend.repository.cafe.CafeRepository;
 import com.stampcrush.backend.repository.user.CustomerRepository;
 import com.stampcrush.backend.repository.user.OwnerRepository;
@@ -10,27 +31,88 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.test.web.servlet.MockMvc;
 
 @KorNamingConverter
-@WebMvcTest
+@WebMvcTest(value = {ManagerCafeCouponSettingCommandApiController.class,
+        ManagerCafeCouponSettingFindApiController.class,
+
+
+},
+        excludeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebMvcConfig.class))
 public abstract class ControllerSliceTest {
 
     @Autowired
-    public MockMvc mockMvc;
+    protected MockMvc mockMvc;
+
+    @Autowired
+    protected ObjectMapper objectMapper;
 
     @MockBean
-    public OwnerRepository ownerRepository;
+    protected ManagerCafeCouponSettingCommandService managerCafeCouponSettingCommandService;
 
     @MockBean
-    public CustomerRepository customerRepository;
+    protected ManagerCafeCouponSettingFindService cafeCouponSettingFindService;
 
     @MockBean
-    public CafeRepository cafeRepository;
+    protected ManagerCafeFindService managerCafeFindService;
+
+    @MockBean
+    protected ManagerCouponCommandService managerCouponCommandService;
+
+    @MockBean
+    protected ManagerCouponFindService managerCouponFindService;
+
+    @MockBean
+    protected ManagerCommandService managerCommandService;
+
+    @MockBean
+    protected ManagerRewardFindService managerRewardFindService;
+
+    @MockBean
+    protected ManagerRewardCommandService managerRewardCommandService;
+
+    @MockBean
+    protected ManagerSampleCouponFindService managerSampleCouponFindService;
+
+    @MockBean
+    protected VisitorCafeFindService visitorCafeFindService;
+
+    @MockBean
+    protected VisitorCouponCommandService visitorCouponCommandService;
+
+    @MockBean
+    protected VisitorCouponFindService visitorCouponFindService;
+
+    @MockBean
+    protected VisitorFavoritesCommandService visitorFavoritesCommandService;
+
+    @MockBean
+    protected VisitorProfilesFindService visitorProfilesFindService;
+
+    @MockBean
+    protected VisitorProfilesCommandService visitorProfilesCommandService;
+
+    @MockBean
+    protected VisitorRewardsFindService visitorRewardsFindService;
+
+    @MockBean
+    protected VisitorVisitHistoryFindService visitorVisitHistoryFindService;
+
+    @MockBean
+    private OwnerRepository ownerRepository;
+
+    @MockBean
+    private CustomerRepository customerRepository;
+
+    @MockBean
+    private CafeRepository cafeRepository;
 
     @SpyBean
-    public AuthTokensGenerator authTokensGenerator;
+    private AuthTokensGenerator authTokensGenerator;
 
     @SpyBean
-    public JwtTokenProvider jwtTokenProvider;
+    private JwtTokenProvider jwtTokenProvider;
 }

--- a/backend/src/test/java/com/stampcrush/backend/api/manager/cafe/ManagerCafeCouponSettingCommandApiControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/manager/cafe/ManagerCafeCouponSettingCommandApiControllerTest.java
@@ -1,68 +1,43 @@
 package com.stampcrush.backend.api.manager.cafe;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.stampcrush.backend.api.ControllerSliceTest;
 import com.stampcrush.backend.api.manager.cafe.request.CafeCouponSettingUpdateRequest;
-import com.stampcrush.backend.application.manager.cafe.ManagerCafeCouponSettingCommandService;
 import com.stampcrush.backend.config.WebMvcConfig;
-import com.stampcrush.backend.entity.user.Owner;
-import com.stampcrush.backend.fixture.OwnerFixture;
-import com.stampcrush.backend.helper.AuthHelper.OwnerAuthorization;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
 
 import java.util.List;
-import java.util.Optional;
 
-import static com.stampcrush.backend.helper.AuthHelper.createOwnerAuthorization;
-import static org.mockito.Mockito.when;
-import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WebMvcTest(value = ManagerCafeCouponSettingCommandApiController.class,
-     excludeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebMvcConfig.class))
 class ManagerCafeCouponSettingCommandApiControllerTest extends ControllerSliceTest {
 
-    private static final CafeCouponSettingUpdateRequest CAFE_COUPON_SETTING_UPDATE_REQUEST = new CafeCouponSettingUpdateRequest(
-            "frontImageUrl",
-            "backImageUrl",
-            "stampImageUrl",
-            List.of(new CafeCouponSettingUpdateRequest.CouponStampCoordinateRequest(1, 1, 1)),
-            "reward",
-            6
-    );
-
-    @MockBean
-    private ManagerCafeCouponSettingCommandService managerCafeCouponSettingCommandService;
-
     @Test
-    void 카페_쿠폰_정책_변경_시_인증이_되면_204_상태코드와_응답을_반환한다() throws Exception {
-        Owner owner = OwnerFixture.GITCHAN;
+    void 카페_쿠폰_정책_변경_시_204_상태코드와_응답을_반환한다() throws Exception {
+        // given
+        CafeCouponSettingUpdateRequest request = new CafeCouponSettingUpdateRequest(
+                "frontImageUrl",
+                "backImageUrl",
+                "stampImageUrl",
+                List.of(new CafeCouponSettingUpdateRequest.CouponStampCoordinateRequest(1, 1, 1)),
+                "reward",
+                6
+        );
 
-        OwnerAuthorization ownerAuthorization = createOwnerAuthorization(owner);
+        doNothing().when(managerCafeCouponSettingCommandService).updateCafeCouponSetting(any(), any(), any());
 
-        when(ownerRepository.findByLoginId(ownerAuthorization.getOwner().getLoginId()))
-                .thenReturn(Optional.of(owner));
-
-        String requestBody = formatRequestBody(CAFE_COUPON_SETTING_UPDATE_REQUEST);
-
+        // when, then
         mockMvc.perform(
                         post("/api/admin/coupon-setting?cafe-id=1")
                                 .contentType(APPLICATION_JSON)
-                                .content(requestBody)
-                                .header(AUTHORIZATION, ownerAuthorization.getBasicAuthHeader())
+                                .content(objectMapper.writeValueAsString(request))
                 )
                 .andExpect(status().isNoContent());
-    }
-
-    private String formatRequestBody(CafeCouponSettingUpdateRequest request) throws JsonProcessingException {
-        ObjectMapper objectMapper = new ObjectMapper();
-        return objectMapper.writeValueAsString(request);
     }
 }

--- a/backend/src/test/java/com/stampcrush/backend/api/manager/cafe/ManagerCafeCouponSettingFindApiControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/manager/cafe/ManagerCafeCouponSettingFindApiControllerTest.java
@@ -21,12 +21,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WebMvcTest(value = ManagerCafeCouponSettingFindApiController.class,
-        excludeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebMvcConfig.class))
 class ManagerCafeCouponSettingFindApiControllerTest extends ControllerSliceTest {
-
-    @MockBean
-    private ManagerCafeCouponSettingFindService cafeCouponSettingFindService;
 
     @Test
     void 카페의_카페_쿠폰_세팅을_조회한다() throws Exception {

--- a/backend/src/test/java/com/stampcrush/backend/api/manager/cafe/ManagerCafeCouponSettingFindApiControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/manager/cafe/ManagerCafeCouponSettingFindApiControllerTest.java
@@ -23,7 +23,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @WebMvcTest(value = ManagerCafeCouponSettingFindApiController.class,
         excludeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebMvcConfig.class))
-public class ManagerCafeCouponSettingFindApiControllerTest extends ControllerSliceTest {
+class ManagerCafeCouponSettingFindApiControllerTest extends ControllerSliceTest {
 
     @MockBean
     private ManagerCafeCouponSettingFindService cafeCouponSettingFindService;

--- a/backend/src/test/java/com/stampcrush/backend/api/manager/cafe/ManagerCafeFindApiControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/manager/cafe/ManagerCafeFindApiControllerTest.java
@@ -1,14 +1,8 @@
 package com.stampcrush.backend.api.manager.cafe;
 
 import com.stampcrush.backend.api.ControllerSliceTest;
-import com.stampcrush.backend.application.manager.cafe.ManagerCafeFindService;
 import com.stampcrush.backend.application.manager.cafe.dto.CafeFindResultDto;
-import com.stampcrush.backend.config.WebMvcConfig;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.FilterType;
 import org.springframework.http.MediaType;
 
 import java.time.LocalTime;
@@ -21,8 +15,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WebMvcTest(value = ManagerCafeFindApiController.class,
-        excludeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebMvcConfig.class))
 class ManagerCafeFindApiControllerTest extends ControllerSliceTest {
 
     @Test

--- a/backend/src/test/java/com/stampcrush/backend/api/manager/cafe/ManagerCafeFindApiControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/manager/cafe/ManagerCafeFindApiControllerTest.java
@@ -25,9 +25,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
         excludeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebMvcConfig.class))
 class ManagerCafeFindApiControllerTest extends ControllerSliceTest {
 
-    @MockBean
-    private ManagerCafeFindService managerCafeFindService;
-
     @Test
     void 사장이_자신의_카페를_조회한다() throws Exception {
         // given

--- a/backend/src/test/java/com/stampcrush/backend/api/manager/coupon/ManagerCouponCommandApiControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/manager/coupon/ManagerCouponCommandApiControllerTest.java
@@ -4,11 +4,7 @@ import com.stampcrush.backend.api.ControllerSliceTest;
 import com.stampcrush.backend.api.manager.coupon.request.CouponCreateRequest;
 import com.stampcrush.backend.api.manager.coupon.request.StampCreateRequest;
 import com.stampcrush.backend.api.manager.coupon.response.CouponCreateResponse;
-import com.stampcrush.backend.config.WebMvcConfig;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.FilterType;
 import org.springframework.test.web.servlet.MvcResult;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -18,9 +14,7 @@ import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WebMvcTest(value = ManagerCouponCommandApiController.class,
-        excludeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebMvcConfig.class))
-public class ManagerCouponCommandApiControllerTest extends ControllerSliceTest {
+class ManagerCouponCommandApiControllerTest extends ControllerSliceTest {
 
     public static String API_PREFIX = "/api/admin";
 

--- a/backend/src/test/java/com/stampcrush/backend/api/manager/coupon/ManagerCouponCommandApiControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/manager/coupon/ManagerCouponCommandApiControllerTest.java
@@ -1,16 +1,12 @@
 package com.stampcrush.backend.api.manager.coupon;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.stampcrush.backend.api.ControllerSliceTest;
 import com.stampcrush.backend.api.manager.coupon.request.CouponCreateRequest;
 import com.stampcrush.backend.api.manager.coupon.request.StampCreateRequest;
 import com.stampcrush.backend.api.manager.coupon.response.CouponCreateResponse;
-import com.stampcrush.backend.application.manager.coupon.ManagerCouponCommandService;
 import com.stampcrush.backend.config.WebMvcConfig;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
 import org.springframework.test.web.servlet.MvcResult;
@@ -25,12 +21,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest(value = ManagerCouponCommandApiController.class,
         excludeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebMvcConfig.class))
 public class ManagerCouponCommandApiControllerTest extends ControllerSliceTest {
-
-    @Autowired
-    private ObjectMapper objectMapper;
-
-    @MockBean
-    private ManagerCouponCommandService managerCouponCommandService;
 
     public static String API_PREFIX = "/api/admin";
 

--- a/backend/src/test/java/com/stampcrush/backend/api/manager/coupon/ManagerCouponFindApiControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/manager/coupon/ManagerCouponFindApiControllerTest.java
@@ -1,14 +1,8 @@
 package com.stampcrush.backend.api.manager.coupon;
 
 import com.stampcrush.backend.api.ControllerSliceTest;
-import com.stampcrush.backend.application.manager.coupon.ManagerCouponFindService;
 import com.stampcrush.backend.application.manager.coupon.dto.CafeCustomerFindResultDto;
-import com.stampcrush.backend.config.WebMvcConfig;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.FilterType;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -19,9 +13,7 @@ import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WebMvcTest(value = ManagerCouponFindApiController.class,
-        excludeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebMvcConfig.class))
-public class ManagerCouponFindApiControllerTest extends ControllerSliceTest {
+class ManagerCouponFindApiControllerTest extends ControllerSliceTest {
 
     public static String API_PREFIX = "/api/admin";
 

--- a/backend/src/test/java/com/stampcrush/backend/api/manager/coupon/ManagerCouponFindApiControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/manager/coupon/ManagerCouponFindApiControllerTest.java
@@ -25,9 +25,6 @@ public class ManagerCouponFindApiControllerTest extends ControllerSliceTest {
 
     public static String API_PREFIX = "/api/admin";
 
-    @MockBean
-    private ManagerCouponFindService managerCouponFindService;
-
     @Test
     void 카페에_방문한_고객들의_정보를_조회한다() throws Exception {
         // given, when

--- a/backend/src/test/java/com/stampcrush/backend/api/manager/owner/ManagerCommandApiControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/manager/owner/ManagerCommandApiControllerTest.java
@@ -24,9 +24,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
         excludeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebMvcConfig.class))
 class ManagerCommandApiControllerTest extends ControllerSliceTest {
 
-    @MockBean
-    private ManagerCommandService managerCommandService;
-
     @Test
     void 회원가입_요청이_정상적일_경우_201_코드를_반환한다() throws Exception {
         // given

--- a/backend/src/test/java/com/stampcrush/backend/api/manager/owner/ManagerCommandApiControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/manager/owner/ManagerCommandApiControllerTest.java
@@ -4,24 +4,16 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.stampcrush.backend.api.ControllerSliceTest;
 import com.stampcrush.backend.api.manager.owner.request.OwnerCreateRequest;
 import com.stampcrush.backend.api.manager.owner.request.OwnerLoginRequest;
-import com.stampcrush.backend.application.manager.owner.ManagerCommandService;
 import com.stampcrush.backend.application.manager.owner.dto.OwnerCreateDto;
 import com.stampcrush.backend.application.manager.owner.dto.OwnerLoginDto;
 import com.stampcrush.backend.auth.api.response.AuthTokensResponse;
-import com.stampcrush.backend.config.WebMvcConfig;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.FilterType;
 
 import static org.mockito.Mockito.when;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WebMvcTest(value = ManagerCommandApiController.class,
-        excludeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebMvcConfig.class))
 class ManagerCommandApiControllerTest extends ControllerSliceTest {
 
     @Test

--- a/backend/src/test/java/com/stampcrush/backend/api/manager/reward/ManagerRewardFindApiControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/manager/reward/ManagerRewardFindApiControllerTest.java
@@ -1,15 +1,9 @@
 package com.stampcrush.backend.api.manager.reward;
 
 import com.stampcrush.backend.api.ControllerSliceTest;
-import com.stampcrush.backend.application.manager.reward.ManagerRewardFindService;
 import com.stampcrush.backend.application.manager.reward.dto.RewardFindDto;
 import com.stampcrush.backend.application.manager.reward.dto.RewardFindResultDto;
-import com.stampcrush.backend.config.WebMvcConfig;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.FilterType;
 import org.springframework.http.MediaType;
 
 import java.util.List;
@@ -20,9 +14,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WebMvcTest(value = ManagerRewardFindApiController.class,
-        excludeFilters =
-        @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebMvcConfig.class))
 class ManagerRewardFindApiControllerTest extends ControllerSliceTest {
 
     @Test

--- a/backend/src/test/java/com/stampcrush/backend/api/manager/reward/ManagerRewardFindApiControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/manager/reward/ManagerRewardFindApiControllerTest.java
@@ -25,9 +25,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
         @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebMvcConfig.class))
 class ManagerRewardFindApiControllerTest extends ControllerSliceTest {
 
-    @MockBean
-    private ManagerRewardFindService managerRewardFindService;
-
     @Test
     void 리워드_목록을_조회한다() throws Exception {
         // given

--- a/backend/src/test/java/com/stampcrush/backend/api/manager/reward/ManagerRewardFindApiControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/manager/reward/ManagerRewardFindApiControllerTest.java
@@ -23,7 +23,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest(value = ManagerRewardFindApiController.class,
         excludeFilters =
         @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebMvcConfig.class))
-public class ManagerRewardFindApiControllerTest extends ControllerSliceTest {
+class ManagerRewardFindApiControllerTest extends ControllerSliceTest {
 
     @MockBean
     private ManagerRewardFindService managerRewardFindService;

--- a/backend/src/test/java/com/stampcrush/backend/api/manager/reward/MangerRewardCommandApiControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/manager/reward/MangerRewardCommandApiControllerTest.java
@@ -24,12 +24,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
         @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebMvcConfig.class))
 class MangerRewardCommandApiControllerTest extends ControllerSliceTest {
 
-    @Autowired
-    private ObjectMapper objectMapper;
-
-    @MockBean
-    private ManagerRewardCommandService managerRewardCommandService;
-
     @Test
     void 리워드를_사용한다() throws Exception {
         // given

--- a/backend/src/test/java/com/stampcrush/backend/api/manager/reward/MangerRewardCommandApiControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/manager/reward/MangerRewardCommandApiControllerTest.java
@@ -22,7 +22,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest(value = ManagerRewardCommandApiController.class,
         excludeFilters =
         @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebMvcConfig.class))
-public class MangerRewardCommandApiControllerTest extends ControllerSliceTest {
+class MangerRewardCommandApiControllerTest extends ControllerSliceTest {
 
     @Autowired
     private ObjectMapper objectMapper;

--- a/backend/src/test/java/com/stampcrush/backend/api/manager/reward/MangerRewardCommandApiControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/manager/reward/MangerRewardCommandApiControllerTest.java
@@ -1,17 +1,9 @@
 package com.stampcrush.backend.api.manager.reward;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.stampcrush.backend.api.ControllerSliceTest;
 import com.stampcrush.backend.api.manager.reward.request.RewardUsedUpdateRequest;
-import com.stampcrush.backend.application.manager.reward.ManagerRewardCommandService;
 import com.stampcrush.backend.application.manager.reward.dto.RewardUsedUpdateDto;
-import com.stampcrush.backend.config.WebMvcConfig;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.FilterType;
 import org.springframework.http.MediaType;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -19,9 +11,6 @@ import static org.mockito.Mockito.doNothing;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WebMvcTest(value = ManagerRewardCommandApiController.class,
-        excludeFilters =
-        @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebMvcConfig.class))
 class MangerRewardCommandApiControllerTest extends ControllerSliceTest {
 
     @Test

--- a/backend/src/test/java/com/stampcrush/backend/api/manager/sample/ManagerSampleCouponFindApiControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/manager/sample/ManagerSampleCouponFindApiControllerTest.java
@@ -3,64 +3,38 @@ package com.stampcrush.backend.api.manager.sample;
 import com.stampcrush.backend.api.ControllerSliceTest;
 import com.stampcrush.backend.application.manager.sample.ManagerSampleCouponFindService;
 import com.stampcrush.backend.application.manager.sample.dto.SampleCouponsFindResultDto;
+import com.stampcrush.backend.config.WebMvcConfig;
 import com.stampcrush.backend.entity.user.Owner;
 import com.stampcrush.backend.fixture.OwnerFixture;
 import com.stampcrush.backend.fixture.SampleCouponFixture;
-import com.stampcrush.backend.helper.BearerAuthHelper;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
 
 import java.util.List;
-import java.util.Optional;
 
-import static com.stampcrush.backend.fixture.SampleCouponFixture.*;
+import static com.stampcrush.backend.fixture.SampleCouponFixture.SAMPLE_BACK_IMAGE_SAVED;
+import static com.stampcrush.backend.fixture.SampleCouponFixture.SAMPLE_FRONT_IMAGE_SAVED;
+import static com.stampcrush.backend.fixture.SampleCouponFixture.SAMPLE_STAMP_IMAGE_SAVED;
 import static org.mockito.Mockito.when;
-import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WebMvcTest(ManagerSampleCouponFindApiController.class)
+@WebMvcTest(value = ManagerSampleCouponFindApiController.class,
+        excludeFilters =
+        @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebMvcConfig.class))
 class ManagerSampleCouponFindApiControllerTest extends ControllerSliceTest {
 
     @MockBean
     private ManagerSampleCouponFindService managerSampleCouponFindService;
 
     @Test
-    void 샘플_쿠폰_조회_요청_시_인증_헤더_정보가_없으면_401_상태코드를_반환한다() throws Exception {
-        mockMvc.perform(
-                        get("/api/admin/coupon-samples")
-                                .contentType(APPLICATION_JSON)
-                )
-                .andExpect(status().isUnauthorized());
-    }
-
-    @Test
-    void 샘플_쿠폰_조회_요청_시_인증이_안되면_401_상태코드를_반환한다() throws Exception {
-        Owner owner = OwnerFixture.GITCHAN;
-
-        when(ownerRepository.findByLoginId(owner.getLoginId()))
-                .thenReturn(Optional.empty());
-
-        mockMvc.perform(
-                        get("/api/admin/coupon-samples")
-                                .contentType(APPLICATION_JSON)
-                                .header(AUTHORIZATION, "Bearer " + BearerAuthHelper.generateToken(owner.getId()))
-                )
-                .andExpect(status().isUnauthorized());
-    }
-
-    @Test
-    void 샘플_쿠폰_조회_요청_시_인증이_되면_200_상태코드와_응답을_반환한다() throws Exception {
-        Owner owner = OwnerFixture.GITCHAN;
-
+    void 샘플_쿠폰_조회_요청한다() throws Exception {
         int maxStampCount = 8;
-
-        when(ownerRepository.findById(owner.getId())).thenReturn(Optional.of(owner));
-        when(ownerRepository.findByLoginId(owner.getLoginId()))
-                .thenReturn(Optional.of(owner));
 
         when(managerSampleCouponFindService.findSampleCouponsByMaxStampCount(maxStampCount))
                 .thenReturn(
@@ -75,7 +49,6 @@ class ManagerSampleCouponFindApiControllerTest extends ControllerSliceTest {
         mockMvc.perform(
                         get("/api/admin/coupon-samples?max-stamp-count=" + maxStampCount)
                                 .contentType(APPLICATION_JSON)
-                                .header(AUTHORIZATION, "Bearer " + BearerAuthHelper.generateToken(owner.getId()))
                 )
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("sampleFrontImages").isNotEmpty())

--- a/backend/src/test/java/com/stampcrush/backend/api/manager/sample/ManagerSampleCouponFindApiControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/manager/sample/ManagerSampleCouponFindApiControllerTest.java
@@ -1,17 +1,9 @@
 package com.stampcrush.backend.api.manager.sample;
 
 import com.stampcrush.backend.api.ControllerSliceTest;
-import com.stampcrush.backend.application.manager.sample.ManagerSampleCouponFindService;
 import com.stampcrush.backend.application.manager.sample.dto.SampleCouponsFindResultDto;
-import com.stampcrush.backend.config.WebMvcConfig;
-import com.stampcrush.backend.entity.user.Owner;
-import com.stampcrush.backend.fixture.OwnerFixture;
 import com.stampcrush.backend.fixture.SampleCouponFixture;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.FilterType;
 
 import java.util.List;
 
@@ -24,9 +16,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WebMvcTest(value = ManagerSampleCouponFindApiController.class,
-        excludeFilters =
-        @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebMvcConfig.class))
 class ManagerSampleCouponFindApiControllerTest extends ControllerSliceTest {
 
     @Test

--- a/backend/src/test/java/com/stampcrush/backend/api/manager/sample/ManagerSampleCouponFindApiControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/manager/sample/ManagerSampleCouponFindApiControllerTest.java
@@ -29,9 +29,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
         @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebMvcConfig.class))
 class ManagerSampleCouponFindApiControllerTest extends ControllerSliceTest {
 
-    @MockBean
-    private ManagerSampleCouponFindService managerSampleCouponFindService;
-
     @Test
     void 샘플_쿠폰_조회_요청한다() throws Exception {
         int maxStampCount = 8;

--- a/backend/src/test/java/com/stampcrush/backend/api/visitor/cafe/VisitorCafeFindApiControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/visitor/cafe/VisitorCafeFindApiControllerTest.java
@@ -25,9 +25,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
         @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebMvcConfig.class))
 class VisitorCafeFindApiControllerTest extends ControllerSliceTest {
 
-    @MockBean
-    private VisitorCafeFindService visitorCafeFindService;
-
     @Test
     void 고객이_카페_정보를_요청한다() throws Exception {
         // given

--- a/backend/src/test/java/com/stampcrush/backend/api/visitor/cafe/VisitorCafeFindApiControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/visitor/cafe/VisitorCafeFindApiControllerTest.java
@@ -1,14 +1,8 @@
 package com.stampcrush.backend.api.visitor.cafe;
 
 import com.stampcrush.backend.api.ControllerSliceTest;
-import com.stampcrush.backend.application.visitor.cafe.VisitorCafeFindService;
 import com.stampcrush.backend.application.visitor.cafe.dto.CafeInfoFindByCustomerResultDto;
-import com.stampcrush.backend.config.WebMvcConfig;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.FilterType;
 import org.springframework.http.MediaType;
 
 import java.time.LocalTime;
@@ -20,9 +14,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WebMvcTest(value = VisitorCafeFindApiController.class,
-        excludeFilters =
-        @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebMvcConfig.class))
 class VisitorCafeFindApiControllerTest extends ControllerSliceTest {
 
     @Test

--- a/backend/src/test/java/com/stampcrush/backend/api/visitor/cafe/VisitorCafeFindApiControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/visitor/cafe/VisitorCafeFindApiControllerTest.java
@@ -3,95 +3,60 @@ package com.stampcrush.backend.api.visitor.cafe;
 import com.stampcrush.backend.api.ControllerSliceTest;
 import com.stampcrush.backend.application.visitor.cafe.VisitorCafeFindService;
 import com.stampcrush.backend.application.visitor.cafe.dto.CafeInfoFindByCustomerResultDto;
-import com.stampcrush.backend.entity.user.Customer;
-import com.stampcrush.backend.helper.BearerAuthHelper;
-import org.junit.jupiter.api.BeforeEach;
+import com.stampcrush.backend.config.WebMvcConfig;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.http.HttpHeaders;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.http.MediaType;
 
 import java.time.LocalTime;
-import java.util.Base64;
-import java.util.Optional;
+import java.time.format.DateTimeFormatter;
 
-import static com.stampcrush.backend.fixture.CustomerFixture.REGISTER_CUSTOMER_GITCHAN;
-import static com.stampcrush.backend.fixture.CustomerFixture.REGISTER_CUSTOMER_GITCHAN_SAVED;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WebMvcTest(VisitorCafeFindApiController.class)
+@WebMvcTest(value = VisitorCafeFindApiController.class,
+        excludeFilters =
+        @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebMvcConfig.class))
 class VisitorCafeFindApiControllerTest extends ControllerSliceTest {
-
-    private static final Long CAFE_ID = 1L;
 
     @MockBean
     private VisitorCafeFindService visitorCafeFindService;
 
-    private Customer customer;
-    private String basicAuthHeader;
-    private String bearerAuthHeader;
-
-    @BeforeEach
-    void setUp() {
-        customer = REGISTER_CUSTOMER_GITCHAN_SAVED;
-
-        String username = customer.getLoginId();
-        String password = customer.getEncryptedPassword();
-        basicAuthHeader = "Basic " + Base64.getEncoder().encodeToString((username + ":" + password).getBytes());
-        bearerAuthHeader = "Bearer " + BearerAuthHelper.generateToken(customer.getId());
-    }
-
     @Test
-    void 카페_조회_요청_시_인증_헤더_정보가_없으면_401코드_반환() throws Exception {
-        mockMvc.perform(get("/api/cafes/" + CAFE_ID)
+    void 고객이_카페_정보를_요청한다() throws Exception {
+        // given
+        CafeInfoFindByCustomerResultDto resultDto = new CafeInfoFindByCustomerResultDto(1L, "깃짱카페",
+                "introduction",
+                LocalTime.NOON,
+                LocalTime.MIDNIGHT,
+                "01012345678",
+                "cafeImageUrl",
+                "roadAddress",
+                "roadAddress"
+        );
+
+        when(visitorCafeFindService.findCafeById(anyLong()))
+                .thenReturn(resultDto);
+
+        // when, then
+        mockMvc.perform(get("/api/cafes/" + 1L)
                         .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isUnauthorized());
-    }
-
-    @Test
-    void 카페_조회_요청_시_고객_인증이_안되면_401코드_반환() throws Exception {
-        // given
-        when(customerRepository.findById(customer.getId())).thenReturn(Optional.empty());
-        when(customerRepository.findByLoginId(customer.getLoginId())).thenReturn(Optional.empty());
-
-        // when, then
-        mockMvc.perform(get("/api/cafes/" + CAFE_ID)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .header(HttpHeaders.AUTHORIZATION, bearerAuthHeader))
-                .andExpect(status().isUnauthorized());
-    }
-
-    @Test
-    void 카페_조회_요청_시_고객_인증되면_200코드_반환() throws Exception {
-        // given
-        when(customerRepository.findById(customer.getId())).thenReturn(Optional.of(customer));
-        when(customerRepository.findByLoginId(customer.getLoginId())).thenReturn(Optional.of(customer));
-        when(visitorCafeFindService.findCafeById(CAFE_ID)).thenReturn(new CafeInfoFindByCustomerResultDto(CAFE_ID, "cafe", "안녕하세요", LocalTime.MIDNIGHT, LocalTime.NOON, "01012345678", "image", "address", "detail"));
-
-        // when, then
-        mockMvc.perform(get("/api/cafes/" + CAFE_ID)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .header(HttpHeaders.AUTHORIZATION, bearerAuthHeader))
-                .andExpect(status().isOk());
-    }
-
-    @Test
-    void 카페_조회_요청_시_비밀번호가_틀리면_401코드_반환() throws Exception {
-        // given
-        Customer wrongCustomer = Customer.registeredCustomerBuilder()
-                .nickname("깃짱")
-                .loginId("gitchan")
-                .encryptedPassword("wrong")
-                .build();
-        when(customerRepository.findByLoginId(customer.getLoginId())).thenReturn(Optional.of(wrongCustomer));
-
-        // when, then
-        mockMvc.perform(get("/api/cafes/" + 1)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .header(HttpHeaders.AUTHORIZATION, bearerAuthHeader))
-                .andExpect(status().isUnauthorized());
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("cafe.id").value(resultDto.getId()))
+                .andExpect(jsonPath("cafe.name").value(resultDto.getName()))
+                .andExpect(jsonPath("cafe.openTime").value(resultDto.getOpenTime().format(DateTimeFormatter.ofPattern("HH:mm"))))
+                .andExpect(jsonPath("cafe.closeTime").value(resultDto.getCloseTime().format(DateTimeFormatter.ofPattern("HH:mm"))))
+                .andExpect(jsonPath("cafe.telephoneNumber").value(resultDto.getTelephoneNumber()))
+                .andExpect(jsonPath("cafe.cafeImageUrl").value(resultDto.getCafeImageUrl()))
+                .andExpect(jsonPath("cafe.roadAddress").value(resultDto.getRoadAddress()))
+                .andExpect(jsonPath("cafe.detailAddress").value(resultDto.getDetailAddress()))
+                .andExpect(jsonPath("cafe.introduction").value(resultDto.getIntroduction()));
+        ;
     }
 }

--- a/backend/src/test/java/com/stampcrush/backend/api/visitor/coupon/VisitorCouponCommandApiControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/visitor/coupon/VisitorCouponCommandApiControllerTest.java
@@ -1,14 +1,8 @@
 package com.stampcrush.backend.api.visitor.coupon;
 
 import com.stampcrush.backend.api.ControllerSliceTest;
-import com.stampcrush.backend.application.visitor.coupon.VisitorCouponCommandService;
-import com.stampcrush.backend.config.WebMvcConfig;
 import com.stampcrush.backend.exception.CouponNotFoundException;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.FilterType;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
@@ -17,9 +11,6 @@ import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WebMvcTest(value = VisitorCouponCommandApiController.class,
-        excludeFilters =
-        @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebMvcConfig.class))
 class VisitorCouponCommandApiControllerTest extends ControllerSliceTest {
 
     @Test

--- a/backend/src/test/java/com/stampcrush/backend/api/visitor/coupon/VisitorCouponCommandApiControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/visitor/coupon/VisitorCouponCommandApiControllerTest.java
@@ -22,9 +22,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
         @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebMvcConfig.class))
 class VisitorCouponCommandApiControllerTest extends ControllerSliceTest {
 
-    @MockBean
-    private VisitorCouponCommandService visitorCouponCommandService;
-
     @Test
     void 삭제_하려는_쿠폰_정보가_올바르지_않은_경우_상태코드가_404_이다() throws Exception {
         // given

--- a/backend/src/test/java/com/stampcrush/backend/api/visitor/coupon/VisitorCouponCommandApiControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/visitor/coupon/VisitorCouponCommandApiControllerTest.java
@@ -20,7 +20,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest(value = VisitorCouponCommandApiController.class,
         excludeFilters =
         @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebMvcConfig.class))
-public class VisitorCouponCommandApiControllerTest extends ControllerSliceTest {
+class VisitorCouponCommandApiControllerTest extends ControllerSliceTest {
 
     @MockBean
     private VisitorCouponCommandService visitorCouponCommandService;

--- a/backend/src/test/java/com/stampcrush/backend/api/visitor/coupon/VisitorCouponFindApiControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/visitor/coupon/VisitorCouponFindApiControllerTest.java
@@ -3,65 +3,36 @@ package com.stampcrush.backend.api.visitor.coupon;
 import com.stampcrush.backend.api.ControllerSliceTest;
 import com.stampcrush.backend.application.visitor.coupon.VisitorCouponFindService;
 import com.stampcrush.backend.application.visitor.coupon.dto.CustomerCouponFindResultDto;
-import com.stampcrush.backend.entity.user.Customer;
+import com.stampcrush.backend.config.WebMvcConfig;
 import com.stampcrush.backend.fixture.CafeFixture;
 import com.stampcrush.backend.fixture.CouponFixture;
-import com.stampcrush.backend.helper.BearerAuthHelper;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
 
 import java.util.List;
-import java.util.Optional;
 
-import static com.stampcrush.backend.fixture.CustomerFixture.REGISTER_CUSTOMER_GITCHAN_SAVED;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.when;
-import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WebMvcTest(VisitorCouponFindApiController.class)
+@WebMvcTest(value = VisitorCouponFindApiController.class,
+        excludeFilters =
+        @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebMvcConfig.class))
 class VisitorCouponFindApiControllerTest extends ControllerSliceTest {
 
     @MockBean
     private VisitorCouponFindService visitorCouponFindService;
 
     @Test
-    void 고객의_쿠폰_조회_요청_시_인증_헤더가_없으면_401_상태코드를_반환한다() throws Exception {
-        mockMvc.perform(
-                        get("/api/coupons")
-                                .contentType(APPLICATION_JSON)
-                )
-                .andExpect(status().isUnauthorized());
-    }
-
-    @Test
-    void 고객의_쿠폰_조회_요청_시_인증이_안되면_401_상태코드를_반환한다() throws Exception {
-        Customer customer = REGISTER_CUSTOMER_GITCHAN_SAVED;
-
-        when(customerRepository.findByLoginId(customer.getLoginId()))
-                .thenReturn(Optional.empty());
-
-        mockMvc.perform(
-                        get("/api/coupons")
-                                .contentType(APPLICATION_JSON)
-                                .header(AUTHORIZATION, "Bearer " + BearerAuthHelper.generateToken(customer.getId()))
-                )
-                .andExpect(status().isUnauthorized());
-    }
-
-    @Test
     void 고객의_쿠폰_조회_요청_시_인증이_되면_200_상태코드와_응답을_반환한다() throws Exception {
-        Customer customer = REGISTER_CUSTOMER_GITCHAN_SAVED;
-
-        when(customerRepository.findById(customer.getId()))
-                .thenReturn(Optional.of(customer));
-        when(customerRepository.findByLoginId(customer.getLoginId()))
-                .thenReturn(Optional.of(customer));
-
-        when(visitorCouponFindService.findOneCouponForOneCafe(customer.getId()))
+        when(visitorCouponFindService.findOneCouponForOneCafe(any()))
                 .thenReturn(
                         List.of(
                                 CustomerCouponFindResultDto.of(
@@ -76,7 +47,6 @@ class VisitorCouponFindApiControllerTest extends ControllerSliceTest {
         mockMvc.perform(
                         get("/api/coupons")
                                 .contentType(APPLICATION_JSON)
-                                .header(AUTHORIZATION, "Bearer " + BearerAuthHelper.generateToken(customer.getId()))
                 )
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("coupons").isNotEmpty());

--- a/backend/src/test/java/com/stampcrush/backend/api/visitor/coupon/VisitorCouponFindApiControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/visitor/coupon/VisitorCouponFindApiControllerTest.java
@@ -27,9 +27,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
         @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebMvcConfig.class))
 class VisitorCouponFindApiControllerTest extends ControllerSliceTest {
 
-    @MockBean
-    private VisitorCouponFindService visitorCouponFindService;
-
     @Test
     void 고객의_쿠폰_조회_요청_시_인증이_되면_200_상태코드와_응답을_반환한다() throws Exception {
         when(visitorCouponFindService.findOneCouponForOneCafe(any()))

--- a/backend/src/test/java/com/stampcrush/backend/api/visitor/coupon/VisitorCouponFindApiControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/visitor/coupon/VisitorCouponFindApiControllerTest.java
@@ -1,30 +1,20 @@
 package com.stampcrush.backend.api.visitor.coupon;
 
 import com.stampcrush.backend.api.ControllerSliceTest;
-import com.stampcrush.backend.application.visitor.coupon.VisitorCouponFindService;
 import com.stampcrush.backend.application.visitor.coupon.dto.CustomerCouponFindResultDto;
-import com.stampcrush.backend.config.WebMvcConfig;
 import com.stampcrush.backend.fixture.CafeFixture;
 import com.stampcrush.backend.fixture.CouponFixture;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.FilterType;
 
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.when;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WebMvcTest(value = VisitorCouponFindApiController.class,
-        excludeFilters =
-        @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebMvcConfig.class))
 class VisitorCouponFindApiControllerTest extends ControllerSliceTest {
 
     @Test

--- a/backend/src/test/java/com/stampcrush/backend/api/visitor/favorites/VisitorFavoritesCommandApiControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/visitor/favorites/VisitorFavoritesCommandApiControllerTest.java
@@ -23,12 +23,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
         @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebMvcConfig.class))
 class VisitorFavoritesCommandApiControllerTest extends ControllerSliceTest {
 
-    @Autowired
-    private ObjectMapper objectMapper;
-
-    @MockBean
-    private VisitorFavoritesCommandService visitorFavoritesCommandService;
-
     @Test
     void 즐겨찾기를_등록한다() throws Exception {
         // given

--- a/backend/src/test/java/com/stampcrush/backend/api/visitor/favorites/VisitorFavoritesCommandApiControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/visitor/favorites/VisitorFavoritesCommandApiControllerTest.java
@@ -13,13 +13,15 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
 import org.springframework.http.MediaType;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(value = VisitorFavoritesCommandApiController.class,
         excludeFilters =
         @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebMvcConfig.class))
-public class VisitorFavoritesCommandApiControllerTest extends ControllerSliceTest {
+class VisitorFavoritesCommandApiControllerTest extends ControllerSliceTest {
 
     @Autowired
     private ObjectMapper objectMapper;
@@ -28,7 +30,23 @@ public class VisitorFavoritesCommandApiControllerTest extends ControllerSliceTes
     private VisitorFavoritesCommandService visitorFavoritesCommandService;
 
     @Test
-    void 리워드를_사용할_때_isFavorites_가_null_이면_상태코드가_400_이다() throws Exception {
+    void 즐겨찾기를_등록한다() throws Exception {
+        // given
+        FavoritesUpdateRequest request = new FavoritesUpdateRequest(true);
+
+        doNothing().when(visitorFavoritesCommandService).changeFavorites(any(), any(), any());
+
+
+        // when, then
+        mockMvc.perform(
+                        post("/api/cafes/1/favorites")
+                                .content(objectMapper.writeValueAsString(request))
+                                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void 변경하려는_favorite_값이_null_이면_상태코드가_400_이다() throws Exception {
         // given
         FavoritesUpdateRequest request = new FavoritesUpdateRequest(null);
 

--- a/backend/src/test/java/com/stampcrush/backend/api/visitor/favorites/VisitorFavoritesCommandApiControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/visitor/favorites/VisitorFavoritesCommandApiControllerTest.java
@@ -1,16 +1,8 @@
 package com.stampcrush.backend.api.visitor.favorites;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.stampcrush.backend.api.ControllerSliceTest;
 import com.stampcrush.backend.api.visitor.favorites.request.FavoritesUpdateRequest;
-import com.stampcrush.backend.application.visitor.favorites.VisitorFavoritesCommandService;
-import com.stampcrush.backend.config.WebMvcConfig;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.FilterType;
 import org.springframework.http.MediaType;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -18,9 +10,6 @@ import static org.mockito.Mockito.doNothing;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WebMvcTest(value = VisitorFavoritesCommandApiController.class,
-        excludeFilters =
-        @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebMvcConfig.class))
 class VisitorFavoritesCommandApiControllerTest extends ControllerSliceTest {
 
     @Test

--- a/backend/src/test/java/com/stampcrush/backend/api/visitor/profile/VisitorProfilesCommandApiControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/visitor/profile/VisitorProfilesCommandApiControllerTest.java
@@ -1,18 +1,10 @@
 package com.stampcrush.backend.api.visitor.profile;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.stampcrush.backend.api.ControllerSliceTest;
 import com.stampcrush.backend.api.visitor.profile.request.VisitorProfilesLinkDataRequest;
 import com.stampcrush.backend.api.visitor.profile.request.VisitorProfilesPhoneNumberUpdateRequest;
-import com.stampcrush.backend.application.visitor.profile.VisitorProfilesCommandService;
-import com.stampcrush.backend.config.WebMvcConfig;
 import com.stampcrush.backend.exception.CustomerBadRequestException;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.FilterType;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -24,11 +16,6 @@ import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WebMvcTest(
-        value = VisitorProfilesCommandApiController.class,
-        excludeFilters =
-        @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebMvcConfig.class)
-)
 class VisitorProfilesCommandApiControllerTest extends ControllerSliceTest {
 
     @Test

--- a/backend/src/test/java/com/stampcrush/backend/api/visitor/profile/VisitorProfilesCommandApiControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/visitor/profile/VisitorProfilesCommandApiControllerTest.java
@@ -31,12 +31,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 )
 class VisitorProfilesCommandApiControllerTest extends ControllerSliceTest {
 
-    @MockBean
-    private VisitorProfilesCommandService visitorProfilesCommandService;
-
-    @Autowired
-    private ObjectMapper objectMapper;
-
     @Test
     void 전화번호를_정상_저장하면_200_상태코드를_반환한다() throws Exception {
         doNothing()

--- a/backend/src/test/java/com/stampcrush/backend/api/visitor/profile/VisitorProfilesFindApiControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/visitor/profile/VisitorProfilesFindApiControllerTest.java
@@ -30,9 +30,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 )
 class VisitorProfilesFindApiControllerTest extends ControllerSliceTest {
 
-    @MockBean
-    private VisitorProfilesFindService visitorProfilesFindService;
-
     @Test
     void 전화번호로_고객을_조회한다() throws Exception {
         Customer customer = CustomerFixture.TEMPORARY_CUSTOMER_1;

--- a/backend/src/test/java/com/stampcrush/backend/api/visitor/profile/VisitorProfilesFindApiControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/visitor/profile/VisitorProfilesFindApiControllerTest.java
@@ -1,16 +1,10 @@
 package com.stampcrush.backend.api.visitor.profile;
 
 import com.stampcrush.backend.api.ControllerSliceTest;
-import com.stampcrush.backend.application.visitor.profile.VisitorProfilesFindService;
 import com.stampcrush.backend.application.visitor.profile.dto.VisitorProfileFindByPhoneNumberResultDto;
-import com.stampcrush.backend.config.WebMvcConfig;
 import com.stampcrush.backend.entity.user.Customer;
 import com.stampcrush.backend.fixture.CustomerFixture;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.FilterType;
 
 import static com.stampcrush.backend.entity.user.CustomerType.TEMPORARY;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -20,14 +14,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WebMvcTest(
-        value = VisitorProfilesFindApiController.class,
-        excludeFilters =
-        @ComponentScan.Filter(
-                type = FilterType.ASSIGNABLE_TYPE,
-                classes = WebMvcConfig.class
-        )
-)
 class VisitorProfilesFindApiControllerTest extends ControllerSliceTest {
 
     @Test

--- a/backend/src/test/java/com/stampcrush/backend/api/visitor/reward/VisitorRewardsFindControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/visitor/reward/VisitorRewardsFindControllerTest.java
@@ -1,16 +1,10 @@
 package com.stampcrush.backend.api.visitor.reward;
 
 import com.stampcrush.backend.api.ControllerSliceTest;
-import com.stampcrush.backend.application.visitor.reward.VisitorRewardsFindService;
 import com.stampcrush.backend.application.visitor.reward.dto.VisitorRewardsFindResultDto;
-import com.stampcrush.backend.config.WebMvcConfig;
 import com.stampcrush.backend.entity.reward.Reward;
 import com.stampcrush.backend.fixture.RewardFixture;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.FilterType;
 import org.springframework.http.MediaType;
 
 import java.time.LocalDate;
@@ -22,14 +16,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WebMvcTest(
-        value = VisitorRewardsFindController.class,
-        excludeFilters =
-        @ComponentScan.Filter(
-                type = FilterType.ASSIGNABLE_TYPE,
-                classes = WebMvcConfig.class
-        )
-)
 class VisitorRewardsFindControllerTest extends ControllerSliceTest {
 
     @Test

--- a/backend/src/test/java/com/stampcrush/backend/api/visitor/reward/VisitorRewardsFindControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/visitor/reward/VisitorRewardsFindControllerTest.java
@@ -32,9 +32,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 )
 class VisitorRewardsFindControllerTest extends ControllerSliceTest {
 
-    @MockBean
-    private VisitorRewardsFindService visitorRewardsFindService;
-
     @Test
     void 고객모드에서_사용_가능한_리워드를_조회한다() throws Exception {
         // given, when

--- a/backend/src/test/java/com/stampcrush/backend/api/visitor/visithistory/VisitorVisitHistoryFindApiControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/visitor/visithistory/VisitorVisitHistoryFindApiControllerTest.java
@@ -1,14 +1,8 @@
 package com.stampcrush.backend.api.visitor.visithistory;
 
 import com.stampcrush.backend.api.ControllerSliceTest;
-import com.stampcrush.backend.application.visitor.visithistory.VisitorVisitHistoryFindService;
 import com.stampcrush.backend.application.visitor.visithistory.dto.CustomerStampHistoryFindResultDto;
-import com.stampcrush.backend.config.WebMvcConfig;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.FilterType;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
@@ -17,8 +11,6 @@ import java.util.List;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 
-@WebMvcTest(value = VisitorVisitHistoryFindApiController.class,
-        excludeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebMvcConfig.class))
 class VisitorVisitHistoryFindApiControllerTest extends ControllerSliceTest {
 
     @Test

--- a/backend/src/test/java/com/stampcrush/backend/api/visitor/visithistory/VisitorVisitHistoryFindApiControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/visitor/visithistory/VisitorVisitHistoryFindApiControllerTest.java
@@ -21,9 +21,6 @@ import static org.mockito.BDDMockito.given;
         excludeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebMvcConfig.class))
 class VisitorVisitHistoryFindApiControllerTest extends ControllerSliceTest {
 
-    @MockBean
-    private VisitorVisitHistoryFindService visitorVisitHistoryFindService;
-
     @Test
     void 고객의_스탬프_적립_내역을_조회한다() throws Exception {
         // given


### PR DESCRIPTION
## 주요 변경사항

- 빈들이랑 어노테이션 다 ControllerSliceTest 에서 상속받도록 했습니다
- ControllerTest 에서 WebMvcConfig Filter 안 걸고 인증 검증하던 메서드들 삭제하였습니다 (스탬프크러쉬 테스트 규칙)

## 리뷰어에게...

## 관련 이슈

closes

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [x] `milestone` 설정
