### PR TITLE
[FE] refactor: 쿠폰 제작 및 변경 페이지의 로딩/에러 핸들링을 개선한다.

### DIFF
--- a/frontend/src/components/ChoiceTemplate/SampleImageList.tsx
+++ b/frontend/src/components/ChoiceTemplate/SampleImageList.tsx
@@ -2,6 +2,7 @@ import { TEMPLATE_MENU } from '.';
 import { SampleCouponRes } from '../../types/api/response';
 import { SampleImage, SampleBackCouponImage } from '../../types/domain/coupon';
 import { TemplateMenu } from '../../types/utils';
+import Button from '../Button';
 import { useSampleImages } from './hooks/useSampleImages';
 import { WarnMsg, SampleImageContainer, SampleImg, WarnMsgBox } from './style';
 
@@ -32,19 +33,32 @@ const SampleImageList = ({
   selectedImageUrl,
   clickSampleImage,
 }: SampleImageListProps) => {
-  const { data, status } = useSampleImages();
+  const { data, status, refetch } = useSampleImages();
 
-  if (status === 'loading') return <div>페이지 로딩중..</div>;
-  if (status === 'error') return <div> 이미지를 불러오는데 실패했습니다. 새로고침 해주세요. </div>;
+  const refetchSampleImages = () => {
+    refetch();
+  };
+
+  if (status === 'loading') return <SampleImageContainer>페이지 로딩중..</SampleImageContainer>;
+  if (status === 'error')
+    return (
+      <SampleImageContainer>
+        <div>샘플 이미지를 불러오는데 실패했습니다.</div>
+        <div>아래 버튼을 눌러 새로고침 해주세요.</div>
+        <Button onClick={refetchSampleImages}>새로고침</Button>
+      </SampleImageContainer>
+    );
 
   const sampleImages = getImagesFromData(data, templateSelect);
 
   if (!sampleImages.length) {
     return (
-      <WarnMsgBox>
-        <WarnMsg>템플릿이 존재하지 않아요:(</WarnMsg>
-        <WarnMsg>빠른 시일 내 준비하겠습니다.</WarnMsg>
-      </WarnMsgBox>
+      <SampleImageContainer>
+        <WarnMsgBox>
+          <WarnMsg>템플릿이 존재하지 않아요:(</WarnMsg>
+          <WarnMsg>빠른 시일 내 준비하겠습니다.</WarnMsg>
+        </WarnMsgBox>
+      </SampleImageContainer>
     );
   }
 

--- a/frontend/src/components/ChoiceTemplate/SampleImageList.tsx
+++ b/frontend/src/components/ChoiceTemplate/SampleImageList.tsx
@@ -5,6 +5,8 @@ import { TemplateMenu } from '../../types/utils';
 import Button from '../Button';
 import { useSampleImages } from './hooks/useSampleImages';
 import { WarnMsg, SampleImageContainer, SampleImg, WarnMsgBox } from './style';
+import CouponLoadImg from '../../assets/coupon_loading_img.png';
+import StampLoadImg from '../../assets/stamp_load_img.png';
 
 interface SampleImageListProps {
   templateSelect: TemplateMenu;
@@ -39,7 +41,21 @@ const SampleImageList = ({
     refetch();
   };
 
-  if (status === 'loading') return <SampleImageContainer>페이지 로딩중..</SampleImageContainer>;
+  if (status === 'loading')
+    return (
+      <SampleImageContainer>
+        {Array.from({ length: 5 }, (v, i) => i).map((element) => {
+          return (
+            <SampleImg
+              key={element}
+              src={templateSelect === '스탬프' ? StampLoadImg : CouponLoadImg}
+              $templateType={templateSelect}
+              $isSelected={false}
+            />
+          );
+        })}
+      </SampleImageContainer>
+    );
   if (status === 'error')
     return (
       <SampleImageContainer>

--- a/frontend/src/pages/Admin/ModifyCouponPolicy/components/CurrentCouponImages/index.tsx
+++ b/frontend/src/pages/Admin/ModifyCouponPolicy/components/CurrentCouponImages/index.tsx
@@ -1,29 +1,54 @@
 import useGetCouponDesign from '../../../ManageCafe/hooks/useGetCouponDesign';
 import { CouponImageFrame, CurrentCouponContainer, Image, StampImageFrame } from './style';
-import LoadingSpinner from '../../../../../components/LoadingSpinner';
 import { useRedirectRegisterPage } from '../../../../../hooks/useRedirectRegisterPage';
+import CouponLoadImg from '../../../../../assets/coupon_loading_img.png';
+import StampLoadImg from '../../../../../assets/stamp_load_img.png';
+import { UseQueryResult } from '@tanstack/react-query';
+import { CouponDesign } from '../../../../../types/domain/coupon';
+
+type ImgType = 'front' | 'back' | 'stamp';
+
+const getImgURLByStatus = (query: UseQueryResult<CouponDesign, unknown>, imgType: ImgType) => {
+  if (query.status === 'loading') {
+    return imgType === 'stamp' ? StampLoadImg : CouponLoadImg;
+  }
+
+  if (query.status === 'error') {
+    throw new Error('요청에 실패하였습니다.');
+  }
+
+  switch (imgType) {
+    case 'front':
+      return query.data.frontImageUrl;
+    case 'back':
+      return query.data.backImageUrl;
+    case 'stamp':
+      return query.data.stampImageUrl;
+    default:
+      throw new Error('잘못된 이미지 타입을 매개변수로 전달했습니다.');
+  }
+};
 
 const CurrentCouponImages = () => {
   const cafeId = useRedirectRegisterPage();
-  const { data: couponDesignData, status } = useGetCouponDesign(cafeId);
+  const couponDesign = useGetCouponDesign(cafeId);
 
-  if (status === 'error') return <div>Error</div>;
-  if (status === 'loading') return <LoadingSpinner />;
+  if (couponDesign.status === 'error') return <div>Error</div>;
 
   return (
     <CurrentCouponContainer>
       <h1>현재 쿠폰 이미지</h1>
       <span>앞면</span>
       <CouponImageFrame>
-        <Image src={couponDesignData?.frontImageUrl} />
+        <Image src={getImgURLByStatus(couponDesign, 'front')} />
       </CouponImageFrame>
       <span>뒷면</span>
       <CouponImageFrame>
-        <Image src={couponDesignData?.backImageUrl} />
+        <Image src={getImgURLByStatus(couponDesign, 'back')} />
       </CouponImageFrame>
       <span>스탬프</span>
       <StampImageFrame>
-        <Image src={couponDesignData?.stampImageUrl} />
+        <Image src={getImgURLByStatus(couponDesign, 'stamp')} />
       </StampImageFrame>
     </CurrentCouponContainer>
   );

--- a/frontend/src/pages/Admin/ModifyCouponPolicy/components/CurrentCouponImages/index.tsx
+++ b/frontend/src/pages/Admin/ModifyCouponPolicy/components/CurrentCouponImages/index.tsx
@@ -1,10 +1,17 @@
 import useGetCouponDesign from '../../../ManageCafe/hooks/useGetCouponDesign';
-import { CouponImageFrame, CurrentCouponContainer, Image, StampImageFrame } from './style';
+import {
+  CouponImageFrame,
+  CurrentCouponContainer,
+  ErrorContainer,
+  Image,
+  StampImageFrame,
+} from './style';
 import { useRedirectRegisterPage } from '../../../../../hooks/useRedirectRegisterPage';
 import CouponLoadImg from '../../../../../assets/coupon_loading_img.png';
 import StampLoadImg from '../../../../../assets/stamp_load_img.png';
 import { UseQueryResult } from '@tanstack/react-query';
 import { CouponDesign } from '../../../../../types/domain/coupon';
+import Button from '../../../../../components/Button';
 
 type ImgType = 'front' | 'back' | 'stamp';
 
@@ -33,7 +40,22 @@ const CurrentCouponImages = () => {
   const cafeId = useRedirectRegisterPage();
   const couponDesign = useGetCouponDesign(cafeId);
 
-  if (couponDesign.status === 'error') return <div>Error</div>;
+  const refetchCouponDesign = () => {
+    couponDesign.refetch();
+  };
+
+  if (couponDesign.status === 'error')
+    return (
+      <CurrentCouponContainer>
+        <ErrorContainer>
+          <div>오류가 발생했습니다. :(</div>
+          <div>아래 새로 고침 버튼을 눌러주세요.</div>
+          <div>쿠폰 미리보기를 확인하지 않으셔도</div>
+          <div>쿠폰 정책을 변경하실 수 있습니다.</div>
+          <Button onClick={refetchCouponDesign}>새로 고침</Button>
+        </ErrorContainer>
+      </CurrentCouponContainer>
+    );
 
   return (
     <CurrentCouponContainer>

--- a/frontend/src/pages/Admin/ModifyCouponPolicy/components/CurrentCouponImages/style.tsx
+++ b/frontend/src/pages/Admin/ModifyCouponPolicy/components/CurrentCouponImages/style.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 export const CurrentCouponContainer = styled.section`
   display: flex;
   flex-direction: column;
-
+  height: 493px;
   border: 3px solid ${({ theme }) => theme.colors.main};
   border-radius: 16px;
   margin-left: 120px;

--- a/frontend/src/pages/Admin/ModifyCouponPolicy/components/CurrentCouponImages/style.tsx
+++ b/frontend/src/pages/Admin/ModifyCouponPolicy/components/CurrentCouponImages/style.tsx
@@ -3,7 +3,6 @@ import styled from 'styled-components';
 export const CurrentCouponContainer = styled.section`
   display: flex;
   flex-direction: column;
-  height: 493px;
   border: 3px solid ${({ theme }) => theme.colors.main};
   border-radius: 16px;
   margin-left: 120px;
@@ -40,4 +39,13 @@ export const Image = styled.img`
 export const StampImageFrame = styled.div`
   width: 50px;
   height: 50px;
+`;
+
+export const ErrorContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 493px; /* 내부 요소의 크기가 변경되면 변경해주어야 함. */
+  width: 225px;
 `;


### PR DESCRIPTION
## 주요 변경사항
- #877 
서버 에러 상황을 중점적으로 두었습니다.
그 이유는 현재 미인증 상황일 때는 401로 redirect되고, 클라이언트가 별다른 입력값 예외를 던지지 않는 상황이기 때문에 다음과 같이 구현했습니다.
### 진입점 - 에러 상황
![Screenshot 2023-10-19 at 14 37 25](https://github.com/woowacourse-teams/2023-stamp-crush/assets/56749516/9e7e7ffb-642f-4688-b2f6-6a80c81e526c)
### 진입점 - 로딩 상황 
![Screenshot 2023-10-19 at 14 40 09](https://github.com/woowacourse-teams/2023-stamp-crush/assets/56749516/ac74391f-d14b-4f3c-b419-2e7d58f61556)

### 템플릿 - 로딩 상황
<img width="1458" alt="Screenshot 2023-10-19 at 17 44 42" src="https://github.com/woowacourse-teams/2023-stamp-crush/assets/56749516/6dce5e69-dcfe-4f69-bafe-a73102bbdd3c">

### 템플릿 - 에러상황
<img width="1458" alt="Screenshot 2023-10-19 at 17 44 20" src="https://github.com/woowacourse-teams/2023-stamp-crush/assets/56749516/77ca4de1-e565-4e42-adab-9388aa75042a">

## 리뷰어에게...

## 관련 이슈

closes #877 

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [x] `milestone` 설정
