### PR TITLE
[FE] refactor: 리워드 적립 페이지의 로딩/에러 핸들링을 개선한다.

### DIFF
--- a/frontend/src/pages/Admin/RewardPage/components/RewardItemList/index.tsx
+++ b/frontend/src/pages/Admin/RewardPage/components/RewardItemList/index.tsx
@@ -4,6 +4,7 @@ import Button from '../../../../../components/Button';
 import useReward from '../../hooks/useReward';
 import useMutateReward from '../../hooks/useMutateReward';
 import { useNavigate } from 'react-router-dom';
+import LoadingSpinnerSVG from '../../../../../assets/loading_spinner.svg';
 
 interface RewardItemListProps {
   cafeId: number;
@@ -13,6 +14,7 @@ interface RewardItemListProps {
 const isNotFoundUser = (error: Error) => {
   return error.message === '404';
 };
+
 const RewardItemList = ({ cafeId, customerId }: RewardItemListProps) => {
   const navigate = useNavigate();
   const reward = useReward(cafeId, customerId);
@@ -60,18 +62,18 @@ const RewardItemList = ({ cafeId, customerId }: RewardItemListProps) => {
   if (reward.status === 'loading') {
     return (
       <RewardItemListContainer>
-        <div>고객 정보 불러오는 중...</div>
+        <LoadingSpinnerSVG />
       </RewardItemListContainer>
     );
   }
 
-  if (reward.data.rewards.length === 0) {
+  if (reward.data.length === 0) {
     return <RewardItemListContainer>보유한 리워드가 없습니다.</RewardItemListContainer>;
   }
 
   return (
     <RewardItemListContainer>
-      {reward.data.rewards.map(({ id, name }: Reward) => (
+      {reward.data.map(({ id, name }: Reward) => (
         <RewardItem key={id}>
           <RewardName>{name}</RewardName>
           <Button onClick={() => activateRewardButton(id)}>사용</Button>

--- a/frontend/src/pages/Admin/RewardPage/components/RewardItemList/index.tsx
+++ b/frontend/src/pages/Admin/RewardPage/components/RewardItemList/index.tsx
@@ -1,0 +1,84 @@
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
+import { getReward } from '../../../../../api/get';
+import { Reward } from '../../../../../types/domain/reward';
+import { RewardName, RewardItemListContainer, RewardItem } from './style';
+import { INVALID_CAFE_ID } from '../../../../../constants/magicNumber';
+import {
+  CustomerIdParams,
+  MutateReq,
+  RewardIdParams,
+  RewardReqBody,
+} from '../../../../../types/api/request';
+import { patchReward } from '../../../../../api/patch';
+import ROUTER_PATH from '../../../../../constants/routerPath';
+import Button from '../../../../../components/Button';
+
+interface RewardItemListProps {
+  cafeId: number;
+  customerId: number;
+}
+const RewardItemList = ({ cafeId, customerId }: RewardItemListProps) => {
+  const navigate = useNavigate();
+
+  // TODO: 내카페의 고객이 아닌 고객의 리워드를 조회할 경우 ErrorMessage를 띄어줌
+  const { data: rewardData, status: rewardStatus } = useQuery(
+    ['getReward'],
+    () => {
+      return getReward({ params: { customerId, cafeId } });
+    },
+    {
+      enabled: cafeId !== INVALID_CAFE_ID,
+    },
+  );
+
+  const { mutate: mutateReward } = useMutation({
+    mutationFn: (request: MutateReq<RewardReqBody, RewardIdParams & CustomerIdParams>) => {
+      return patchReward(request);
+    },
+    onSuccess() {
+      navigate(ROUTER_PATH.customerList);
+    },
+    onError() {
+      alert('에러가 발생했습니다. 네트워크 상태를 확인해주세요.');
+    },
+  });
+
+  const activateRewardButton = (rewardId: number) => {
+    mutateReward({
+      params: {
+        rewardId,
+        customerId,
+      },
+      body: {
+        used: true,
+        cafeId,
+      },
+    });
+  };
+
+  if (rewardStatus === 'error') {
+    return <div>불러오는 중 에러가 발생했습니다. 다시 시도해주세요.</div>;
+  }
+
+  if (rewardStatus === 'loading') {
+    return <div>고객 정보 불러오는 중...</div>;
+  }
+
+  if (rewardData.rewards.length === 0) {
+    return <p>보유한 리워드가 없습니다.</p>;
+  }
+
+  return (
+    <RewardItemListContainer>
+      {rewardData.rewards.map(({ id, name }: Reward) => (
+        <RewardItem key={id}>
+          <RewardName>{name}</RewardName>
+          <Button onClick={() => activateRewardButton(id)}>사용</Button>
+        </RewardItem>
+      ))}
+    </RewardItemListContainer>
+  );
+};
+
+export default RewardItemList;

--- a/frontend/src/pages/Admin/RewardPage/components/RewardItemList/index.tsx
+++ b/frontend/src/pages/Admin/RewardPage/components/RewardItemList/index.tsx
@@ -14,7 +14,6 @@ const isNotFoundUser = (error: Error) => {
   return error.message === '404';
 };
 const RewardItemList = ({ cafeId, customerId }: RewardItemListProps) => {
-  // TODO: 내카페의 고객이 아닌 고객의 리워드를 조회할 경우 ErrorMessage를 띄어줌
   const navigate = useNavigate();
   const reward = useReward(cafeId, customerId);
   const { mutate: mutateReward } = useMutateReward();

--- a/frontend/src/pages/Admin/RewardPage/components/RewardItemList/index.tsx
+++ b/frontend/src/pages/Admin/RewardPage/components/RewardItemList/index.tsx
@@ -3,14 +3,20 @@ import { RewardName, RewardItemListContainer, RewardItem } from './style';
 import Button from '../../../../../components/Button';
 import useReward from '../../hooks/useReward';
 import useMutateReward from '../../hooks/useMutateReward';
+import { useNavigate } from 'react-router-dom';
 
 interface RewardItemListProps {
   cafeId: number;
   customerId: number;
 }
+
+const isNotFoundUser = (error: Error) => {
+  return error.message === '404';
+};
 const RewardItemList = ({ cafeId, customerId }: RewardItemListProps) => {
   // TODO: 내카페의 고객이 아닌 고객의 리워드를 조회할 경우 ErrorMessage를 띄어줌
-  const { data: rewardData, status: rewardStatus } = useReward(cafeId, customerId);
+  const navigate = useNavigate();
+  const reward = useReward(cafeId, customerId);
   const { mutate: mutateReward } = useMutateReward();
 
   const activateRewardButton = (rewardId: number) => {
@@ -26,21 +32,47 @@ const RewardItemList = ({ cafeId, customerId }: RewardItemListProps) => {
     });
   };
 
-  if (rewardStatus === 'error') {
-    return <div>불러오는 중 에러가 발생했습니다. 다시 시도해주세요.</div>;
+  const refreshReward = () => {
+    reward.refetch();
+  };
+
+  const goBackButton = () => {
+    navigate(-1);
+  };
+
+  if (reward.status === 'error') {
+    return (
+      <RewardItemListContainer>
+        {isNotFoundUser(reward.error) ? (
+          <>
+            <div>고객을 카페에서 찾을 수 없습니다.</div>
+            <Button onClick={goBackButton}>뒤로가기</Button>
+          </>
+        ) : (
+          <>
+            <div>에러가 발생했습니다.</div>
+            <Button onClick={refreshReward}>다시 불러오기</Button>
+          </>
+        )}
+      </RewardItemListContainer>
+    );
   }
 
-  if (rewardStatus === 'loading') {
-    return <div>고객 정보 불러오는 중...</div>;
+  if (reward.status === 'loading') {
+    return (
+      <RewardItemListContainer>
+        <div>고객 정보 불러오는 중...</div>
+      </RewardItemListContainer>
+    );
   }
 
-  if (rewardData.rewards.length === 0) {
-    return <p>보유한 리워드가 없습니다.</p>;
+  if (reward.data.rewards.length === 0) {
+    return <RewardItemListContainer>보유한 리워드가 없습니다.</RewardItemListContainer>;
   }
 
   return (
     <RewardItemListContainer>
-      {rewardData.rewards.map(({ id, name }: Reward) => (
+      {reward.data.rewards.map(({ id, name }: Reward) => (
         <RewardItem key={id}>
           <RewardName>{name}</RewardName>
           <Button onClick={() => activateRewardButton(id)}>사용</Button>

--- a/frontend/src/pages/Admin/RewardPage/components/RewardItemList/index.tsx
+++ b/frontend/src/pages/Admin/RewardPage/components/RewardItemList/index.tsx
@@ -1,9 +1,7 @@
-import { useMutation, useQuery } from '@tanstack/react-query';
+import { useMutation } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
-import { getReward } from '../../../../../api/get';
 import { Reward } from '../../../../../types/domain/reward';
 import { RewardName, RewardItemListContainer, RewardItem } from './style';
-import { INVALID_CAFE_ID } from '../../../../../constants/magicNumber';
 import {
   CustomerIdParams,
   MutateReq,
@@ -13,6 +11,7 @@ import {
 import { patchReward } from '../../../../../api/patch';
 import ROUTER_PATH from '../../../../../constants/routerPath';
 import Button from '../../../../../components/Button';
+import useReward from '../../hooks/useReward';
 
 interface RewardItemListProps {
   cafeId: number;
@@ -22,15 +21,7 @@ const RewardItemList = ({ cafeId, customerId }: RewardItemListProps) => {
   const navigate = useNavigate();
 
   // TODO: 내카페의 고객이 아닌 고객의 리워드를 조회할 경우 ErrorMessage를 띄어줌
-  const { data: rewardData, status: rewardStatus } = useQuery(
-    ['getReward'],
-    () => {
-      return getReward({ params: { customerId, cafeId } });
-    },
-    {
-      enabled: cafeId !== INVALID_CAFE_ID,
-    },
-  );
+  const { data: rewardData, status: rewardStatus } = useReward(cafeId, customerId);
 
   const { mutate: mutateReward } = useMutation({
     mutationFn: (request: MutateReq<RewardReqBody, RewardIdParams & CustomerIdParams>) => {

--- a/frontend/src/pages/Admin/RewardPage/components/RewardItemList/index.tsx
+++ b/frontend/src/pages/Admin/RewardPage/components/RewardItemList/index.tsx
@@ -1,39 +1,17 @@
-import { useMutation } from '@tanstack/react-query';
-import { useNavigate } from 'react-router-dom';
 import { Reward } from '../../../../../types/domain/reward';
 import { RewardName, RewardItemListContainer, RewardItem } from './style';
-import {
-  CustomerIdParams,
-  MutateReq,
-  RewardIdParams,
-  RewardReqBody,
-} from '../../../../../types/api/request';
-import { patchReward } from '../../../../../api/patch';
-import ROUTER_PATH from '../../../../../constants/routerPath';
 import Button from '../../../../../components/Button';
 import useReward from '../../hooks/useReward';
+import useMutateReward from '../../hooks/useMutateReward';
 
 interface RewardItemListProps {
   cafeId: number;
   customerId: number;
 }
 const RewardItemList = ({ cafeId, customerId }: RewardItemListProps) => {
-  const navigate = useNavigate();
-
   // TODO: 내카페의 고객이 아닌 고객의 리워드를 조회할 경우 ErrorMessage를 띄어줌
   const { data: rewardData, status: rewardStatus } = useReward(cafeId, customerId);
-
-  const { mutate: mutateReward } = useMutation({
-    mutationFn: (request: MutateReq<RewardReqBody, RewardIdParams & CustomerIdParams>) => {
-      return patchReward(request);
-    },
-    onSuccess() {
-      navigate(ROUTER_PATH.customerList);
-    },
-    onError() {
-      alert('에러가 발생했습니다. 네트워크 상태를 확인해주세요.');
-    },
-  });
+  const { mutate: mutateReward } = useMutateReward();
 
   const activateRewardButton = (rewardId: number) => {
     mutateReward({

--- a/frontend/src/pages/Admin/RewardPage/components/RewardItemList/style.tsx
+++ b/frontend/src/pages/Admin/RewardPage/components/RewardItemList/style.tsx
@@ -1,0 +1,43 @@
+import styled from 'styled-components';
+
+export const RewardItemListContainer = styled.ul`
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 20px;
+`;
+
+export const RewardItem = styled.li`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+
+  width: 90%;
+
+  font-weight: 600;
+  button {
+    width: 80px;
+    height: 32px;
+    padding: 5px;
+  }
+`;
+
+export const RewardName = styled.span`
+  display: flex;
+  align-items: center;
+  width: 100%;
+  height: 20px;
+  font-size: 18px;
+
+  padding: 5px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  &:hover {
+    overflow: visible;
+    white-space: normal;
+  }
+`;

--- a/frontend/src/pages/Admin/RewardPage/hooks/useMutateReward.ts
+++ b/frontend/src/pages/Admin/RewardPage/hooks/useMutateReward.ts
@@ -1,0 +1,27 @@
+import { useMutation } from '@tanstack/react-query';
+import {
+  CustomerIdParams,
+  MutateReq,
+  RewardIdParams,
+  RewardReqBody,
+} from '../../../../types/api/request';
+import { patchReward } from '../../../../api/patch';
+import { useNavigate } from 'react-router-dom';
+import ROUTER_PATH from '../../../../constants/routerPath';
+
+const useMutateReward = () => {
+  const navigate = useNavigate();
+  return useMutation({
+    mutationFn: (request: MutateReq<RewardReqBody, RewardIdParams & CustomerIdParams>) => {
+      return patchReward(request);
+    },
+    onSuccess() {
+      navigate(ROUTER_PATH.customerList);
+    },
+    onError() {
+      alert('에러가 발생했습니다. 네트워크 상태를 확인해주세요.');
+    },
+  });
+};
+
+export default useMutateReward;

--- a/frontend/src/pages/Admin/RewardPage/hooks/useReward.ts
+++ b/frontend/src/pages/Admin/RewardPage/hooks/useReward.ts
@@ -2,9 +2,10 @@ import { useQuery } from '@tanstack/react-query';
 import { INVALID_CAFE_ID } from '../../../../constants/magicNumber';
 import { getReward } from '../../../../api/get';
 import { RewardRes } from '../../../../types/api/response';
+import { Reward } from '../../../../types/domain/reward';
 
 const useReward = (cafeId: number, customerId: number) =>
-  useQuery<RewardRes, Error>(
+  useQuery<RewardRes, Error, Reward[]>(
     ['getReward'],
     () => {
       return getReward({ params: { customerId, cafeId } });
@@ -12,6 +13,7 @@ const useReward = (cafeId: number, customerId: number) =>
     {
       enabled: cafeId !== INVALID_CAFE_ID,
       refetchOnWindowFocus: false,
+      select: (data) => data.rewards,
       retry: false,
     },
   );

--- a/frontend/src/pages/Admin/RewardPage/hooks/useReward.ts
+++ b/frontend/src/pages/Admin/RewardPage/hooks/useReward.ts
@@ -1,15 +1,18 @@
 import { useQuery } from '@tanstack/react-query';
 import { INVALID_CAFE_ID } from '../../../../constants/magicNumber';
 import { getReward } from '../../../../api/get';
+import { RewardRes } from '../../../../types/api/response';
 
 const useReward = (cafeId: number, customerId: number) =>
-  useQuery(
+  useQuery<RewardRes, Error>(
     ['getReward'],
     () => {
       return getReward({ params: { customerId, cafeId } });
     },
     {
       enabled: cafeId !== INVALID_CAFE_ID,
+      refetchOnWindowFocus: false,
+      retry: false,
     },
   );
 

--- a/frontend/src/pages/Admin/RewardPage/hooks/useReward.ts
+++ b/frontend/src/pages/Admin/RewardPage/hooks/useReward.ts
@@ -1,0 +1,16 @@
+import { useQuery } from '@tanstack/react-query';
+import { INVALID_CAFE_ID } from '../../../../constants/magicNumber';
+import { getReward } from '../../../../api/get';
+
+const useReward = (cafeId: number, customerId: number) =>
+  useQuery(
+    ['getReward'],
+    () => {
+      return getReward({ params: { customerId, cafeId } });
+    },
+    {
+      enabled: cafeId !== INVALID_CAFE_ID,
+    },
+  );
+
+export default useReward;

--- a/frontend/src/pages/Admin/RewardPage/index.tsx
+++ b/frontend/src/pages/Admin/RewardPage/index.tsx
@@ -1,70 +1,18 @@
-import { useMutation, useQuery } from '@tanstack/react-query';
-import Button from '../../../components/Button';
-import { RewardContainer, RewardContent, RewardItemContainer, RewardItemWrapper } from './style';
-import Text from '../../../components/Text';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
+import { RewardContainer } from './style';
 import { Spacing } from '../../../style/layout/common';
-import { getReward } from '../../../api/get';
-import { patchReward } from '../../../api/patch';
 import { useRedirectRegisterPage } from '../../../hooks/useRedirectRegisterPage';
-import {
-  MutateReq,
-  RewardReqBody,
-  RewardIdParams,
-  CustomerIdParams,
-} from '../../../types/api/request';
-import { Reward } from '../../../types/domain/reward';
-import ROUTER_PATH from '../../../constants/routerPath';
-import { INVALID_CAFE_ID } from '../../../constants/magicNumber';
+import { CustomerPhoneNumber } from '../../../types/domain/customer';
+import Text from '../../../components/Text';
+import RewardItemList from './components/RewardItemList';
+
+interface RewardPageState {
+  state: CustomerPhoneNumber;
+}
 
 const RewardPage = () => {
   const cafeId = useRedirectRegisterPage();
-  const location = useLocation();
-  const navigate = useNavigate();
-
-  // TODO: 내카페의 고객이 아닌 고객의 리워드를 조회할 경우 ErrorMessage를 띄어줌
-  const { data: rewardData, status: rewardStatus } = useQuery(
-    ['getReward'],
-    () => {
-      return getReward({ params: { customerId: location.state.id, cafeId } });
-    },
-    {
-      enabled: cafeId !== INVALID_CAFE_ID,
-    },
-  );
-
-  const { mutate: mutateReward } = useMutation({
-    mutationFn: (request: MutateReq<RewardReqBody, RewardIdParams & CustomerIdParams>) => {
-      return patchReward(request);
-    },
-    onSuccess() {
-      navigate(ROUTER_PATH.customerList);
-    },
-    onError() {
-      alert('에러가 발생했습니다. 네트워크 상태를 확인해주세요.');
-    },
-  });
-
-  if (rewardStatus === 'error') {
-    return <div>불러오는 중 에러가 발생했습니다. 다시 시도해주세요.</div>;
-  }
-
-  if (rewardStatus === 'loading') {
-    return <div>고객 정보 불러오는 중...</div>;
-  }
-
-  const activateRewardButton = (rewardId: number) => {
-    mutateReward({
-      params: {
-        rewardId,
-        customerId: location.state.id,
-      },
-      body: {
-        used: true,
-        cafeId,
-      },
-    });
-  };
+  const location = useLocation() as RewardPageState;
 
   return (
     <>
@@ -76,18 +24,7 @@ const RewardPage = () => {
         <Spacing $size={72} />
         <Text variant="subTitle">보유 리워드 내역</Text>
         <Spacing $size={42} />
-        <RewardItemContainer>
-          {rewardData.rewards.length ? (
-            rewardData.rewards.map(({ id, name }: Reward) => (
-              <RewardItemWrapper key={id}>
-                <RewardContent>{name}</RewardContent>
-                <Button onClick={() => activateRewardButton(id)}>사용</Button>
-              </RewardItemWrapper>
-            ))
-          ) : (
-            <p>보유한 리워드가 없습니다.</p>
-          )}
-        </RewardItemContainer>
+        <RewardItemList cafeId={cafeId} customerId={location.state.id} />
       </RewardContainer>
     </>
   );

--- a/frontend/src/pages/Admin/RewardPage/style.tsx
+++ b/frontend/src/pages/Admin/RewardPage/style.tsx
@@ -47,48 +47,6 @@ export const RewardContainer = styled.section`
   width: 70%;
 `;
 
-export const RewardItemContainer = styled.ul`
-  width: 100%;
-  height: 100%;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 20px;
-`;
-
-export const RewardItemWrapper = styled.li`
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  justify-content: space-between;
-
-  width: 90%;
-
-  font-weight: 600;
-  button {
-    width: 80px;
-    height: 32px;
-    padding: 5px;
-  }
-`;
-
-export const RewardContent = styled.span`
-  display: flex;
-  align-items: center;
-  width: 100%;
-  height: 20px;
-  font-size: 18px;
-
-  padding: 5px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  &:hover {
-    overflow: visible;
-    white-space: normal;
-  }
-`;
-
 export const Divider = styled.div`
   margin: 30px 30px;
   border: 1px solid black;


### PR DESCRIPTION
## 주요 변경사항

## 404에러를 해결하였습니다.
현재 카페에 적립을 하지 않은 고객의 경우 404로 에러를 발생해, 해당 에러를 이 페이지 내에서 처리 하였습니다.

이 페이지에서 처리한 이유는 해당 에러를 `api/admin/customers/3/rewards?cafe-id=13&used=false`에서 내뱉기 때문에,
EnterPhoneNumber 에서 처리하기 불가능하다고 판단해 처리했습니다..!

사용자에게는 제안사항으로 뒤로가기 버튼을 제공해, 리워드 사용의 enter-phone-number로 이동할 수 있는 버튼을 제공합니다.

그래도 빠른 적립을 위해 몇 가지를 고안해보았습니다.

### background refetch를 없앴습니다.

사장님의 적립 플로우 상 background refetch가 얼마나 일어날까? 하는 생각이 있었습니다.

따라서 background refetch를 삭제했습니다.

### retry를 false처리했습니다. 
기존의 경우 에러가 발생하는 경우 4번정도 시도를 해보고 안되면 에러 페이지를 표시합니다.

그 동안 사용자는 로딩 인디케이터를 보고 있는데 사장님 같은 경우는 빠른 적립 플로우가 필요하므로 안될경우 4번정도 다시 요청을 시도할 것 없이 즉각적으로 에러를 보여주고, 그에 대한 해결책을 빠르게 제공하는게 중요하다고 생각했습니다.

따라서 retry를 없애는 대신 에러에 대해 어떻게 동작할지 제안해주는 화면을 고안해보았습니다.

아래는 404에러 발생시 사용자에게 뒤로가는 동작을 제안하는 화면입니다. 이외의 다른 서버오류는 refetch할 수 있는 동작을 제공합니다.

캡처는 해당 부분만 보이도록 화면 전체 사이즈에 안맞게 캡처한 점 양해 부탁드립니다
|404 에러 화면 | 기타 에러 화면|
|--|--|
|<img alt="image" src="https://github.com/woowacourse-teams/2023-stamp-crush/assets/56749516/6260f9b5-279c-4c5d-9187-d75c3b50ec01">|<img alt="image" src="https://github.com/woowacourse-teams/2023-stamp-crush/assets/56749516/9b83e48a-666e-4e97-a077-564a1f584b92">|

### 로딩 화면
컴포넌트를 분리해 전체화면이 아닌 데이터 fetch하는 부분만 해당 컴포넌트로 대체하게 만들었습니다.
<img width="789" alt="image" src="https://github.com/woowacourse-teams/2023-stamp-crush/assets/56749516/842c2b44-a5be-437b-9409-25201ac6b4f6">


## 리뷰어에게...

## 관련 이슈

closes #878 

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [x] `milestone` 설정
