### PR TITLE
[BE] feat: 개발환경용 인증 기능 구현

### DIFF
--- a/backend/src/main/java/com/stampcrush/backend/dev/DevAuthController.java
+++ b/backend/src/main/java/com/stampcrush/backend/dev/DevAuthController.java
@@ -1,0 +1,45 @@
+package com.stampcrush.backend.dev;
+
+import com.stampcrush.backend.auth.api.response.AuthTokensResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@RequiredArgsConstructor
+@Profile({"local", "dev"})
+@RequestMapping("/api/dev/")
+public class DevAuthController {
+
+    private final DevAuthService devAuthService;
+
+    @GetMapping("/register/admin/{joinedName}")
+    public ResponseEntity<AuthTokensResponse> managerSignUp(
+            @PathVariable String joinedName
+    ) {
+        return ResponseEntity.ok().body(devAuthService.joinManager(joinedName));
+    }
+
+    @GetMapping("/register/visitor/{joinedName}")
+    public ResponseEntity<AuthTokensResponse> visitorSignUp(
+            @PathVariable String joinedName
+    ) {
+        return ResponseEntity.ok().body(devAuthService.joinVisitor(joinedName));
+    }
+
+    @GetMapping("/login/admin/{joinedName}")
+    public ResponseEntity<AuthTokensResponse> managerLogin(
+            @PathVariable String joinedName
+    ) {
+        return ResponseEntity.ok(devAuthService.loginManger(joinedName));
+    }
+
+    @GetMapping("/login/visitor/{joinedName}")
+    public ResponseEntity<AuthTokensResponse> visitorLogin(
+            @PathVariable String joinedName
+    ) {
+        return ResponseEntity.ok(devAuthService.loginVisitor(joinedName));
+    }
+}

--- a/backend/src/main/java/com/stampcrush/backend/dev/DevAuthController.java
+++ b/backend/src/main/java/com/stampcrush/backend/dev/DevAuthController.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 
 @RequiredArgsConstructor
 @Profile({"local", "dev"})
-@RequestMapping("/api/dev/")
+@RequestMapping("/api/dev")
 public class DevAuthController {
 
     private final DevAuthService devAuthService;

--- a/backend/src/main/java/com/stampcrush/backend/dev/DevAuthService.java
+++ b/backend/src/main/java/com/stampcrush/backend/dev/DevAuthService.java
@@ -1,0 +1,72 @@
+package com.stampcrush.backend.dev;
+
+import com.stampcrush.backend.auth.OAuthProvider;
+import com.stampcrush.backend.auth.api.response.AuthTokensResponse;
+import com.stampcrush.backend.auth.application.util.AuthTokensGenerator;
+import com.stampcrush.backend.entity.user.Customer;
+import com.stampcrush.backend.entity.user.Owner;
+import com.stampcrush.backend.repository.user.CustomerRepository;
+import com.stampcrush.backend.repository.user.OwnerRepository;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Profile({"local", "dev"})
+@Transactional
+@RequiredArgsConstructor
+@Service
+public class DevAuthService {
+
+    private final AtomicLong idGen = new AtomicLong(-1);
+    private final Map<String, Long> managerNameIdMap = new HashMap<>();
+    private final Map<String, Long> visitorNameIdMap = new HashMap<>();
+
+    private final OwnerRepository ownerRepository;
+    private final CustomerRepository customerRepository;
+    private final AuthTokensGenerator authTokensGenerator;
+
+    public AuthTokensResponse joinManager(String nickname) {
+        Owner owner = Owner.builder()
+                .nickname(nickname)
+                .oAuthProvider(OAuthProvider.NAVER)
+                .oAuthId(idGen.decrementAndGet())
+                .build();
+        Owner savedOwner = ownerRepository.save(owner);
+        Long ownerId = savedOwner.getId();
+        managerNameIdMap.put(nickname, ownerId);
+        return authTokensGenerator.generate(ownerId);
+    }
+
+    public AuthTokensResponse joinVisitor(String nickname) {
+        Customer customer = Customer.registeredCustomerBuilder()
+                .nickname(nickname)
+                .email(nickname + "@test.com")
+                .oAuthProvider(OAuthProvider.NAVER)
+                .oAuthId(idGen.decrementAndGet())
+                .build();
+        Customer savedCustomer = customerRepository.save(customer);
+        Long customerId = savedCustomer.getId();
+        visitorNameIdMap.put(nickname, customerId);
+        return authTokensGenerator.generate(customerId);
+    }
+
+    public AuthTokensResponse loginManger(String nickName) {
+        Long id = managerNameIdMap.computeIfAbsent(nickName, (key) -> {
+            joinManager(nickName);
+            return managerNameIdMap.get(nickName);
+        });
+        return authTokensGenerator.generate(id);
+    }
+
+    public AuthTokensResponse loginVisitor(String nickName) {
+        Long id = visitorNameIdMap.computeIfAbsent(nickName, (key) -> {
+            joinVisitor(nickName);
+            return visitorNameIdMap.get(nickName);
+        });
+        return authTokensGenerator.generate(id);
+    }
+}


### PR DESCRIPTION
## 주요 변경사항
개발환경용 인증 기능 구현했습니다.
- 사장님 가입: `/api/dev/register/admin/{가입시킬 닉네임}`
- 손님 가입:  `/api/dev/visitor/{가입시킬 닉네임}`
- 사장님 로그인: `/api/dev/login/admin/{가입한 닉네임}`
- 손님 로그인: `/api/dev/login/visitor/{가입한 닉네임}`

## 리뷰어에게...
서브모듈 접근권한이 없어서 테스트는 못 해봤습니다.
그냥 로컬에서 몇번 돌려보고 정삭작동하면 슛 하면 될 듯 합니다.
dev용이므로, 오류가 있다고 해서 치명적이지 않으므로 테스트코드는 따로 작성하지 않았습니다.

## 관련 이슈

closes #907 

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [x] `milestone` 설정
