### PR TITLE
[FE] refactor: z-index 상수화를 통한 의미 부여

### DIFF
--- a/frontend/src/components/Alert/style.tsx
+++ b/frontend/src/components/Alert/style.tsx
@@ -1,4 +1,5 @@
 import { styled } from 'styled-components';
+import { Z_INDEX } from '../../constants/magicNumber';
 
 export const AlertContainer = styled.div`
   display: flex;
@@ -9,7 +10,7 @@ export const AlertContainer = styled.div`
   top: 50%;
   left: 50%;
   border-radius: 10px;
-  z-index: 200;
+  z-index: ${Z_INDEX.highest + Z_INDEX.above};
   transform: translate(-50%, -50%);
 `;
 
@@ -19,7 +20,7 @@ export const BackDrop = styled.div`
   left: 0;
   width: 100vw;
   height: 120vh;
-  z-index: 150;
+  z-index: ${Z_INDEX.highest};
   background-color: rgba(0, 0, 0, 0.3);
 `;
 

--- a/frontend/src/components/BottomTabBar/style.tsx
+++ b/frontend/src/components/BottomTabBar/style.tsx
@@ -1,4 +1,5 @@
 import { styled } from 'styled-components';
+import { Z_INDEX } from '../../constants/magicNumber';
 
 interface TabBarProps {
   $isCustomerMode: boolean;
@@ -16,7 +17,7 @@ export const TabBarContainer = styled.div<TabBarProps>`
   border-radius: 8px 8px 0 0;
   box-shadow: 0px -4px 8px 0 rgba(0, 0, 0, 0.1);
   background: white;
-  z-index: 100;
+  z-index: ${Z_INDEX.above};
 
   @media screen and (max-width: 768px) {
     display: flex;

--- a/frontend/src/components/LoadingSpinner/style.tsx
+++ b/frontend/src/components/LoadingSpinner/style.tsx
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import { Z_INDEX } from '../../constants/magicNumber';
 
 export const LoadingContainer = styled.div`
   display: flex;
@@ -13,6 +14,6 @@ export const CustomerLoadingContainer = styled(LoadingContainer)`
   position: absolute;
   width: 85%;
   height: 50vh;
-  z-index: 999;
+  z-index: ${Z_INDEX.highest};
   background: transparent;
 `;

--- a/frontend/src/components/Modal/style.tsx
+++ b/frontend/src/components/Modal/style.tsx
@@ -1,31 +1,27 @@
 import styled from 'styled-components';
+import { Z_INDEX } from '../../constants/magicNumber';
 
 export const ModalBackdrop = styled.div`
   position: absolute;
   top: 0;
   left: 0;
-
   width: 100vw;
   height: 120vh;
-
-  z-index: 0;
-
+  z-index: ${Z_INDEX.highest};
   background-color: rgba(0, 0, 0, 0.3);
 `;
 
 export const BaseModal = styled.div`
   position: fixed;
-
   top: 50%;
   left: 50%;
   width: fit-content;
   height: auto;
-
   padding: 35px;
   border-radius: 10px;
   box-shadow: rgba(0, 0, 0, 0.1) 3px 3px 5px 0px;
 
-  z-index: 1;
+  z-index: ${Z_INDEX.highest + Z_INDEX.above};
   background-color: ${({ theme }) => theme.colors.white};
 
   transform: translate(-50%, -50%);

--- a/frontend/src/components/SelectBox/style.tsx
+++ b/frontend/src/components/SelectBox/style.tsx
@@ -1,4 +1,5 @@
 import styled, { css } from 'styled-components';
+import { Z_INDEX } from '../../constants/magicNumber';
 
 export const BaseSelectBox = styled.span<{
   $minWidth: number;
@@ -63,7 +64,7 @@ export const BaseSelectBox = styled.span<{
       padding: 0;
       box-shadow: rgba(0, 0, 0, 0.1) 3px 3px 5px 0px;
       max-height: 400px;
-      z-index: 1;
+      z-index: ${Z_INDEX.above};
 
       label {
         border-top: 1px solid ${({ theme }) => theme.colors.gray};

--- a/frontend/src/constants/magicNumber.ts
+++ b/frontend/src/constants/magicNumber.ts
@@ -17,3 +17,11 @@ export const INTRO_LIMITATION = 150;
 export const PHONE_NUMBER_START_WITH_02 = 12;
 
 export const PHONE_NUMBER_START_WITHOUT_02 = 13;
+
+export const Z_INDEX = {
+  lowest: -99,
+  below: -10,
+  base: 0,
+  above: 10,
+  highest: 99,
+} as const;

--- a/frontend/src/pages/Admin/EnterPhoneNumber/components/GuideAlert/style.tsx
+++ b/frontend/src/pages/Admin/EnterPhoneNumber/components/GuideAlert/style.tsx
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import { Z_INDEX } from '../../../../../constants/magicNumber';
 
 export const BackDrop = styled.div`
   position: fixed;
@@ -6,6 +7,6 @@ export const BackDrop = styled.div`
   left: 0;
   width: 100vw;
   height: 100vh;
-  z-index: 10;
+  z-index: ${Z_INDEX.highest};
   background-color: rgba(0, 0, 0, 0.3);
 `;

--- a/frontend/src/pages/Customer/CouponList/components/CafeInfo/style.tsx
+++ b/frontend/src/pages/Customer/CouponList/components/CafeInfo/style.tsx
@@ -40,23 +40,3 @@ export const MaxStampCount = styled.span`
   font-size: 24px;
   color: #f3b209;
 `;
-
-export const BackDrop = styled.div<{ $couponMainColor: string }>`
-  z-index: -10;
-  width: 100%;
-  max-width: 450px;
-  overflow: hidden;
-  height: 100%;
-  position: absolute;
-  top: 0;
-  right: 0;
-  background: linear-gradient(
-    white,
-    rgba(255, 255, 255, 0.5) 32%,
-    ${({ $couponMainColor }) => $couponMainColor} 80%,
-    white
-  );
-  opacity: 0.7;
-  left: 50%;
-  transform: translateX(-50%);
-`;

--- a/frontend/src/pages/Customer/CouponList/components/CouponDetail/style.tsx
+++ b/frontend/src/pages/Customer/CouponList/components/CouponDetail/style.tsx
@@ -1,4 +1,5 @@
 import styled, { css } from 'styled-components';
+import { Z_INDEX } from '../../../../../constants/magicNumber';
 import { popup } from '../../../../../style/keyframes';
 
 export const CouponDetailContainer = styled.section<{ $isDetail: boolean }>`
@@ -11,7 +12,7 @@ export const CouponDetailContainer = styled.section<{ $isDetail: boolean }>`
   background: white;
   max-width: 450px;
   transform: translateY(100%);
-  z-index: 110;
+  z-index: ${Z_INDEX.highest + Z_INDEX.below};
   overscroll-behavior-x: none;
 
   ${({ $isDetail }) =>
@@ -31,7 +32,6 @@ export const CouponDetailContainer = styled.section<{ $isDetail: boolean }>`
     top: 55px;
     left: 50%;
     transform: translateX(-50%);
-    z-index: 999;
   }
 `;
 

--- a/frontend/src/pages/Customer/CouponList/components/FlippedCoupon/style.tsx
+++ b/frontend/src/pages/Customer/CouponList/components/FlippedCoupon/style.tsx
@@ -1,4 +1,5 @@
 import { css, styled } from 'styled-components';
+import { Z_INDEX } from '../../../../../constants/magicNumber';
 
 export const CouponContainer = styled.div`
   display: flex;
@@ -32,17 +33,15 @@ export const CouponImage = styled.img`
   object-fit: cover;
   backface-visibility: hidden;
   box-shadow: 0px -2px 15px -2px #888;
-
-  z-index: 2;
 `;
 
 export const FrontImage = styled(CouponImage)`
-  z-index: 10;
+  z-index: ${Z_INDEX.above};
 `;
 
 export const BackImage = styled(CouponImage)`
   transform: rotateY(180deg);
-  z-index: 0;
+  z-index: ${Z_INDEX.base};
 `;
 
 export const StampImage = styled.img<{ $x: number; $y: number }>`
@@ -55,5 +54,5 @@ export const StampImage = styled.img<{ $x: number; $y: number }>`
   backface-visibility: hidden;
   transform-style: preserve-3d;
   transform: rotateY(180deg);
-  z-index: 1;
+  z-index: ${Z_INDEX.above};
 `;

--- a/frontend/src/pages/Customer/CouponList/style.tsx
+++ b/frontend/src/pages/Customer/CouponList/style.tsx
@@ -55,26 +55,6 @@ export const MaxStampCount = styled.span`
   color: #f3b209;
 `;
 
-export const BackDrop = styled.div<{ $couponMainColor: string }>`
-  z-index: -10;
-  width: 100%;
-  max-width: 450px;
-  overflow: hidden;
-  height: 100%;
-  position: absolute;
-  top: 0;
-  right: 0;
-  background: linear-gradient(
-    white,
-    rgba(255, 255, 255, 0.5) 32%,
-    ${(props) => props.$couponMainColor} 80%,
-    white
-  );
-  opacity: 0.7;
-  left: 50%;
-  transform: translateX(-50%);
-`;
-
 export const CouponListContainer = styled.div<{
   $isOn: boolean;
 }>`

--- a/frontend/src/pages/Introduction/style.tsx
+++ b/frontend/src/pages/Introduction/style.tsx
@@ -1,5 +1,6 @@
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
+import { Z_INDEX } from '../../constants/magicNumber';
 
 interface ButtonStyledProps {
   $isFilled?: boolean;
@@ -14,7 +15,7 @@ export const Header = styled.header`
   height: 78px;
   position: fixed;
   top: 0;
-  z-index: 20;
+  z-index: ${Z_INDEX.above};
   background: linear-gradient(to bottom, rgba(0, 0, 0, 0.1) 5%, transparent);
 `;
 
@@ -65,7 +66,7 @@ export const CustomerPreview = styled.img`
   width: 415px;
   border-radius: 20px;
   box-shadow: 0px 0px 20px 10px rgba(0, 0, 0, 0.1);
-  z-index: 2;
+  z-index: ${Z_INDEX.base};
 
   @media screen and (max-width: 450px) {
     width: 300px;
@@ -128,7 +129,7 @@ export const ApplyButton = styled.button`
   right: 4rem;
   font-size: 18px;
   font-weight: 600;
-  z-index: 10;
+  z-index: ${Z_INDEX.above};
 `;
 
 export const OwnerIntro = styled.h2`

--- a/frontend/src/style/keyframes.ts
+++ b/frontend/src/style/keyframes.ts
@@ -1,4 +1,5 @@
 import { keyframes } from 'styled-components';
+import { Z_INDEX } from '../constants/magicNumber';
 
 export const swap = keyframes`
   50% {
@@ -7,7 +8,7 @@ export const swap = keyframes`
   }
   100% {
     transform: translateY(-45px) scale(0.85);
-    z-index: -1;
+    z-index: ${Z_INDEX.below};
   }
 `;
 


### PR DESCRIPTION
## 주요 변경사항

z-index 속성을 많은 곳에서 사용하고 있는데, 숫자의 범위나 기준이 모호한 것 같아 '상수화를 통한 의미부여' 리팩토링을 진행했습니다.

[참고자료](https://velog.io/@nonarnee/%ED%94%84%EB%A1%9C%EC%A0%9D%ED%8A%B8%EC%97%90%EC%84%9C-z-index-%EA%B0%92%EC%9D%84-%EA%B4%80%EB%A6%AC%ED%95%98%EB%8A%94-%EB%B0%A9%EB%B2%95)

```javascript
export const Z_INDEX = {
  lowest: -99,
  below: -10,
  base: 0,
  above: 10,
  highest: 99,
} as const;
```

변하지 않는 Z_INDEX 객체는 5가지 속성을 가집니다.

header와 같이 base 상태에서 위로 올려야 하는 해야하는 경우는 
```javascript
z-index: ${Z_INDEX.above};
```

alert나 backdrop 과 같이 페이지 최상단에 위치해야 하는 경우
```javascript
export const AlertContainer = styled.div`
  ...
  z-index: ${Z_INDEX.highest + Z_INDEX.above};
`;

export const BackDrop = styled.div`
  ...
  z-index: ${Z_INDEX.highest};
`;
```

다음과 같이 활용해볼 수 있을 것 같습니다.

페이지 내에 여러 z-index 가 존재하는 경우에도
Z_INDEX.above와 Z_INDEX.below 값을 적절히 더하며 
z-index 단계를 규칙적으로 설정할 수 있을 것 같습니다. 

## 리뷰어에게...

## 관련 이슈

closes #905 

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [ ] `milestone` 설정
