### PR TITLE
[FE] bug: 고객 모드 헤더의 CLS 이슈를 해결한다.

### DIFF
--- a/frontend/src/pages/Customer/CouponList/components/CafeInfo/style.tsx
+++ b/frontend/src/pages/Customer/CouponList/components/CafeInfo/style.tsx
@@ -40,3 +40,23 @@ export const MaxStampCount = styled.span`
   font-size: 24px;
   color: #f3b209;
 `;
+
+export const BackDrop = styled.div<{ $couponMainColor: string }>`
+  z-index: -10;
+  width: 100%;
+  max-width: 450px;
+  overflow: hidden;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  right: 0;
+  background: linear-gradient(
+    white,
+    rgba(255, 255, 255, 0.5) 32%,
+    ${({ $couponMainColor }) => $couponMainColor} 80%,
+    white
+  );
+  opacity: 0.7;
+  left: 50%;
+  transform: translateX(-50%);
+`;

--- a/frontend/src/pages/Customer/CouponList/style.tsx
+++ b/frontend/src/pages/Customer/CouponList/style.tsx
@@ -4,6 +4,7 @@ export const HeaderContainer = styled.header`
   display: flex;
   width: 100%;
   height: 65px;
+  min-height: 65px;
   justify-content: space-between;
   align-items: center;
   padding: 0 25px;
@@ -77,7 +78,7 @@ export const ToggleContainer = styled.section`
   display: flex;
   justify-content: flex-end;
   align-items: center;
-  padding: 2rem 40px;
+  padding: 2rem;
 `;
 
 export const ToggleName = styled.span<{ $isOn: boolean }>`


### PR DESCRIPTION
## 주요 변경사항
- 헤더와 토글의 폰트에서 Layout Shift 발생
- 헤더에 `min-height`, 토글 컨테이너의 `padding`을 `2rem 40px` -> `2rem`으로 변경
+ `BackDrop` 스타일 제거로 인한 오류 해결

<img width="376" alt="스크린샷 2023-11-06 오후 8 18 15" src="https://github.com/woowacourse-teams/2023-stamp-crush/assets/90092440/f18e038c-1dce-4509-9f7e-ef3a93ea620e">
<img width="393" alt="스크린샷 2023-11-06 오후 8 18 37" src="https://github.com/woowacourse-teams/2023-stamp-crush/assets/90092440/77cc9469-6773-4768-8699-1483555c1468">

## 리뷰어에게...

## 관련 이슈

closes #912 

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [ ] `milestone` 설정
