### PR TITLE
[BE] feat: 테스트 병렬 실행 설정

### DIFF
--- a/backend/src/test/java/com/stampcrush/backend/acceptance/AcceptanceTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/AcceptanceTest.java
@@ -19,6 +19,8 @@ import io.restassured.RestAssured;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
@@ -26,9 +28,10 @@ import org.springframework.boot.test.web.server.LocalServerPort;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 
 @KorNamingConverter
+@Execution(ExecutionMode.SAME_THREAD)
 @ExtendWith(DataClearExtension.class)
 @SpringBootTest(webEnvironment = RANDOM_PORT)
-public class AcceptanceTest {
+public abstract class AcceptanceTest {
 
     @Autowired
     protected AuthTokensGenerator authTokensGenerator;

--- a/backend/src/test/java/com/stampcrush/backend/api/ControllerSliceTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/ControllerSliceTest.java
@@ -42,6 +42,8 @@ import com.stampcrush.backend.config.WebMvcConfig;
 import com.stampcrush.backend.repository.cafe.CafeRepository;
 import com.stampcrush.backend.repository.user.CustomerRepository;
 import com.stampcrush.backend.repository.user.OwnerRepository;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -51,6 +53,7 @@ import org.springframework.context.annotation.FilterType;
 import org.springframework.test.web.servlet.MockMvc;
 
 @KorNamingConverter
+@Execution(ExecutionMode.SAME_THREAD)
 @WebMvcTest(value = {ManagerCafeCouponSettingCommandApiController.class,
         ManagerCafeCouponSettingFindApiController.class,
         ManagerCafeFindApiController.class,

--- a/backend/src/test/java/com/stampcrush/backend/api/docs/DocsControllerTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/api/docs/DocsControllerTest.java
@@ -58,6 +58,8 @@ import com.stampcrush.backend.repository.user.OwnerRepository;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -81,6 +83,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 @KorNamingConverter
 @AutoConfigureRestDocs
 @AutoConfigureMockMvc
+@Execution(ExecutionMode.SAME_THREAD)
 @WebMvcTest({
         ManagerCafeFindApiController.class,
         VisitorCafeFindApiController.class,

--- a/backend/src/test/resources/junit-platform.properties
+++ b/backend/src/test/resources/junit-platform.properties
@@ -1,0 +1,4 @@
+junit.jupiter.execution.parallel.enabled=true
+junit.jupiter.execution.parallel.mode.classes.default = concurrent
+junit.jupiter.execution.parallel.config.strategy=fixed
+junit.jupiter.execution.parallel.config.fixed.parallelism=6


### PR DESCRIPTION
## 주요 변경사항

Junit 에 테스트를 병렬로 실행시키는 설정이 있더라고요. 이걸 이용하면 빌드 시간을 조금이라도 줄일 수 있을 것 같아서 적용해봤습니다! 
제 로컬(인텔 맥) 에서는 빌드 시간 1분 9초 -> 45 초로 개선됏습니다.

테스트 시 병렬로 돌아가는 스레드 개수는 6개로 설정했어요. (별도의 ForkJoinPool 스레드를 사용합니다.)
- 인수 테스트, docs 테스트, api 단위 테스트는 병렬로 돌리면 테스트 실패 -> 각각 스레드 하나씩 싱글 스레드로 돌아가야 되기 때문에 3개 할당
- 나머지 unit 테스트는 thread-safe 하기 때문에 병렬로 실행해도 괜찮다. 4 ~ 7 개로 돌려봤는데 6개가 1초라도 더 빨라서 6개로 했습니다. (사실 큰 차이 안남)

## 리뷰어에게...

안녕하세요 깃짱, 말랑~ 오랜만에 PR 올리네요. 공부하다가 Junit 에서 테스트를 병렬로 실행시킬 수 있더라고요. 이를 통해 빌드 시간을 줄일 수 있을 것 같아서 PR 올립니다! 꼭 적용 안해주셔도 됩니다 ㅎㅎ


`junit.jupiter.execution.parallel.enabled=true`
`junit.jupiter.execution.parallel.mode.classes.default = concurrent`
위 설정을 통해 기본적으로 모든 테스트는 병렬로 돌아갑니다. 그리고 인수, docs, api 테스트는 싱글 스레드로 돌려야 하기 때문에 각각의 추상 클래스에 `@Execution(ExecutionMode.SAME_THREAD)` 설정을 통해 싱글 스레드로 돌아가도록 설정했습니다.

`junit.jupiter.execution.parallel.config.strategy=fixed`
`junit.jupiter.execution.parallel.config.fixed.parallelism=6`
위 설정을 통해 스레드 개수를 6개로 고정했습니다. 위 설정을 제거하면 CPU 코어같은 자원에 맞게 스레드 개수를 할당한다고 합니다.

### 결과
**전**
![스크린샷 2023-11-10 오전 1 37 05](https://github.com/woowacourse-teams/2023-stamp-crush/assets/62167801/1cc36fb3-0f20-4056-8ca6-38642aea6ce2)

**후**
![스크린샷 2023-11-10 오전 1 30 34](https://github.com/woowacourse-teams/2023-stamp-crush/assets/62167801/5f454016-652b-4971-be35-c822ed459f09)


참고한 문서 [링크](https://junit.org/junit5/docs/snapshot/user-guide/index.html#writing-tests-parallel-execution)

## 관련 이슈

closes

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [x] `milestone` 설정
