### PR TITLE
[BE] feat: 리프레시 토큰을 쿠키를 통해 전달

### DIFF
--- a/backend/src/main/java/com/stampcrush/backend/auth/api/ManagerAuthController.java
+++ b/backend/src/main/java/com/stampcrush/backend/auth/api/ManagerAuthController.java
@@ -1,9 +1,14 @@
 package com.stampcrush.backend.auth.api;
 
+import static org.springframework.boot.web.server.Cookie.SameSite.NONE;
+import static org.springframework.http.HttpHeaders.SET_COOKIE;
+
 import com.stampcrush.backend.auth.api.request.OAuthRegisterOwnerCreateRequest;
 import com.stampcrush.backend.auth.api.response.AuthTokensResponse;
 import com.stampcrush.backend.auth.application.ManagerAuthService;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -19,14 +24,21 @@ public class ManagerAuthController {
 
     @PostMapping("/register/test/token")
     public ResponseEntity<AuthTokensResponse> joinManager(
-            @RequestBody OAuthRegisterOwnerCreateRequest request
+            @RequestBody OAuthRegisterOwnerCreateRequest request,
+            HttpServletResponse response
     ) {
-        return ResponseEntity.ok().body(
-                managerAuthService.join(
-                        request.getNickname(),
-                        request.getoAuthProvider(),
-                        request.getoAuthId()
-                )
+        AuthTokensResponse tokenResponse = managerAuthService.join(
+                request.getNickname(),
+                request.getoAuthProvider(),
+                request.getoAuthId()
         );
+        ResponseCookie cookie = ResponseCookie.from("REFRESH_TOKEN", tokenResponse.getRefreshToken())
+                .httpOnly(true)
+                .secure(true)
+                .path("/api/admin/auth/reissue-token")
+                .sameSite(NONE.attributeValue())
+                .build();
+        response.addHeader(SET_COOKIE, cookie.toString());
+        return ResponseEntity.ok(tokenResponse);
     }
 }

--- a/backend/src/main/java/com/stampcrush/backend/auth/api/ManagerReissueTokenController.java
+++ b/backend/src/main/java/com/stampcrush/backend/auth/api/ManagerReissueTokenController.java
@@ -1,11 +1,16 @@
 package com.stampcrush.backend.auth.api;
 
+import static org.springframework.boot.web.server.Cookie.SameSite.NONE;
+import static org.springframework.http.HttpHeaders.SET_COOKIE;
+
 import com.stampcrush.backend.auth.api.response.AuthTokensResponse;
 import com.stampcrush.backend.auth.application.ManagerReissueTokenService;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -18,10 +23,17 @@ public class ManagerReissueTokenController {
 
     @GetMapping("/reissue-token")
     public ResponseEntity<AuthTokensResponse> reissueToken(
-            @RequestHeader("Refresh") String refreshToken
+            @CookieValue(name = "REFRESH_TOKEN") String refreshToken,
+            HttpServletResponse response
     ) {
-        return ResponseEntity.ok(
-                managerReissueTokenService.reissueToken(refreshToken)
-        );
+        AuthTokensResponse tokenResponse = managerReissueTokenService.reissueToken(refreshToken);
+        ResponseCookie cookie = ResponseCookie.from("REFRESH_TOKEN", tokenResponse.getRefreshToken())
+                .httpOnly(true)
+                .secure(true)
+                .path("/api/admin/auth/reissue-token")
+                .sameSite(NONE.attributeValue())
+                .build();
+        response.addHeader(SET_COOKIE, cookie.toString());
+        return ResponseEntity.ok(tokenResponse);
     }
 }

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/ManagerReissueTokenAcceptanceTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/ManagerReissueTokenAcceptanceTest.java
@@ -37,7 +37,7 @@ class ManagerReissueTokenAcceptanceTest extends AcceptanceTest {
     void 로그아웃_이후에_해당_Refresh_Token을_사용해서_토큰_재발급을_받을_수_없다() {
         final ExtractableResponse<Response> authResponse = 카페_사장_회원_가입_요청(OWNER_CREATE_REQUEST);
         final String accessToken = authResponse.jsonPath().getString("accessToken");
-        final String refreshToken = authResponse.jsonPath().getString("refreshToken");
+        final String refreshToken = authResponse.cookie("REFRESH_TOKEN");
 
         카페_사장_로그_아웃_요청(accessToken, refreshToken);
 

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/step/ManagerJoinStep.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/step/ManagerJoinStep.java
@@ -24,7 +24,7 @@ public class ManagerJoinStep {
 
     public static String 카페_사장_회원_가입_요청하고_Refresh_토큰_반환(OAuthRegisterOwnerCreateRequest request) {
         ExtractableResponse<Response> response = 카페_사장_회원_가입_요청(request);
-        return response.jsonPath().getString("refreshToken");
+        return response.cookie("REFRESH_TOKEN");
     }
 
     public static String 카페_사장_회원_가입_요청하고_액세스_토큰_반환(OAuthRegisterOwnerCreateRequest request) {

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/step/ManagerReissueTokenStep.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/step/ManagerReissueTokenStep.java
@@ -1,22 +1,20 @@
 package com.stampcrush.backend.acceptance.step;
 
+import static io.restassured.http.ContentType.JSON;
+
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
-
-import static io.restassured.http.ContentType.JSON;
 
 public class ManagerReissueTokenStep {
 
     public static ExtractableResponse<Response> Refresh_토큰으로_토큰_재발급_요청(final String refreshToken) {
         return RestAssured.given()
                 .log().all()
-                .header("Refresh", refreshToken)
+                .cookie("REFRESH_TOKEN", refreshToken)
                 .contentType(JSON)
-
                 .when()
                 .get("/api/admin/auth/reissue-token")
-
                 .then()
                 .log().all()
                 .extract();


### PR DESCRIPTION
## 주요 변경사항
리프레시 토큰을 쿠키를 통해 전달하도록 했습니다.
이 과정에서 보안을 위해 HTTP ONLY 속성과, SECURE 속성을 주었고, reissue-token에 대해서만 쿠키가 전달되도록 path를 설정했습니다.
dev서버에서 프론트와 같이 QA해가며 잘 동작하는지 확인할 필요성이 있습니당

## 리뷰어에게...
코드 중복이 하나 있는데, Controller를 통합하면 줄일 수 있을 것 같으나, 일단은 메서드가 두개이므로 그대로 두었습니다.

## 관련 이슈

closes #931 

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [x] `milestone` 설정
