### PR TITLE
[BE] fix: CafePolicyRepositoryTest 에서 필요없어진 테스트 삭제

### DIFF
--- a/backend/src/main/java/com/stampcrush/backend/repository/cafe/CafePolicyRepository.java
+++ b/backend/src/main/java/com/stampcrush/backend/repository/cafe/CafePolicyRepository.java
@@ -4,8 +4,6 @@ import com.stampcrush.backend.entity.cafe.Cafe;
 import com.stampcrush.backend.entity.cafe.CafePolicy;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.time.LocalDateTime;
-import java.util.List;
 import java.util.Optional;
 
 public interface CafePolicyRepository extends JpaRepository<CafePolicy, Long> {
@@ -13,6 +11,4 @@ public interface CafePolicyRepository extends JpaRepository<CafePolicy, Long> {
     Optional<CafePolicy> findByCafe(Cafe cafe);
 
     Optional<CafePolicy> findByCafeAndIsActivateTrue(Cafe cafe);
-
-    List<CafePolicy> findByCafeAndCreatedAtGreaterThan(Cafe cafe, LocalDateTime createdAt);
 }

--- a/backend/src/test/java/com/stampcrush/backend/repository/cafe/CafePolicyRepositoryTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/repository/cafe/CafePolicyRepositoryTest.java
@@ -11,7 +11,6 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 import java.time.LocalTime;
-import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -76,74 +75,5 @@ class CafePolicyRepositoryTest {
                 () -> assertThat(filteredCafePolicy.get()).isEqualTo(activeCafePolicy),
                 () -> assertThat(filteredCafePolicy.get()).isNotEqualTo(disableCafePolicy)
         );
-    }
-
-    @Test
-    void 특정_시간보다_이후에_생성된_카페_리워드_정책이_있으면_해당_정책들을_반환한다() {
-        Cafe savedCafe = cafeRepository.save(
-                new Cafe(
-                        "깃짱카페",
-                        LocalTime.NOON,
-                        LocalTime.MIDNIGHT,
-                        "01012345678",
-                        "#",
-                        "안녕하세요",
-                        "서울시 올림픽로 어쩌고",
-                        "루터회관",
-                        "10-222-333",
-                        ownerRepository.save(new Owner("이름", "아이디", "pw", "phone"))
-                )
-        );
-
-        CafePolicy oldCafePolicy = cafePolicyRepository.save(
-                new CafePolicy(
-                        2,
-                        "마카롱",
-                        12,
-                        savedCafe
-                )
-        );
-
-        CafePolicy newCafePolicy = cafePolicyRepository.save(
-                new CafePolicy(
-                        2,
-                        "아메리카노",
-                        12,
-                        savedCafe
-                )
-        );
-
-        List<CafePolicy> cafePolicies = cafePolicyRepository.findByCafeAndCreatedAtGreaterThan(savedCafe, oldCafePolicy.getCreatedAt());
-        assertThat(cafePolicies).isNotEmpty();
-    }
-
-    @Test
-    void 특정_시간보다_이후에_생성된_카페_리워드_정책이_없으면_빈_리스트_반환() {
-        Cafe savedCafe = cafeRepository.save(
-                new Cafe(
-                        "깃짱카페",
-                        LocalTime.NOON,
-                        LocalTime.MIDNIGHT,
-                        "01012345678",
-                        "#",
-                        "안녕하세요",
-                        "서울시 올림픽로 어쩌고",
-                        "루터회관",
-                        "10-222-333",
-                        ownerRepository.save(new Owner("이름", "아이디", "pw", "phone"))
-                )
-        );
-
-        CafePolicy currentPolicy = cafePolicyRepository.save(
-                new CafePolicy(
-                        2,
-                        "마카롱",
-                        12,
-                        savedCafe
-                )
-        );
-
-        List<CafePolicy> cafePolicies = cafePolicyRepository.findByCafeAndCreatedAtGreaterThan(savedCafe, currentPolicy.getCreatedAt());
-        assertThat(cafePolicies).isEmpty();
     }
 }


### PR DESCRIPTION
## 주요 변경사항

findByCafeAndCreatedAtGreaterThan 을 테스트하는 코드 삭제

## 리뷰어에게...

## 관련 이슈

closes

## 체크리스트

- [ ] `reviewers` 설정
- [ ] `label` 설정
- [ ] `milestone` 설정
