### PR TITLE
[BE] feat: 회원 탈퇴 시 발생하는 N+1 문제 해결

### DIFF
--- a/backend/src/main/java/com/stampcrush/backend/application/visitor/profile/VisitorCancelMembershipCommandService.java
+++ b/backend/src/main/java/com/stampcrush/backend/application/visitor/profile/VisitorCancelMembershipCommandService.java
@@ -32,17 +32,10 @@ public class VisitorCancelMembershipCommandService {
     public void cancelMembership(Long customerId) {
         Customer customer = findExistingCustomer(customerId);
 
-        List<Coupon> coupons = couponRepository.findByCustomer(customer);
-        couponRepository.deleteAll(coupons);
-
-        List<Reward> rewards = rewardRepository.findByCustomer(customer);
-        rewardRepository.deleteAll(rewards);
-
-        List<Favorites> favorites = favoritesRepository.findByCustomer(customer);
-        favoritesRepository.deleteAll(favorites);
-
-        List<VisitHistory> visitHistories = visitHistoryRepository.findByCustomer(customer);
-        visitHistoryRepository.deleteAll(visitHistories);
+        couponRepository.deleteByCustomer(customerId);
+        rewardRepository.deleteByCustomer(customerId);
+        favoritesRepository.deleteByCustomer(customerId);
+        visitHistoryRepository.deleteByCustomer(customerId);
 
         customerRepository.delete(customer);
     }

--- a/backend/src/main/java/com/stampcrush/backend/repository/coupon/CouponRepository.java
+++ b/backend/src/main/java/com/stampcrush/backend/repository/coupon/CouponRepository.java
@@ -6,6 +6,7 @@ import com.stampcrush.backend.entity.coupon.CouponStatus;
 import com.stampcrush.backend.entity.user.Customer;
 import com.stampcrush.backend.entity.user.CustomerType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -32,4 +33,8 @@ public interface CouponRepository extends JpaRepository<Coupon, Long> {
     Optional<Coupon> findByIdAndCustomerId(Long id, Long customerId);
 
     List<Coupon> findByCustomer(Customer customer);
+
+    @Modifying
+    @Query(value = "update Coupon c set c.deleted = true where c.customer_id = :customerId", nativeQuery = true)
+    void deleteByCustomer(Long customerId);
 }

--- a/backend/src/main/java/com/stampcrush/backend/repository/favorites/FavoritesRepository.java
+++ b/backend/src/main/java/com/stampcrush/backend/repository/favorites/FavoritesRepository.java
@@ -4,6 +4,8 @@ import com.stampcrush.backend.entity.cafe.Cafe;
 import com.stampcrush.backend.entity.favorites.Favorites;
 import com.stampcrush.backend.entity.user.Customer;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 import java.util.Optional;
@@ -13,4 +15,8 @@ public interface FavoritesRepository extends JpaRepository<Favorites, Long> {
     Optional<Favorites> findByCafeAndCustomer(Cafe cafe, Customer customer);
 
     List<Favorites> findByCustomer(Customer customer);
+
+    @Modifying
+    @Query(value = "update Favorites f set f.deleted = true where f.customer_id = :customerId", nativeQuery = true)
+    void deleteByCustomer(Long customerId);
 }

--- a/backend/src/main/java/com/stampcrush/backend/repository/reward/RewardRepository.java
+++ b/backend/src/main/java/com/stampcrush/backend/repository/reward/RewardRepository.java
@@ -4,16 +4,22 @@ import com.stampcrush.backend.entity.cafe.Cafe;
 import com.stampcrush.backend.entity.reward.Reward;
 import com.stampcrush.backend.entity.user.Customer;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 
 public interface RewardRepository extends JpaRepository<Reward, Long> {
 
-    List<Reward> findAllByCustomerIdAndCafeIdAndUsed(Long CustomerId, Long CafeId, boolean used);
+    List<Reward> findAllByCustomerIdAndCafeIdAndUsed(Long customerId, Long cafeId, boolean used);
 
     List<Reward> findAllByCustomerAndUsed(Customer customer, boolean used);
 
     Long countByCafeAndCustomerAndUsed(Cafe cafe, Customer customer, Boolean used);
 
     List<Reward> findByCustomer(Customer customer);
+
+    @Modifying
+    @Query(value = "update Reward r set r.deleted = true where r.customer_id = :customerId", nativeQuery = true)
+    void deleteByCustomer(Long customerId);
 }

--- a/backend/src/main/java/com/stampcrush/backend/repository/visithistory/VisitHistoryRepository.java
+++ b/backend/src/main/java/com/stampcrush/backend/repository/visithistory/VisitHistoryRepository.java
@@ -4,6 +4,8 @@ import com.stampcrush.backend.entity.cafe.Cafe;
 import com.stampcrush.backend.entity.user.Customer;
 import com.stampcrush.backend.entity.visithistory.VisitHistory;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 
@@ -16,4 +18,8 @@ public interface VisitHistoryRepository extends JpaRepository<VisitHistory, Long
     List<VisitHistory> findByCafeIdAndCustomerId(Long cafeId, Long customerId);
 
     List<VisitHistory> findByCustomer(Customer customer);
+
+    @Modifying
+    @Query(value = "update visit_history v set v.deleted = true where v.customer_id = :customerId", nativeQuery = true)
+    void deleteByCustomer(Long customerId);
 }

--- a/backend/src/test/java/com/stampcrush/backend/acceptance/VisitorCancelMembershipAcceptanceTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/acceptance/VisitorCancelMembershipAcceptanceTest.java
@@ -80,8 +80,6 @@ class VisitorCancelMembershipAcceptanceTest extends AcceptanceTest {
         ExtractableResponse<Response> response = 가입_고객_회원_탈퇴_요청(customerToken);
 
         // then
-        assertAll(
-                () -> assertThat(response.statusCode()).isEqualTo(NO_CONTENT.value())
-        );
+        assertThat(response.statusCode()).isEqualTo(NO_CONTENT.value());
     }
 }

--- a/backend/src/test/java/com/stampcrush/backend/application/visitor/profile/VisitorCancelMembershipCommandServiceTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/application/visitor/profile/VisitorCancelMembershipCommandServiceTest.java
@@ -1,0 +1,77 @@
+package com.stampcrush.backend.application.visitor.profile;
+
+import com.stampcrush.backend.application.ServiceSliceTest;
+import com.stampcrush.backend.entity.user.Customer;
+import com.stampcrush.backend.exception.CustomerNotFoundException;
+import com.stampcrush.backend.repository.coupon.CouponRepository;
+import com.stampcrush.backend.repository.favorites.FavoritesRepository;
+import com.stampcrush.backend.repository.reward.RewardRepository;
+import com.stampcrush.backend.repository.user.CustomerRepository;
+import com.stampcrush.backend.repository.visithistory.VisitHistoryRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.BDDMockito;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.Mockito.times;
+
+@ServiceSliceTest
+class VisitorCancelMembershipCommandServiceTest {
+
+    @InjectMocks
+    private VisitorCancelMembershipCommandService visitorCancelMembershipCommandService;
+
+    @Mock
+    private CustomerRepository customerRepository;
+
+    @Mock
+    private RewardRepository rewardRepository;
+
+    @Mock
+    private FavoritesRepository favoritesRepository;
+
+    @Mock
+    private VisitHistoryRepository visitHistoryRepository;
+
+    @Mock
+    private CouponRepository couponRepository;
+
+    @Test
+    void 존재하지_않는_회원탈퇴_시_예외() {
+        // given
+        given(customerRepository.findById(1L))
+                .willReturn(Optional.empty());
+
+        // when, then
+        assertThatThrownBy(() -> visitorCancelMembershipCommandService.cancelMembership(1L))
+                .isInstanceOf(CustomerNotFoundException.class);
+    }
+
+    @Test
+    void 회원탈퇴() {
+        // given
+        given(customerRepository.findById(1L))
+                .willReturn(Optional.of(Customer.registeredCustomerBuilder().build()));
+
+        // when
+        visitorCancelMembershipCommandService.cancelMembership(1L);
+
+        // then
+        then(couponRepository).should(times(1)).deleteByCustomer(anyLong());
+        then(rewardRepository).should(times(1)).deleteByCustomer(anyLong());
+        then(favoritesRepository).should(times(1)).deleteByCustomer(anyLong());
+        then(visitHistoryRepository).should(times(1)).deleteByCustomer(anyLong());
+        then(customerRepository).should(times(1)).delete(any());
+    }
+}

--- a/backend/src/test/java/com/stampcrush/backend/repository/coupon/CouponRepositoryTest2.java
+++ b/backend/src/test/java/com/stampcrush/backend/repository/coupon/CouponRepositoryTest2.java
@@ -433,6 +433,52 @@ class CouponRepositoryTest2 {
         );
     }
 
+    @Test
+    void 고객의_쿠폰을_삭제한다_jpql() {
+        Owner savedOwner = ownerRepository.save(OwnerFixture.GITCHAN);
+        Cafe gitchanCafe = cafeRepository.save(
+                new Cafe(
+                        "깃짱카페",
+                        "서초구",
+                        "어쩌고",
+                        "0101010101",
+                        savedOwner
+                )
+        );
+        Customer deleteCouponCustomer = customerRepository.save(CustomerFixture.REGISTER_CUSTOMER_GITCHAN);
+        Customer noDeleteCouponCustomer = customerRepository.save(CustomerFixture.REGISTER_CUSTOMER_1);
+
+        Coupon gitchanCafeCoupon = saveCoupon(
+                gitchanCafe,
+                deleteCouponCustomer,
+                cafeCouponDesignRepository.save(
+                        new CafeCouponDesign("front", "back", "stamp", gitchanCafe)
+                ),
+                cafePolicyRepository.save(
+                        new CafePolicy(10, "아메리카노", 8, gitchanCafe)
+                )
+        );
+
+        Coupon gitchanCafeNoDeleteCoupon = saveCoupon(
+                gitchanCafe,
+                noDeleteCouponCustomer,
+                cafeCouponDesignRepository.save(
+                        new CafeCouponDesign("front", "back", "stamp", gitchanCafe)
+                ),
+                cafePolicyRepository.save(
+                        new CafePolicy(10, "아메리카노", 8, gitchanCafe)
+                )
+        );
+
+        couponRepository.deleteByCustomer(deleteCouponCustomer.getId());
+        List<Coupon> deleteUserCoupons = couponRepository.findByCustomer(deleteCouponCustomer);
+        // then
+        assertAll(
+                () -> assertThat(deleteUserCoupons).isEmpty(),
+                () -> assertThat(gitchanCafeNoDeleteCoupon.getDeleted()).isFalse()
+        );
+    }
+
     private Coupon saveCoupon(Cafe savedCafe, Customer savedCustomer, CafeCouponDesign cafeCouponDesign, CafePolicy cafePolicy) {
         return couponRepository.save(
                 new Coupon(

--- a/backend/src/test/java/com/stampcrush/backend/repository/coupon/CouponRepositoryTest2.java
+++ b/backend/src/test/java/com/stampcrush/backend/repository/coupon/CouponRepositoryTest2.java
@@ -471,11 +471,11 @@ class CouponRepositoryTest2 {
         );
 
         couponRepository.deleteByCustomer(deleteCouponCustomer.getId());
-        List<Coupon> deleteUserCoupons = couponRepository.findByCustomer(deleteCouponCustomer);
+
         // then
         assertAll(
-                () -> assertThat(deleteUserCoupons).isEmpty(),
-                () -> assertThat(gitchanCafeNoDeleteCoupon.getDeleted()).isFalse()
+                () -> assertThat(couponRepository.findByCustomer(deleteCouponCustomer)).isEmpty(),
+                () -> assertThat(couponRepository.findByCustomer(noDeleteCouponCustomer)).isNotEmpty()
         );
     }
 

--- a/backend/src/test/java/com/stampcrush/backend/repository/favorites/FavoritesRepositoryTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/repository/favorites/FavoritesRepositoryTest.java
@@ -1,0 +1,69 @@
+package com.stampcrush.backend.repository.favorites;
+
+import com.stampcrush.backend.common.KorNamingConverter;
+import com.stampcrush.backend.entity.cafe.Cafe;
+import com.stampcrush.backend.entity.favorites.Favorites;
+import com.stampcrush.backend.entity.user.Customer;
+import com.stampcrush.backend.entity.user.Owner;
+import com.stampcrush.backend.fixture.CustomerFixture;
+import com.stampcrush.backend.fixture.OwnerFixture;
+import com.stampcrush.backend.repository.cafe.CafeRepository;
+import com.stampcrush.backend.repository.user.CustomerRepository;
+import com.stampcrush.backend.repository.user.OwnerRepository;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+@KorNamingConverter
+@DataJpaTest
+class FavoritesRepositoryTest {
+
+    @Autowired
+    private OwnerRepository ownerRepository;
+
+    @Autowired
+    private CafeRepository cafeRepository;
+
+    @Autowired
+    private CustomerRepository customerRepository;
+
+    @Autowired
+    private FavoritesRepository favoritesRepository;
+
+    @Test
+    void 해당_고객의_즐겨찾기를_삭제한다() {
+        // given
+        Cafe cafe = createCafe(OwnerFixture.GITCHAN);
+        Customer deletedCustomer = customerRepository.save(CustomerFixture.REGISTER_CUSTOMER_GITCHAN);
+        Customer noDeletedCustomer = customerRepository.save(CustomerFixture.REGISTER_CUSTOMER_1);
+
+        favoritesRepository.save(new Favorites(cafe, deletedCustomer));
+        favoritesRepository.save(new Favorites(cafe, noDeletedCustomer));
+
+        // when
+        favoritesRepository.deleteByCustomer(deletedCustomer.getId());
+
+        // then
+        assertAll(
+                () -> assertThat(favoritesRepository.findByCustomer(deletedCustomer)).isEmpty(),
+                () -> assertThat(favoritesRepository.findByCustomer(noDeletedCustomer)).isNotEmpty()
+        );
+    }
+
+    private Cafe createCafe(Owner owner) {
+        Owner savedOwner = ownerRepository.save(owner);
+        return cafeRepository.save(
+                new Cafe(
+                        "깃짱카페",
+                        "서초구",
+                        "어쩌고",
+                        "0101010101",
+                        savedOwner
+                )
+        );
+    }
+}

--- a/backend/src/test/java/com/stampcrush/backend/repository/reward/RewardRepositoryTest.java
+++ b/backend/src/test/java/com/stampcrush/backend/repository/reward/RewardRepositoryTest.java
@@ -10,6 +10,7 @@ import com.stampcrush.backend.fixture.OwnerFixture;
 import com.stampcrush.backend.repository.cafe.CafeRepository;
 import com.stampcrush.backend.repository.user.CustomerRepository;
 import com.stampcrush.backend.repository.user.OwnerRepository;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -17,6 +18,7 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 @KorNamingConverter
 @DataJpaTest
@@ -79,6 +81,31 @@ class RewardRepositoryTest {
 
         // then
         assertThat(countOfUnusedReward).isEqualTo(4);
+    }
+
+    @Test
+    void 해당_고객의_리워드를_삭제한다() {
+        // given
+        Cafe cafe = createCafe(OwnerFixture.GITCHAN);
+        Customer customer1 = customerRepository.save(CustomerFixture.REGISTER_CUSTOMER_GITCHAN);
+        Customer customer2 = customerRepository.save(CustomerFixture.REGISTER_CUSTOMER_1);
+
+        rewardRepository.save(new Reward("Reward1", customer1, cafe));
+        rewardRepository.save(new Reward("Reward2", customer1, cafe));
+        rewardRepository.save(new Reward("Reward3", customer1, cafe));
+        rewardRepository.save(new Reward("Reward4", customer1, cafe));
+        rewardRepository.save(new Reward("Reward5", customer1, cafe));
+
+        rewardRepository.save(new Reward("no delete", customer2, cafe));
+
+        // when
+        rewardRepository.deleteByCustomer(customer1.getId());
+
+        // then
+        assertAll(
+                () -> assertThat(rewardRepository.findByCustomer(customer1)).isEmpty(),
+                () -> assertThat(rewardRepository.findByCustomer(customer2)).isNotEmpty()
+        );
     }
 
     private Cafe createCafe(Owner owner) {


### PR DESCRIPTION
## 주요 변경사항
- 기존에 deleteAll() 을 사용하던 회원 탈퇴 로직을 별도의 JPQL 로 작성한 deleteByCustomer() 로 대체했습니다.

## 리뷰어에게...
- 회원 탈퇴가 일어나진 않겠지만 그래도 쿼리 개선하고 싶어서 PR 올립니다..!
- `VisitorCancelMembershipAcceptanceTest.이것저것_많이한_회원_탈퇴` 기준 28번의 쿼리 -> 5번의 쿼리로 감소했습니다.
- 기존 엔티티에 모두 @Where 가 붙어 있어서 이를 무시하기 위해 JQPL 에 nativeQuery 옵션 설정했습니다.
- 인수테스트에 탈퇴한 고객의 리워드 같은거 조회해서 빈 배열인지 확인하려고 했는데 이미 탈퇴한 회원으로 조회 요청하면 예외 발생해서 못했습니다. (인증 로직 잘 짰네요 ㅎ)
    - 대신 service 테스트를 통해서 deleteByCustomer() 메서드 호출하는지 검증하는 테스트 추가했습니다.
    - 각각의 repository 단위테스트도 추가했습니다.

## 관련 이슈

closes

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [x] `milestone` 설정
